### PR TITLE
Add OpenClaw CDP login provider + fail-fast infographic create errors

### DIFF
--- a/src/notebooklm_tools/cli/commands/studio.py
+++ b/src/notebooklm_tools/cli/commands/studio.py
@@ -533,9 +533,13 @@ def create_infographic(
                     source_ids=parse_source_ids(source_ids),
                 )
         
+        if not result or not result.get("artifact_id"):
+            console.print("[red]Error:[/red] NotebookLM rejected infographic creation (no artifact returned).")
+            console.print("[dim]The backend returned a generic UserDisplayableError. Try again later or create from NotebookLM UI for diagnosis.[/dim]")
+            raise typer.Exit(1)
+
         console.print(f"[green]✓[/green] Infographic generation started")
-        if result:
-            console.print(f"  Artifact ID: {result.get('artifact_id', 'unknown')}")
+        console.print(f"  Artifact ID: {result.get('artifact_id', 'unknown')}")
         console.print(f"\n[dim]Run 'nlm studio status {notebook_id}' to check progress.[/dim]")
     except NLMError as e:
         console.print(f"[red]Error:[/red] {e.message}")

--- a/src/notebooklm_tools/core/studio.py
+++ b/src/notebooklm_tools/core/studio.py
@@ -331,7 +331,12 @@ class StudioMixin(BaseClient):
                     self.STUDIO_TYPE_DATA_TABLE: "data_table",
                 }
                 artifact_type = "quiz" if is_quiz else type_map.get(type_code, "unknown")
-                status = "in_progress" if status_code == 1 else "completed" if status_code == 3 else "unknown"
+                status_map = {
+                    1: "in_progress",
+                    3: "completed",
+                    4: "failed",
+                }
+                status = status_map.get(status_code, "unknown")
 
                 # Extract custom_instructions (focus prompt) if present
                 # Custom prompt is stored at artifact_data[STUDIO_ARTIFACT_FOCUS_INDEX][1][0] for artifacts that have one


### PR DESCRIPTION
## What this PR fixes

### 1) `nlm login` can now use an external CDP provider (OpenClaw)
- Added `--provider` (`builtin` | `openclaw`) and `--cdp-url` options to `nlm login`.
- New path `extract_cookies_via_existing_cdp(...)` in `utils/cdp.py` reads cookies/tokens from an already-running browser CDP endpoint.
- Uses `suppress_origin=True` for websocket CDP commands to support managed endpoints that reject default Origin.

This avoids running a second Chrome profile for login when users already have an OpenClaw-managed browser session.

### 2) Fix false-success behavior in `nlm infographic create`
- Before: command printed success even when backend returned generic `UserDisplayableError` and no artifact.
- Now: if `create_infographic()` returns no artifact, CLI exits non-zero with a clear message.

### 3) Better status visibility
- Map studio status code `4` to `failed` (instead of `unknown`) in `poll_studio_status`.

---

## Why

In real runs, `infographic create` could silently fail at backend level and still print:

- `✓ Infographic generation started`

Then downstream automation polls forever and ends with `artifact_not_found`.

This PR makes the failure explicit and actionable.

---

## Related issue

- Closes #46

