### PR TITLE
v0.2.13: Unify storage to ~/.notebooklm-mcp-cli/ only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.13] - 2026-02-03
+
+### Fixed
+- **Unified storage location** - Consolidated all storage to `~/.notebooklm-mcp-cli/`. Previously some code still referenced the old `~/.notebooklm-mcp/` location, causing confusion. Now everything uses the single unified location.
+
 ## [0.2.12] - 2026-02-03
 
 ### Removed

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -125,7 +125,7 @@ The MCP auto-extracts CSRF token (`SNlM0e`) and session ID (`FdrFJe`) from the N
 
 ### Symptoms
 - `ValueError: Could not extract CSRF token from page`
-- Debug HTML saved to `~/.notebooklm-mcp/debug_page.html`
+- Debug HTML saved to `~/.notebooklm-mcp-cli/debug_page.html`
 
 ### How to fix
 If auto-extraction fails:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "notebooklm-mcp-cli"
-version = "0.2.12"
+version = "0.2.13"
 description = "Unified CLI and MCP server for Google NotebookLM"
 readme = "README.md"
 license = "MIT"

--- a/src/notebooklm_mcp/__init__.py
+++ b/src/notebooklm_mcp/__init__.py
@@ -7,4 +7,4 @@ May work with Google Workspace accounts but has not been tested.
 WARNING: This uses undocumented internal APIs that may change at any time.
 """
 
-__version__ = "0.2.12"
+__version__ = "0.2.13"

--- a/src/notebooklm_mcp/api_client.py
+++ b/src/notebooklm_mcp/api_client.py
@@ -392,7 +392,7 @@ class NotebookLMClient:
             if not csrf_match:
                 # Save HTML for debugging
                 from pathlib import Path
-                debug_dir = Path.home() / ".notebooklm-mcp"
+                debug_dir = Path.home() / ".notebooklm-mcp-cli"
                 debug_dir.mkdir(exist_ok=True)
                 debug_path = debug_dir / "debug_page.html"
                 debug_path.write_text(html)

--- a/src/notebooklm_mcp/auth.py
+++ b/src/notebooklm_mcp/auth.py
@@ -57,7 +57,7 @@ class AuthTokens:
 
 def get_cache_path() -> Path:
     """Get the path to the auth cache file."""
-    cache_dir = Path.home() / ".notebooklm-mcp"
+    cache_dir = Path.home() / ".notebooklm-mcp-cli"
     cache_dir.mkdir(exist_ok=True)
     return cache_dir / "auth.json"
 
@@ -180,7 +180,7 @@ def extract_session_id_from_page(html: str) -> str | None:
 #   1. Make sure Chrome is open with DevTools MCP connected
 #   2. Run: nlm login
 #   3. If not logged in, log in via the Chrome window
-#   4. Tokens are cached to ~/.notebooklm-mcp/auth.json
+#   4. Tokens are cached to ~/.notebooklm-mcp-cli/auth.json
 #   5. Start the MCP server - it will use cached tokens
 #
 # The auth flow script is separate because:

--- a/src/notebooklm_tools/__init__.py
+++ b/src/notebooklm_tools/__init__.py
@@ -1,6 +1,6 @@
 """NotebookLM Tools - Unified CLI and MCP server for Google NotebookLM."""
 
-__version__ = "0.2.12"
+__version__ = "0.2.13"
 
 from notebooklm_tools.core.client import NotebookLMClient
 

--- a/src/notebooklm_tools/core/base.py
+++ b/src/notebooklm_tools/core/base.py
@@ -613,7 +613,7 @@ class BaseClient:
             if not csrf_match:
                 # Save HTML for debugging
                 from pathlib import Path
-                debug_dir = Path.home() / ".notebooklm-mcp"
+                debug_dir = Path.home() / ".notebooklm-mcp-cli"
                 debug_dir.mkdir(exist_ok=True)
                 debug_path = debug_dir / "debug_page.html"
                 debug_path.write_text(html)

--- a/src/notebooklm_tools/utils/config.py
+++ b/src/notebooklm_tools/utils/config.py
@@ -2,7 +2,6 @@
 
 Uses ~/.notebooklm-mcp-cli/ for all data (config, profiles, Chrome profile).
 Supports migration from old locations:
-- ~/.notebooklm-mcp/ (old MCP location)
 - ~/.notebooklm-tools/ (previous unified location)  
 - ~/Library/Application Support/nlm/ (old CLI location on macOS)
 """
@@ -100,14 +99,11 @@ def get_auth_cache_file() -> Path:
 
 # Old locations for Chrome profiles
 OLD_CHROME_PROFILES = [
-    Path.home() / ".notebooklm-mcp" / "chrome-profile",  # Old MCP
     Path.home() / ".nlm" / "chrome-profile",  # Old CLI
 ]
 
 # Old locations for aliases
-OLD_ALIAS_LOCATIONS = [
-    Path.home() / ".notebooklm-mcp" / "aliases.json",  # Old MCP (if any)
-]
+OLD_ALIAS_LOCATIONS: list[Path] = []
 
 # Try to add old CLI alias location (platformdirs-based)
 try:
@@ -214,11 +210,6 @@ def run_migration(dry_run: bool = True, prefer_source: str | None = None) -> lis
             # Prefer CLI location
             sources["chrome_profiles"].sort(
                 key=lambda p: 0 if ".nlm" in str(p) else 1
-            )
-        elif prefer_source == "mcp":
-            # Prefer MCP location
-            sources["chrome_profiles"].sort(
-                key=lambda p: 0 if ".notebooklm-mcp" in str(p) else 1
             )
         
         # Use the first available

--- a/uv.lock
+++ b/uv.lock
@@ -858,7 +858,7 @@ wheels = [
 
 [[package]]
 name = "notebooklm-mcp-cli"
-version = "0.2.11"
+version = "0.2.13"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

- Remove all references to the old `~/.notebooklm-mcp/` folder
- Consolidate everything to `~/.notebooklm-mcp-cli/`
- Users were confused by the old folder thinking it wasn't needed

## Changes

- `src/notebooklm_mcp/auth.py` - Use `.notebooklm-mcp-cli` for cache
- `src/notebooklm_mcp/api_client.py` - Use `.notebooklm-mcp-cli` for debug
- `src/notebooklm_tools/core/base.py` - Use `.notebooklm-mcp-cli` for debug
- `src/notebooklm_tools/utils/config.py` - Remove old migration paths
- `docs/KNOWN_ISSUES.md` - Update debug path reference

## Test Plan

- [x] 132 unit tests pass
- [x] No more references to `.notebooklm-mcp` in src/ or docs/

Made with [Cursor](https://cursor.com)