### PR TITLE
feat: Claude Desktop Extension (.mcpb) with automated build & release

### DIFF
--- a/.agent/workflows/release.md
+++ b/.agent/workflows/release.md
@@ -1,0 +1,58 @@
+---
+description: How to create a new release of notebooklm-mcp-cli
+---
+
+# Release Process
+
+// turbo-all
+
+## Steps
+
+1. Ensure you're on the release branch (e.g., `dev/0.2.18`)
+
+2. Bump version in both files:
+   - `pyproject.toml` → `version = "X.Y.Z"`
+   - `src/notebooklm_tools/__init__.py` → `__version__ = "X.Y.Z"`
+
+3. Update `CHANGELOG.md` with the new version entry
+
+4. Rebuild the MCPB extension package (auto-syncs version from pyproject.toml):
+```bash
+python3 scripts/build_mcpb.py
+```
+
+5. Reinstall locally and test:
+```bash
+uv cache clean && uv tool install --force .
+```
+
+6. Run tests:
+```bash
+uv run pytest
+```
+
+7. Commit all changes:
+```bash
+git add -A && git commit -m "release: vX.Y.Z"
+```
+
+8. Merge to main and tag:
+```bash
+git checkout main && git merge dev/X.Y.Z
+git tag vX.Y.Z && git push origin main --tags
+```
+
+9. Publish to PyPI:
+```bash
+uv build && uv publish
+```
+
+## Checklist
+
+- [ ] Version bumped in `pyproject.toml` and `__init__.py`
+- [ ] CHANGELOG updated
+- [ ] MCPB rebuilt (`python3 scripts/build_mcpb.py`)
+- [ ] Tests pass
+- [ ] Committed and pushed
+- [ ] Tagged
+- [ ] Published to PyPI

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write  # Required for trusted publishing (OIDC)
+      contents: write  # Required to upload release assets
     
     steps:
       - name: Checkout repository
@@ -28,3 +29,11 @@ jobs:
       
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Build MCPB extension
+        run: python3 scripts/build_mcpb.py
+
+      - name: Upload MCPB to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: notebooklm-mcp-*.mcpb

--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,5 @@ downloads/
 run*.notebooklm-py-analysis/
 *.code-workspace
 
-# Untested/experimental
-desktop-extension/
-notebooklm-mcp.mcpb
+# Build artifacts
+*.mcpb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.18] - 2026-02-09
+
+### Added
+- **Claude Desktop Extension (.mcpb)** — One-click install for Claude Desktop. Download the `.mcpb` file from the release page, double-click to install. No manual config editing required.
+- **MCPB build automation** — `scripts/build_mcpb.py` reads version from `pyproject.toml`, syncs `manifest.json`, and packages the `.mcpb` file. Old builds are auto-cleaned.
+- **GitHub Actions release asset** — `.mcpb` file is automatically built and attached to GitHub Releases alongside PyPI publish.
+- **`nlm doctor` and `nlm setup` documentation** — Added to AI docs (`nlm --ai`) and skill file.
+
+### Changed
+- **Manifest uses `uvx`** — Claude Desktop extension now uses `uvx --from notebooklm-mcp-cli notebooklm-mcp` for universal PATH compatibility.
+
+### Removed
+- Cleaned up `PROJECT_RECAP.md` and `todo.md` (outdated development artifacts).
+
 ## [0.2.17] - 2026-02-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Also remove from your AI tools:
 |------|---------|
 | Claude Code | `claude mcp remove notebooklm-mcp` |
 | Gemini CLI | `gemini mcp remove notebooklm-mcp` |
+| Claude Desktop | Settings → Extensions → Remove |
 | Cursor/VS Code | Remove entry from `~/.cursor/mcp.json` or `~/.vscode/mcp.json` |
 
 ## Authentication

