### PR TITLE
Fix Chrome detection on Linux distros

### DIFF
--- a/src/notebooklm_mcp/auth_cli.py
+++ b/src/notebooklm_mcp/auth_cli.py
@@ -76,7 +76,17 @@ def launch_chrome(port: int, headless: bool = False) -> bool:
     if system == "Darwin":
         chrome_path = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
     elif system == "Linux":
-        chrome_path = "google-chrome"
+        # Try multiple Chrome binary names (varies by distro)
+        import shutil
+        chrome_candidates = ["google-chrome", "google-chrome-stable", "chromium", "chromium-browser"]
+        chrome_path = None
+        for candidate in chrome_candidates:
+            if shutil.which(candidate):
+                chrome_path = candidate
+                break
+        if not chrome_path:
+            print(f"Chrome not found. Tried: {', '.join(chrome_candidates)}")
+            return False
     elif system == "Windows":
         chrome_path = r"C:\Program Files\Google\Chrome\Application\chrome.exe"
     else:


### PR DESCRIPTION
## Summary
- Auth CLI now tries multiple Chrome binary names on Linux
- Fixes failure on Arch Linux (uses `google-chrome-stable`) and other distros

## Changes
Single file change to `auth_cli.py`:
- Try: `google-chrome`, `google-chrome-stable`, `chromium`, `chromium-browser`
- Uses `shutil.which()` to find the first available browser

## Test plan
- [x] Tested on Arch Linux where `google-chrome-stable` is the binary name

🤖 Generated with [Claude Code](https://claude.com/claude-code)