### PR TITLE
feat: add `nlm setup` and `nlm doctor` commands

### DIFF
--- a/src/notebooklm_tools/cli/commands/doctor.py
+++ b/src/notebooklm_tools/cli/commands/doctor.py
@@ -1,0 +1,279 @@
+"""Diagnostic command for troubleshooting NotebookLM MCP setup."""
+
+import shutil
+import platform
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+app = typer.Typer(
+    name="doctor",
+    help="Diagnose NotebookLM MCP installation and configuration",
+    invoke_without_command=True,
+)
+
+
+@app.callback(invoke_without_command=True)
+def doctor(
+    ctx: typer.Context,
+    verbose: bool = typer.Option(
+        False, "--verbose", "-v",
+        help="Show additional diagnostic details",
+    ),
+) -> None:
+    """
+    Run diagnostics on your NotebookLM MCP installation.
+
+    Checks installation, authentication, Chrome profile, and AI tool
+    configurations. Suggests fixes for common issues.
+
+    Examples:
+        nlm doctor
+        nlm doctor --verbose
+    """
+    if ctx.invoked_subcommand is not None:
+        return
+
+    console.print("[bold]NotebookLM MCP Doctor[/bold]\n")
+
+    all_ok = True
+    all_ok &= _check_installation(verbose)
+    console.print()
+    all_ok &= _check_authentication(verbose)
+    console.print()
+    all_ok &= _check_chrome(verbose)
+    console.print()
+    all_ok &= _check_clients(verbose)
+    console.print()
+
+    if all_ok:
+        console.print("[green]✓ All checks passed![/green]")
+    else:
+        console.print("[yellow]Some issues found.[/yellow] See suggestions above.")
+
+
+def _check_installation(verbose: bool) -> bool:
+    """Check that the package and binaries are properly installed."""
+    console.print("[bold]Installation[/bold]")
+    ok = True
+
+    # Package version
+    try:
+        from notebooklm_tools import __version__
+        console.print(f"  notebooklm-mcp-cli: [green]{__version__}[/green]")
+    except ImportError:
+        console.print(f"  notebooklm-mcp-cli: [red]not importable[/red]")
+        ok = False
+
+    # Binary paths
+    for cmd in ["nlm", "notebooklm-mcp"]:
+        path = shutil.which(cmd)
+        if path:
+            console.print(f"  {cmd}: [green]{path}[/green]")
+        else:
+            console.print(f"  {cmd}: [red]not found in PATH[/red]")
+            ok = False
+
+    # Python version
+    if verbose:
+        import sys
+        console.print(f"  python: [dim]{sys.executable} ({platform.python_version()})[/dim]")
+        console.print(f"  platform: [dim]{platform.system()} {platform.machine()}[/dim]")
+
+    return ok
+
+
+def _check_authentication(verbose: bool) -> bool:
+    """Check authentication status."""
+    console.print("[bold]Authentication[/bold]")
+    ok = True
+
+    from notebooklm_tools.core.auth import AuthManager
+    from notebooklm_tools.utils.config import get_config
+
+    config = get_config()
+    default_profile = config.auth.default_profile
+    profiles = AuthManager.list_profiles()
+
+    if not profiles:
+        console.print(f"  Profiles: [red]none[/red]")
+        console.print(f"  [yellow]→[/yellow] Run [cyan]nlm login[/cyan] to authenticate")
+        return False
+
+    console.print(f"  Default profile: [cyan]{default_profile}[/cyan]")
+    console.print(f"  Profiles found: {len(profiles)}")
+
+    # Check default profile
+    try:
+        auth = AuthManager(default_profile)
+        if auth.profile_exists():
+            profile = auth.load_profile()
+
+            has_cookies = bool(profile.cookies)
+            has_csrf = bool(profile.csrf_token)
+            email = profile.email or "unknown"
+
+            if has_cookies:
+                console.print(f"  Cookies: [green]present[/green] ({len(profile.cookies)} cookies)")
+            else:
+                console.print(f"  Cookies: [red]missing[/red]")
+                ok = False
+
+            console.print(f"  CSRF token: {'[green]yes[/green]' if has_csrf else '[yellow]no[/yellow] (will auto-extract)'}")
+            console.print(f"  Account: {email}")
+
+            if verbose:
+                # Show last validated time
+                last_validated = getattr(profile, "last_validated", None)
+                if last_validated:
+                    console.print(f"  Last validated: [dim]{last_validated}[/dim]")
+        else:
+            console.print(f"  Profile '{default_profile}': [red]not found[/red]")
+            console.print(f"  [yellow]→[/yellow] Run [cyan]nlm login[/cyan] to create it")
+            ok = False
+    except Exception as e:
+        console.print(f"  Profile '{default_profile}': [red]error loading[/red] ({e})")
+        ok = False
+
+    # Show other profiles
+    if verbose and len(profiles) > 1:
+        console.print(f"  Other profiles: {', '.join(p for p in profiles if p != default_profile)}")
+
+    return ok
+
+
+def _check_chrome(verbose: bool) -> bool:
+    """Check Chrome installation and saved profile."""
+    console.print("[bold]Chrome[/bold]")
+    ok = True
+
+    # Chrome binary
+    system = platform.system()
+    if system == "Darwin":
+        chrome_path = Path("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome")
+    elif system == "Windows":
+        chrome_path = Path("C:/Program Files/Google/Chrome/Application/chrome.exe")
+        if not chrome_path.exists():
+            chrome_path = Path("C:/Program Files (x86)/Google/Chrome/Application/chrome.exe")
+    else:
+        chrome_path = Path(shutil.which("google-chrome") or shutil.which("chromium") or "")
+
+    if chrome_path.exists():
+        console.print(f"  Chrome: [green]installed[/green]")
+        if verbose:
+            console.print(f"  [dim]{chrome_path}[/dim]")
+    else:
+        console.print(f"  Chrome: [red]not found[/red]")
+        console.print(f"  [yellow]→[/yellow] Chrome is required for authentication")
+        ok = False
+
+    # Saved Chrome profile
+    from notebooklm_tools.utils.config import get_storage_dir
+
+    chrome_profiles_dir = get_storage_dir() / "chrome-profiles"
+    has_profile = False
+
+    if chrome_profiles_dir.exists():
+        for profile_dir in chrome_profiles_dir.iterdir():
+            if profile_dir.is_dir() and (profile_dir / "Default").exists():
+                has_profile = True
+                console.print(f"  Saved profile: [green]{profile_dir.name}[/green]")
+                if verbose:
+                    console.print(f"  [dim]{profile_dir}[/dim]")
+
+    # Also check legacy location
+    legacy_chrome = get_storage_dir() / "chrome-profile"
+    if legacy_chrome.exists() and (legacy_chrome / "Default").exists():
+        has_profile = True
+        if verbose:
+            console.print(f"  Legacy profile: [dim]{legacy_chrome}[/dim]")
+
+    if has_profile:
+        console.print(f"  Headless auth: [green]available[/green] (saved Google login)")
+    else:
+        console.print(f"  Headless auth: [yellow]not available[/yellow] (no saved profile)")
+        console.print(f"  [dim]Run nlm login once to save Chrome profile for headless refresh[/dim]")
+
+    return ok
+
+
+def _check_clients(verbose: bool) -> bool:
+    """Check AI tool MCP configurations."""
+    console.print("[bold]AI Tool Configurations[/bold]")
+
+    # Import setup module for config detection
+    from notebooklm_tools.cli.commands.setup import (
+        CLIENT_REGISTRY,
+        _claude_desktop_config_path,
+        _gemini_config_path,
+        _cursor_config_path,
+        _windsurf_config_path,
+        _read_json_config,
+        _is_configured,
+    )
+
+    import subprocess
+
+    configured_count = 0
+    total_count = 0
+
+    for client_id, info in CLIENT_REGISTRY.items():
+        if not info["has_auto_setup"]:
+            continue
+        total_count += 1
+
+        status = None
+
+        if client_id == "claude-code":
+            claude_cmd = shutil.which("claude")
+            if claude_cmd:
+                try:
+                    result = subprocess.run(
+                        [claude_cmd, "mcp", "list"],
+                        capture_output=True, text=True, timeout=5,
+                    )
+                    if "notebooklm" in result.stdout.lower():
+                        status = True
+                except (subprocess.TimeoutExpired, OSError):
+                    pass
+            elif not claude_cmd:
+                if verbose:
+                    console.print(f"  {info['name']}: [dim]not installed[/dim]")
+                continue
+
+        elif client_id == "claude-desktop":
+            path = _claude_desktop_config_path()
+            config = _read_json_config(path)
+            status = _is_configured(config)
+
+        elif client_id == "gemini":
+            path = _gemini_config_path()
+            config = _read_json_config(path)
+            status = _is_configured(config, "notebooklm")
+
+        elif client_id == "cursor":
+            path = _cursor_config_path()
+            config = _read_json_config(path)
+            status = _is_configured(config)
+
+        elif client_id == "windsurf":
+            path = _windsurf_config_path()
+            config = _read_json_config(path)
+            status = _is_configured(config)
+
+        if status is True:
+            console.print(f"  {info['name']}: [green]configured[/green]")
+            configured_count += 1
+        elif status is False:
+            console.print(f"  {info['name']}: [yellow]not configured[/yellow]  → [cyan]nlm setup add {client_id}[/cyan]")
+        # None means we couldn't determine (already printed)
+
+    if configured_count == 0:
+        console.print(f"\n  [yellow]No AI tools configured.[/yellow]")
+        console.print(f"  Run [cyan]nlm setup add <client>[/cyan] to configure one.")
+        return False
+
+    return True

