### PR TITLE
v0.2.16: Fix Windows JSON parse errors and profile handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "notebooklm-mcp-cli"
-version = "0.2.15"
+version = "0.2.16"
 description = "Unified CLI and MCP server for Google NotebookLM"
 readme = "README.md"
 license = "MIT"

--- a/src/notebooklm_tools/__init__.py
+++ b/src/notebooklm_tools/__init__.py
@@ -1,6 +1,6 @@
 """NotebookLM Tools - Unified CLI and MCP server for Google NotebookLM."""
 
-__version__ = "0.2.15"
+__version__ = "0.2.16"
 
 from notebooklm_tools.core.client import NotebookLMClient
 

--- a/src/notebooklm_tools/cli/main.py
+++ b/src/notebooklm_tools/cli/main.py
@@ -87,9 +87,9 @@ def login_callback(
         False, "--check",
         help="Only check if current auth is valid",
     ),
-    profile: str = typer.Option(
-        "default", "--profile", "-p",
-        help="Profile name to save credentials to",
+    profile: Optional[str] = typer.Option(
+        None, "--profile", "-p",
+        help="Profile name (uses config default if not specified)",
     ),
     cookie_file: Optional[str] = typer.Option(
         None, "--file", "-f",
@@ -105,10 +105,15 @@ def login_callback(
     """
     from notebooklm_tools.core.auth import AuthManager
     from notebooklm_tools.core.exceptions import NLMError
+    from notebooklm_tools.utils.config import get_config
 
     # If a subcommand is invoked, don't run login logic
     if ctx.invoked_subcommand is not None:
         return
+
+    # Use config default if no profile specified
+    if profile is None:
+        profile = get_config().auth.default_profile
 
     auth = AuthManager(profile)
 

--- a/src/notebooklm_tools/core/auth.py
+++ b/src/notebooklm_tools/core/auth.py
@@ -7,10 +7,14 @@ Storage location: ~/.notebooklm-mcp-cli/ (unified for CLI and MCP)
 """
 
 import json
+import logging
 import os
 import time
 from dataclasses import dataclass
 from pathlib import Path
+
+# Use logging instead of print to avoid corrupting MCP stdio protocol
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -106,11 +110,11 @@ def load_cached_tokens() -> AuthTokens | None:
         # Just warn if tokens are old, but still return them
         # Let the API client's functional check determine validity
         if tokens.is_expired():
-            print("Note: Cached tokens are older than 1 week. They may still work.")
+            logger.warning("Cached tokens are older than 1 week. They may still work.")
 
         return tokens
     except (json.JSONDecodeError, KeyError, TypeError) as e:
-        print(f"Failed to load cached tokens: {e}")
+        logger.warning(f"Failed to load cached tokens: {e}")
         return None
 
 
@@ -125,7 +129,7 @@ def save_tokens_to_cache(tokens: AuthTokens, silent: bool = False) -> None:
     with open(cache_path, "w") as f:
         json.dump(tokens.to_dict(), f, indent=2)
     if not silent:
-        print(f"Auth tokens cached to {cache_path}")
+        logger.info(f"Auth tokens cached to {cache_path}")
 
 
 def extract_tokens_via_chrome_devtools() -> AuthTokens | None:

--- a/src/notebooklm_tools/core/notebooks.py
+++ b/src/notebooklm_tools/core/notebooks.py
@@ -10,12 +10,15 @@ This mixin provides all notebook-related operations:
 - delete_notebook: Delete a notebook
 """
 
+import logging
 from typing import Any
 
 from .base import BaseClient
 from . import constants
 from .data_types import Notebook
 from .utils import parse_timestamp
+
+logger = logging.getLogger(__name__)
 
 
 # Ownership constants (from metadata position 0)
@@ -41,27 +44,27 @@ class NotebookMixin(BaseClient):
         url = self._build_url(self.RPC_LIST_NOTEBOOKS)
 
         if debug:
-            print(f"[DEBUG] URL: {url}")
-            print(f"[DEBUG] Body: {body[:200]}...")
+            logger.debug(f"URL: {url}")
+            logger.debug(f"Body: {body[:200]}...")
 
         response = client.post(url, content=body)
         response.raise_for_status()
 
         if debug:
-            print(f"[DEBUG] Response status: {response.status_code}")
-            print(f"[DEBUG] Response length: {len(response.text)} chars")
+            logger.debug(f"Response status: {response.status_code}")
+            logger.debug(f"Response length: {len(response.text)} chars")
 
         parsed = self._parse_response(response.text)
         result = self._extract_rpc_result(parsed, self.RPC_LIST_NOTEBOOKS)
 
         if debug:
-            print(f"[DEBUG] Parsed chunks: {len(parsed)}")
-            print(f"[DEBUG] Result type: {type(result)}")
+            logger.debug(f"Parsed chunks: {len(parsed)}")
+            logger.debug(f"Result type: {type(result)}")
             if result:
-                print(f"[DEBUG] Result length: {len(result) if isinstance(result, list) else 'N/A'}")
+                logger.debug(f"Result length: {len(result) if isinstance(result, list) else 'N/A'}")
                 if isinstance(result, list) and len(result) > 0:
-                    print(f"[DEBUG] First item type: {type(result[0])}")
-                    print(f"[DEBUG] First item: {str(result[0])[:500]}...")
+                    logger.debug(f"First item type: {type(result[0])}")
+                    logger.debug(f"First item: {str(result[0])[:500]}...")
 
         notebooks = []
         if result and isinstance(result, list):

--- a/src/notebooklm_tools/mcp/server.py
+++ b/src/notebooklm_tools/mcp/server.py
@@ -171,8 +171,10 @@ Examples:
     set_query_timeout(args.query_timeout)
     
     # Run server with appropriate transport
+    # show_banner=False prevents Rich box-drawing output that can corrupt
+    # the JSON-RPC protocol on Windows (especially with non-English locales)
     if args.transport == "stdio":
-        mcp.run()
+        mcp.run(show_banner=False)
     elif args.transport == "http":
         mcp.run(
             transport="streamable-http",
@@ -180,12 +182,14 @@ Examples:
             port=args.port,
             path=args.path,
             stateless_http=args.stateless,
+            show_banner=False,
         )
     elif args.transport == "sse":
         mcp.run(
             transport="sse",
             host=args.host,
             port=args.port,
+            show_banner=False,
         )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -858,7 +858,7 @@ wheels = [
 
 [[package]]
 name = "notebooklm-mcp-cli"
-version = "0.2.14"
+version = "0.2.15"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary
- Add `show_banner=False` to `mcp.run()` to prevent FastMCP banner from corrupting stdio JSON-RPC protocol on Windows (fixes #35)
- Replace `print()` with logging in `auth.py` and `notebooks.py` to avoid stdout pollution in MCP mode
- Fix `nlm login --check` to use config's `default_profile` instead of hardcoded "default"

## Test plan
- [x] All 129 unit tests pass
- [x] `nlm login --check` uses configured default profile
- [x] `nlm --version` shows 0.2.16
- [ ] Windows user confirms JSON parse errors resolved (pending #35 feedback)