### PR TITLE
Add source_get_content tool for raw text extraction

### DIFF
--- a/src/notebooklm_mcp/server.py
+++ b/src/notebooklm_mcp/server.py
@@ -204,6 +204,30 @@ def source_describe(source_id: str) -> dict[str, Any]:
 
 
 @mcp.tool()
+def source_get_content(source_id: str) -> dict[str, Any]:
+    """Get raw text content of a source (no AI processing).
+
+    Returns the original indexed text from PDFs, web pages, pasted text,
+    or YouTube transcripts. Much faster than notebook_query for content export.
+
+    Args:
+        source_id: Source UUID
+
+    Returns: content (str), title (str), source_type (str), char_count (int)
+    """
+    try:
+        client = get_client()
+        result = client.get_source_fulltext(source_id)
+
+        return {
+            "status": "success",
+            **result,  # Includes content, title, source_type, url, char_count
+        }
+    except Exception as e:
+        return {"status": "error", "error": str(e)}
+
+
+@mcp.tool()
 def notebook_add_url(notebook_id: str, url: str) -> dict[str, Any]:
     """Add URL (website or YouTube) as source.
 


### PR DESCRIPTION
## Summary

Adds a new `source_get_content` MCP tool that retrieves the raw indexed text from any NotebookLM source without AI processing.

## What's Added

- **New MCP tool:** `source_get_content(source_id)` returns:
  - `content`: Full raw text of the source
  - `title`: Source title
  - `source_type`: Type name (pdf, web_page, youtube, pasted_text, google_docs, etc.)
  - `char_count`: Character count
  - `url`: Source URL if available

- **Fixed response parsing** for the `hizoJc` RPC - content is stored in deeply nested block structures that required recursive extraction

- **Extended source type mappings** to include types 3 (pdf), 5 (web_page), 8 (pasted_text variant), and 9 (youtube)

## Why This Is Useful

1. **Export without re-running AI:** Extract content you've already indexed in NotebookLM without consuming Gemini API quota or waiting for AI processing

2. **Research project export:** When you've built a notebook with Deep Research (~40 sources), you can now bulk-export all source content to local markdown files for offline analysis or backup

3. **YouTube transcript extraction:** Get full video transcripts that NotebookLM has already processed

4. **Much faster than `notebook_query`:** Direct content retrieval vs asking AI to reproduce text

**Example use case:** Export an entire research notebook to markdown:
```python
for source in sources:
    content = source_get_content(source['id'])
    with open(f"{content['title']}.md", 'w') as f:
        f.write(content['content'])
```

## Testing

Tested with real NotebookLM sources:

1. **Pasted text source** (type 8): "Strategic Rejuvenation and Capital Discipline" analysis document
   - ✅ Retrieved 30,907 characters
   - ✅ Correct title and source_type
   - ✅ Saved to markdown successfully

2. **YouTube transcript** (type 9): "Company Presentation" investor webcast
   - ✅ Retrieved 39,018 characters (full transcript including Q&A)
   - ✅ Correct source_type identification
   - ✅ Saved to markdown successfully

Testing approach: Used direct API calls to `NotebookLMClient.get_source_fulltext()` with debug output to verify response parsing, then confirmed via the MCP tool interface.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)