--- a/src/notebooklm_tools/cli/commands/setup.py
+++ b/src/notebooklm_tools/cli/commands/setup.py
@@ -1,0 +1,448 @@
+"""MCP server setup commands for AI tool clients.
+
+Configures the notebooklm-mcp server in various AI tool config files,
+so the tools can use NotebookLM via MCP protocol.
+
+This is different from `nlm skill` which installs skill/reference docs.
+`nlm setup` configures the actual MCP server transport.
+"""
+
+import json
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+app = typer.Typer(
+    name="setup",
+    help="Configure NotebookLM MCP server for AI tools",
+    no_args_is_help=True,
+)
+
+# MCP server command - the binary that clients will execute
+MCP_SERVER_CMD = "notebooklm-mcp"
+
+
+def _find_mcp_server_path() -> Optional[str]:
+    """Find the full path to the notebooklm-mcp binary."""
+    return shutil.which(MCP_SERVER_CMD)
+
+
+def _read_json_config(path: Path) -> dict:
+    """Read a JSON config file, returning empty dict if missing or invalid."""
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _write_json_config(path: Path, config: dict) -> None:
+    """Write a JSON config file, creating parent dirs as needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(config, indent=2) + "\n")
+
+
+def _is_configured(config: dict, key: str = "notebooklm-mcp") -> bool:
+    """Check if notebooklm-mcp is already in an mcpServers config."""
+    servers = config.get("mcpServers", {})
+    return key in servers or "notebooklm" in servers
+
+
+def _add_mcp_server(config: dict, key: str = "notebooklm-mcp", extra: Optional[dict] = None) -> dict:
+    """Add notebooklm-mcp to an mcpServers config dict."""
+    config.setdefault("mcpServers", {})
+    entry = {"command": MCP_SERVER_CMD, "args": []}
+    if extra:
+        entry.update(extra)
+    config["mcpServers"][key] = entry
+    return config
+
+
+# =============================================================================
+# Client-specific config paths
+# =============================================================================
+
+def _claude_desktop_config_path() -> Path:
+    """Get Claude Desktop config path (platform-specific)."""
+    system = platform.system()
+    if system == "Darwin":
+        return Path.home() / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
+    elif system == "Windows":
+        appdata = Path(os.environ.get("APPDATA", ""))
+        return appdata / "Claude" / "claude_desktop_config.json"
+    else:  # Linux
+        return Path.home() / ".config" / "claude" / "claude_desktop_config.json"
+
+
+def _gemini_config_path() -> Path:
+    """Get Gemini CLI config path."""
+    return Path.home() / ".gemini" / "settings.json"
+
+
+def _cursor_config_path(level: str = "user") -> Path:
+    """Get Cursor MCP config path."""
+    if level == "project":
+        return Path(".cursor") / "mcp.json"
+    # User-level
+    system = platform.system()
+    if system == "Darwin":
+        return Path.home() / ".cursor" / "mcp.json"
+    elif system == "Windows":
+        appdata = Path(os.environ.get("APPDATA", ""))
+        return appdata / "Cursor" / "User" / "mcp.json"
+    else:
+        return Path.home() / ".config" / "cursor" / "mcp.json"
+
+
+def _windsurf_config_path() -> Path:
+    """Get Windsurf MCP config path."""
+    system = platform.system()
+    if system == "Darwin":
+        return Path.home() / ".codeium" / "windsurf" / "mcp_config.json"
+    elif system == "Windows":
+        appdata = Path(os.environ.get("APPDATA", ""))
+        return appdata / "Codeium" / "windsurf" / "mcp_config.json"
+    else:
+        return Path.home() / ".config" / "codeium" / "windsurf" / "mcp_config.json"
+
+
+# =============================================================================
+# Client definitions
+# =============================================================================
+
+import os
+
+CLIENT_REGISTRY = {
+    "claude-code": {
+        "name": "Claude Code",
+        "description": "Anthropic CLI (claude command)",
+        "has_auto_setup": True,
+    },
+    "claude-desktop": {
+        "name": "Claude Desktop",
+        "description": "Claude desktop application",
+        "has_auto_setup": True,
+    },
+    "gemini": {
+        "name": "Gemini CLI",
+        "description": "Google Gemini CLI",
+        "has_auto_setup": True,
+    },
+    "cursor": {
+        "name": "Cursor",
+        "description": "Cursor AI editor",
+        "has_auto_setup": True,
+    },
+    "windsurf": {
+        "name": "Windsurf",
+        "description": "Codeium Windsurf editor",
+        "has_auto_setup": True,
+    },
+    "codex": {
+        "name": "Codex CLI",
+        "description": "OpenAI Codex CLI",
+        "has_auto_setup": False,
+    },
+}
+
+
+def _complete_client(incomplete: str) -> list[str]:
+    """Shell completion for client names."""
+    return [name for name in CLIENT_REGISTRY if name.startswith(incomplete)]
+
+
+# =============================================================================
+# Setup implementations
+# =============================================================================
+
+def _setup_claude_code() -> bool:
+    """Add MCP to Claude Code via `claude mcp add`."""
+    claude_cmd = shutil.which("claude")
+    if not claude_cmd:
+        console.print("[yellow]Warning:[/yellow] 'claude' command not found in PATH")
+        console.print("  Install Claude Code: https://docs.anthropic.com/en/docs/claude-code")
+        console.print()
+        console.print("  Manual setup — add to [dim]~/.claude/settings.json[/dim]:")
+        console.print('    "mcpServers": { "notebooklm-mcp": { "command": "notebooklm-mcp" } }')
+        return False
+
+    try:
+        result = subprocess.run(
+            [claude_cmd, "mcp", "add", "-s", "user", "notebooklm-mcp", "--", MCP_SERVER_CMD],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            console.print(f"[green]✓[/green] Added to Claude Code (user scope)")
+            return True
+        elif "already exists" in result.stderr.lower():
+            console.print(f"[green]✓[/green] Already configured in Claude Code")
+            return True
+        else:
+            console.print(f"[yellow]Warning:[/yellow] claude mcp add returned: {result.stderr.strip()}")
+            return False
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        console.print(f"[yellow]Warning:[/yellow] Could not run claude command: {e}")
+        return False
+
+
+def _setup_claude_desktop() -> bool:
+    """Add MCP to Claude Desktop config file."""
+    config_path = _claude_desktop_config_path()
+    config = _read_json_config(config_path)
+
+    if _is_configured(config):
+        console.print(f"[green]✓[/green] Already configured in Claude Desktop")
+        return True
+
+    _add_mcp_server(config)
+    _write_json_config(config_path, config)
+    console.print(f"[green]✓[/green] Added to Claude Desktop")
+    console.print(f"  [dim]{config_path}[/dim]")
+    return True
+
+
+def _setup_gemini() -> bool:
+    """Add MCP to Gemini CLI config."""
+    config_path = _gemini_config_path()
+    config = _read_json_config(config_path)
+
+    if _is_configured(config, "notebooklm"):
+        console.print(f"[green]✓[/green] Already configured in Gemini CLI")
+        return True
+
+    _add_mcp_server(config, key="notebooklm", extra={"trust": True})
+    _write_json_config(config_path, config)
+    console.print(f"[green]✓[/green] Added to Gemini CLI")
+    console.print(f"  [dim]{config_path}[/dim]")
+    return True
+
+
+def _setup_cursor(level: str = "user") -> bool:
+    """Add MCP to Cursor config."""
+    config_path = _cursor_config_path(level)
+    config = _read_json_config(config_path)
+
+    if _is_configured(config):
+        console.print(f"[green]✓[/green] Already configured in Cursor ({level})")
+        return True
+
+    _add_mcp_server(config)
+    _write_json_config(config_path, config)
+    console.print(f"[green]✓[/green] Added to Cursor ({level})")
+    console.print(f"  [dim]{config_path}[/dim]")
+    return True
+
+
+def _setup_windsurf() -> bool:
+    """Add MCP to Windsurf config."""
+    config_path = _windsurf_config_path()
+    config = _read_json_config(config_path)
+
+    if _is_configured(config):
+        console.print(f"[green]✓[/green] Already configured in Windsurf")
+        return True
+
+    _add_mcp_server(config)
+    _write_json_config(config_path, config)
+    console.print(f"[green]✓[/green] Added to Windsurf")
+    console.print(f"  [dim]{config_path}[/dim]")
+    return True
+
+
+# =============================================================================
+# Commands
+# =============================================================================
+
+@app.command("add")
+def setup_add(
+    client: str = typer.Argument(
+        ...,
+        help="AI tool to configure (claude-code, claude-desktop, gemini, cursor, windsurf)",
+        shell_complete=_complete_client,
+    ),
+) -> None:
+    """
+    Add NotebookLM MCP server to an AI tool.
+
+    Configures the MCP server transport so the AI tool can access
+    NotebookLM features (notebooks, sources, audio, research, etc).
+
+    Examples:
+        nlm setup add claude-code
+        nlm setup add claude-desktop
+        nlm setup add gemini
+        nlm setup add cursor
+        nlm setup add windsurf
+    """
+    if client not in CLIENT_REGISTRY:
+        valid = ", ".join(CLIENT_REGISTRY.keys())
+        console.print(f"[red]Error:[/red] Unknown client '{client}'")
+        console.print(f"Available clients: {valid}")
+        raise typer.Exit(1)
+
+    info = CLIENT_REGISTRY[client]
+    console.print(f"\n[bold]{info['name']}[/bold] — Adding NotebookLM MCP\n")
+
+    if not info["has_auto_setup"]:
+        console.print(f"[yellow]Note:[/yellow] {info['name']} doesn't use MCP server config.")
+        console.print(f"Use [cyan]nlm skill install {client}[/cyan] to install skill files instead.")
+        raise typer.Exit(0)
+
+    setup_fn = {
+        "claude-code": _setup_claude_code,
+        "claude-desktop": _setup_claude_desktop,
+        "gemini": _setup_gemini,
+        "cursor": _setup_cursor,
+        "windsurf": _setup_windsurf,
+    }
+
+    success = setup_fn[client]()
+    if success:
+        console.print(f"\n[dim]Restart {info['name']} to activate the MCP server.[/dim]")
+
+
+@app.command("remove")
+def setup_remove(
+    client: str = typer.Argument(
+        ...,
+        help="AI tool to remove MCP from",
+        shell_complete=_complete_client,
+    ),
+) -> None:
+    """
+    Remove NotebookLM MCP server from an AI tool.
+
+    Examples:
+        nlm setup remove claude-desktop
+        nlm setup remove gemini
+    """
+    if client not in CLIENT_REGISTRY:
+        valid = ", ".join(CLIENT_REGISTRY.keys())
+        console.print(f"[red]Error:[/red] Unknown client '{client}'")
+        console.print(f"Available clients: {valid}")
+        raise typer.Exit(1)
+
+    # Client-specific removal
+    if client == "claude-code":
+        claude_cmd = shutil.which("claude")
+        if claude_cmd:
+            result = subprocess.run(
+                [claude_cmd, "mcp", "remove", "-s", "user", "notebooklm-mcp"],
+                capture_output=True, text=True, timeout=10,
+            )
+            if result.returncode == 0:
+                console.print(f"[green]✓[/green] Removed from Claude Code")
+            else:
+                console.print(f"[yellow]Note:[/yellow] {result.stderr.strip()}")
+        else:
+            console.print("[yellow]Warning:[/yellow] 'claude' command not found")
+        return
+
+    # JSON config-based clients
+    config_paths = {
+        "claude-desktop": _claude_desktop_config_path(),
+        "gemini": _gemini_config_path(),
+        "cursor": _cursor_config_path(),
+        "windsurf": _windsurf_config_path(),
+    }
+
+    config_path = config_paths.get(client)
+    if not config_path or not config_path.exists():
+        console.print(f"[dim]No config file found for {client}.[/dim]")
+        return
+
+    config = _read_json_config(config_path)
+    servers = config.get("mcpServers", {})
+
+    removed = False
+    for key in ["notebooklm-mcp", "notebooklm"]:
+        if key in servers:
+            del servers[key]
+            removed = True
+
+    if removed:
+        _write_json_config(config_path, config)
+        console.print(f"[green]✓[/green] Removed from {CLIENT_REGISTRY[client]['name']}")
+    else:
+        console.print(f"[dim]NotebookLM MCP was not configured in {CLIENT_REGISTRY[client]['name']}.[/dim]")
+
+
+@app.command("list")
+def setup_list() -> None:
+    """
+    Show supported AI tools and their MCP configuration status.
+    """
+    table = Table(title="NotebookLM MCP Server Configuration")
+    table.add_column("Client", style="cyan")
+    table.add_column("Description")
+    table.add_column("MCP Status", justify="center")
+    table.add_column("Config Path", style="dim")
+
+    for client_id, info in CLIENT_REGISTRY.items():
+        status = "[dim]-[/dim]"
+        config_path = ""
+
+        if client_id == "claude-code":
+            # Check via claude command
+            claude_cmd = shutil.which("claude")
+            if claude_cmd:
+                try:
+                    result = subprocess.run(
+                        [claude_cmd, "mcp", "list"],
+                        capture_output=True, text=True, timeout=5,
+                    )
+                    if "notebooklm" in result.stdout.lower():
+                        status = "[green]✓[/green]"
+                except (subprocess.TimeoutExpired, OSError):
+                    status = "[dim]?[/dim]"
+                config_path = "claude mcp list"
+            else:
+                config_path = "not installed"
+
+        elif client_id == "claude-desktop":
+            path = _claude_desktop_config_path()
+            config = _read_json_config(path)
+            if _is_configured(config):
+                status = "[green]✓[/green]"
+            config_path = str(path).replace(str(Path.home()), "~")
+
+        elif client_id == "gemini":
+            path = _gemini_config_path()
+            config = _read_json_config(path)
+            if _is_configured(config, "notebooklm"):
+                status = "[green]✓[/green]"
+            config_path = str(path).replace(str(Path.home()), "~")
+
+        elif client_id == "cursor":
+            path = _cursor_config_path()
+            config = _read_json_config(path)
+            if _is_configured(config):
+                status = "[green]✓[/green]"
+            config_path = str(path).replace(str(Path.home()), "~")
+
+        elif client_id == "windsurf":
+            path = _windsurf_config_path()
+            config = _read_json_config(path)
+            if _is_configured(config):
+                status = "[green]✓[/green]"
+            config_path = str(path).replace(str(Path.home()), "~")
+
+        elif client_id == "codex":
+            config_path = "uses nlm skill install codex"
+
+        table.add_row(info["name"], info["description"], status, config_path)
+
+    console.print(table)
+    console.print("\n[dim]Add MCP server:  nlm setup add <client>[/dim]")
+    console.print("[dim]Install skills:  nlm skill install <tool>[/dim]")

--- a/src/notebooklm_tools/cli/main.py
+++ b/src/notebooklm_tools/cli/main.py
@@ -14,6 +14,8 @@ from notebooklm_tools.cli.commands.source import app as source_app
 from notebooklm_tools.cli.commands.alias import app as alias_app
 from notebooklm_tools.cli.commands.config import app as config_app
 from notebooklm_tools.cli.commands.skill import app as skill_app
+from notebooklm_tools.cli.commands.setup import app as setup_app
+from notebooklm_tools.cli.commands.doctor import app as doctor_app
 from notebooklm_tools.cli.commands.studio import (
     app as studio_app,
     audio_app,
@@ -389,6 +391,8 @@ app.add_typer(download_app, name="download", help="Download artifacts (audio, vi
 app.add_typer(share_app, name="share", help="Manage notebook sharing")
 app.add_typer(export_app, name="export", help="Export artifacts to Google Docs/Sheets")
 app.add_typer(skill_app, name="skill", help="Install skills for AI tools")
+app.add_typer(setup_app, name="setup", help="Configure MCP server for AI tools")
+app.add_typer(doctor_app, name="doctor", help="Diagnose installation and configuration")
 
 # Generation commands as top-level
 app.add_typer(audio_app, name="audio", help="Create audio overviews")


### PR DESCRIPTION
## Summary

Adds two new CLI commands to streamline MCP server configuration and troubleshooting across AI tools.

### `nlm setup` — One-command MCP server configuration

Configures the `notebooklm-mcp` server transport for AI clients. This complements the existing `nlm skill` (which installs skill/reference docs) by handling the actual MCP server wiring.

**Supported clients:**
- **Claude Code** — `nlm setup add claude-code` (uses `claude mcp add -s user`)
- **Claude Desktop** — `nlm setup add claude-desktop` (writes `claude_desktop_config.json`)
- **Gemini CLI** — `nlm setup add gemini` (writes `~/.gemini/settings.json`)
- **Cursor** — `nlm setup add cursor` (writes `~/.cursor/mcp.json`)
- **Windsurf** — `nlm setup add windsurf` (writes `mcp_config.json`)
- **Codex CLI** — directs to `nlm skill install codex`

**Subcommands:**
- `nlm setup add <client>` — add MCP to a client
- `nlm setup remove <client>` — remove MCP from a client
- `nlm setup list` — show all clients and config status

Platform-aware config paths (macOS, Windows, Linux). Idempotent — detects if already configured.

### `nlm doctor` — Diagnostic troubleshooting

One-command health check covering:

- **Installation** — package version, binary paths
- **Authentication** — profile status, cookies, CSRF token, account email
- **Chrome** — browser installed, saved profiles (headless auth availability)
- **AI Tools** — which clients have MCP configured, with fix suggestions

```
$ nlm doctor

NotebookLM MCP Doctor

Installation
  notebooklm-mcp-cli: 0.2.16
  nlm: /Users/tony/.local/bin/nlm
  notebooklm-mcp: /Users/tony/.local/bin/notebooklm-mcp

Authentication
  Default profile: default
  Profiles found: 2
  Cookies: present (38 cookies)
  CSRF token: yes
  Account: user@gmail.com

Chrome
  Chrome: installed
  Saved profile: default
  Headless auth: available (saved Google login)

AI Tool Configurations
  Claude Code: configured
  Claude Desktop: configured
  Gemini CLI: configured
  Cursor: not configured  → nlm setup add cursor
  Windsurf: not configured  → nlm setup add windsurf

✓ All checks passed!
```

## Motivation

Setting up the MCP server across multiple AI tools currently requires users to manually edit JSON config files with different paths per platform and per client. This is the #1 friction point for new users after authentication.

These commands reduce the getting-started flow to:
```bash
nlm login                        # authenticate
nlm setup add claude-desktop     # configure client
# restart client — done!
```

And `nlm doctor` gives users a single command to run when things aren't working, instead of manually checking auth, Chrome profiles, and config files.

## Implementation

- `src/notebooklm_tools/cli/commands/setup.py` — new command module
- `src/notebooklm_tools/cli/commands/doctor.py` — new command module
- `src/notebooklm_tools/cli/main.py` — register both commands

Follows existing patterns from `skill.py` and `config.py`. Uses `rich` for styled output, `typer` for CLI framework, platform-aware paths.

## Test plan

- [ ] `nlm setup list` shows correct status for each client
- [ ] `nlm setup add claude-desktop` creates/updates config correctly
- [ ] `nlm setup add gemini` adds MCP with `trust: true`
- [ ] `nlm setup add cursor` creates `.cursor/mcp.json`
- [ ] `nlm setup add windsurf` creates platform-correct config
- [ ] `nlm setup add claude-code` uses `claude mcp add -s user`
- [ ] `nlm setup remove <client>` cleanly removes entries
- [ ] `nlm doctor` reports correct status for all sections
- [ ] `nlm doctor --verbose` shows additional details
- [ ] Idempotent: running setup twice doesn't duplicate entries
- [ ] Cross-platform: config paths resolve correctly on macOS/Windows/Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)