### PR TITLE
Add configurable DevTools timeout for auth CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ notebooklm-mcp-auth --file
 
 **File mode** shows instructions for manually extracting cookies from Chrome DevTools and saving them to a file.
 
+If the Chrome DevTools endpoint is slow, increase its timeout:
+
+```bash
+notebooklm-mcp-auth --devtools-timeout 15
+```
+
 After successful auth, add the MCP to your AI tool and restart.
 
 For detailed instructions, troubleshooting, and how the authentication system works, see **[docs/AUTHENTICATION.md](docs/AUTHENTICATION.md)**.

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -37,6 +37,12 @@ notebooklm-mcp-auth
 # 4. Wait for "SUCCESS!" message
 ```
 
+If your DevTools endpoint is slow to respond, you can increase the timeout:
+
+```bash
+notebooklm-mcp-auth --devtools-timeout 15
+```
+
 ### What Happens Behind the Scenes
 
 1. A dedicated Chrome profile is created at `~/.notebooklm-mcp/chrome-profile/`

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -60,6 +60,7 @@ notebooklm-mcp --transport http --debug
 --port PORT         Chrome DevTools port (default: 9222)
 --show-tokens       Show cached tokens
 --no-auto-launch    Don't auto-launch Chrome
+--devtools-timeout  DevTools HTTP timeout in seconds (default: 5.0)
 ```
 
 ## Environment Variables


### PR DESCRIPTION
- Add --devtools-timeout flag to notebooklm-mcp-auth

- Thread the timeout through DevTools HTTP calls

- Document the new flag in README and auth docs

Sometimes the default timeout of the http call  :9222/json/version is not enough, the auth command succeed only after I set timeout to 15 seconds.