--- a/desktop-extension/manifest.json
+++ b/desktop-extension/manifest.json
@@ -1,0 +1,81 @@
+{
+  "manifest_version": "0.2",
+  "name": "notebooklm-mcp",
+  "display_name": "NotebookLM MCP Server",
+  "version": "0.2.18",
+  "description": "Connect Claude to Google NotebookLM. Create podcasts, research topics, generate quizzes, flashcards, mind maps, and more from your notebooks.",
+  "long_description": "This extension connects Claude Desktop to Google NotebookLM via the Model Context Protocol. It provides 29 tools for managing notebooks, sources, and generating AI content.\n\n**Prerequisites:**\n1. Install the package: `pip install notebooklm-mcp-cli` or `uv tool install notebooklm-mcp-cli`\n2. Authenticate: Run `nlm login` to set up your Google account\n\n**Features:**\n- Create and manage notebooks\n- Add sources (URLs, YouTube, Google Drive, text, files)\n- Generate podcasts (Audio Overview)\n- Create quizzes, flashcards, mind maps, reports\n- Research topics with web or Drive search",
+  "author": {
+    "name": "Jacob Ben-David",
+    "email": "jacob@genai.dev",
+    "url": "https://github.com/jacob-bd"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jacob-bd/notebooklm-mcp-cli"
+  },
+  "homepage": "https://github.com/jacob-bd/notebooklm-mcp-cli",
+  "documentation": "https://github.com/jacob-bd/notebooklm-mcp-cli#readme",
+  "support": "https://github.com/jacob-bd/notebooklm-mcp-cli/issues",
+  "server": {
+    "type": "python",
+    "entry_point": "notebooklm-mcp",
+    "mcp_config": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "notebooklm-mcp-cli",
+        "notebooklm-mcp"
+      ],
+      "env": {}
+    }
+  },
+  "tools": [
+    {
+      "name": "notebook_create",
+      "description": "Create a new notebook"
+    },
+    {
+      "name": "notebook_list",
+      "description": "List all notebooks"
+    },
+    {
+      "name": "notebook_query",
+      "description": "Query notebook sources with AI"
+    },
+    {
+      "name": "source_add",
+      "description": "Add sources (URL, text, Drive, file)"
+    },
+    {
+      "name": "studio_create",
+      "description": "Generate audio, video, reports, quizzes, etc."
+    },
+    {
+      "name": "research_start",
+      "description": "Research topics via web or Drive"
+    }
+  ],
+  "tools_generated": true,
+  "keywords": [
+    "notebooklm",
+    "google",
+    "podcast",
+    "research",
+    "notebook",
+    "ai",
+    "education"
+  ],
+  "license": "MIT",
+  "compatibility": {
+    "claude_desktop": ">=0.10.0",
+    "platforms": [
+      "darwin",
+      "win32",
+      "linux"
+    ],
+    "runtimes": {
+      "python": ">=3.11"
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "notebooklm-mcp-cli"
-version = "0.2.17"
+version = "0.2.18"
 description = "Unified CLI and MCP server for Google NotebookLM"
 readme = "README.md"
 license = "MIT"

--- a/scripts/build_mcpb.py
+++ b/scripts/build_mcpb.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Build the .mcpb extension package for Claude Desktop.
+
+Reads version from pyproject.toml, syncs it into desktop-extension/manifest.json,
+then packages everything into notebooklm-mcp.mcpb (a zip file).
+
+Usage:
+    python scripts/build_mcpb.py
+    # or: uv run scripts/build_mcpb.py
+"""
+
+import json
+import zipfile
+from pathlib import Path
+
+# Paths relative to project root
+PROJECT_ROOT = Path(__file__).parent.parent
+PYPROJECT = PROJECT_ROOT / "pyproject.toml"
+MANIFEST = PROJECT_ROOT / "desktop-extension" / "manifest.json"
+
+
+def get_version_from_pyproject() -> str:
+    """Extract version string from pyproject.toml without external deps."""
+    text = PYPROJECT.read_text()
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("version") and "=" in stripped:
+            # version = "0.2.18"
+            return stripped.split("=", 1)[1].strip().strip('"').strip("'")
+    raise ValueError("Could not find version in pyproject.toml")
+
+
+def sync_manifest_version(version: str) -> dict:
+    """Update manifest.json with the current version, return the manifest dict."""
+    manifest = json.loads(MANIFEST.read_text())
+    old_version = manifest.get("version", "unknown")
+
+    if old_version != version:
+        manifest["version"] = version
+        MANIFEST.write_text(json.dumps(manifest, indent=2) + "\n")
+        print(f"  manifest.json: {old_version} → {version}")
+    else:
+        print(f"  manifest.json: already at {version}")
+
+    return manifest
+
+
+def build_mcpb() -> None:
+    """Build the .mcpb file (zip containing manifest.json)."""
+    version = get_version_from_pyproject()
+    output = PROJECT_ROOT / f"notebooklm-mcp-{version}.mcpb"
+
+    print(f"\n📦 Building notebooklm-mcp-{version}.mcpb\n")
+
+    # Sync version
+    sync_manifest_version(version)
+
+    # Clean up old .mcpb files
+    for old in PROJECT_ROOT.glob("notebooklm-mcp*.mcpb"):
+        if old != output:
+            old.unlink()
+            print(f"  🗑  Removed old: {old.name}")
+
+    # Package as zip
+    with zipfile.ZipFile(output, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.write(MANIFEST, "manifest.json")
+
+    size_kb = output.stat().st_size / 1024
+    print(f"\n✅ Built: {output.name} ({size_kb:.1f} KB)")
+    print(f"   Location: {output}")
+
+
+if __name__ == "__main__":
+    build_mcpb()

--- a/src/notebooklm_tools/__init__.py
+++ b/src/notebooklm_tools/__init__.py
@@ -1,6 +1,6 @@
 """NotebookLM Tools - Unified CLI and MCP server for Google NotebookLM."""
 
-__version__ = "0.2.17"
+__version__ = "0.2.18"
 
 from notebooklm_tools.core.client import NotebookLMClient
 

--- a/src/notebooklm_tools/cli/ai_docs.py
+++ b/src/notebooklm_tools/cli/ai_docs.py
@@ -102,6 +102,8 @@ nlm status artifacts <notebook>
 | `nlm data-table` | Create data tables (create) |
 | `nlm share` | Manage notebook sharing (status, public, private, invite) |
 | `nlm skill` | Install AI assistant skills (install, uninstall, list, show) |
+| `nlm doctor` | Diagnose installation, auth, Chrome, and AI tool configs |
+| `nlm setup` | Configure MCP server for AI tools (add, remove, list) |
 
 ### All Verb-First Commands
 
@@ -646,6 +648,29 @@ nlm show config --json          # Display as JSON
 nlm get config <key>            # Get specific setting
 nlm set config <key> <value>    # Update setting
 ```
+
+### Diagnostics & Setup
+
+**Doctor** - Diagnose your NotebookLM MCP installation:
+```bash
+nlm doctor                      # Run all diagnostic checks
+nlm doctor --verbose            # Show additional details
+```
+
+Checks: installation, authentication, Chrome profile, AI tool configs. Shows suggestions for any issues found.
+
+**Setup** - Configure MCP server for AI tools:
+```bash
+nlm setup list                          # Show all clients and their MCP status
+nlm setup add claude-code               # Add to Claude Code (via claude mcp add)
+nlm setup add claude-desktop            # Add to Claude Desktop config file
+nlm setup add gemini                    # Add to Gemini CLI config
+nlm setup add cursor                    # Add to Cursor config
+nlm setup add windsurf                  # Add to Windsurf config
+nlm setup remove <client>               # Remove MCP from client
+```
+
+**Supported Clients:** claude-code, claude-desktop, gemini, cursor, windsurf, codex
 
 ---
 


### PR DESCRIPTION
## What's New in v0.2.18

### Claude Desktop Extension (.mcpb)
- **One-click install** — Download the `.mcpb` from the release page, double-click to install in Claude Desktop
- **Universal compatibility** — Uses `uvx` in the manifest for PATH-safe server startup
- **Tested and verified** — Confirmed working in Claude Desktop with all 29 tools

### Build Automation
- `scripts/build_mcpb.py` — Syncs version from `pyproject.toml` into manifest and packages `.mcpb`
- `publish.yml` updated — GitHub Actions now auto-attaches `.mcpb` to releases

### Documentation
- Added `nlm doctor` and `nlm setup` to AI docs and skill file
- Added Claude Desktop to uninstall table in README
- Cleaned up outdated `PROJECT_RECAP.md` and `todo.md`