### PR TITLE
feat: Add nlm skill update command and Cline/Antigravity/OpenClaw support

### DIFF
--- a/.agent/workflows/release.md
+++ b/.agent/workflows/release.md
@@ -13,6 +13,8 @@ description: How to create a new release of notebooklm-mcp-cli
 2. Bump version in both files:
    - `pyproject.toml` → `version = "X.Y.Z"`
    - `src/notebooklm_tools/__init__.py` → `__version__ = "X.Y.Z"`
+   - `src/notebooklm_tools/data/SKILL.md` (frontmatter) → `version: "X.Y.Z"`
+   - `src/notebooklm_tools/data/AGENTS_SECTION.md` (comment) → `<!-- nlm-version: X.Y.Z -->`
 
 3. Update `CHANGELOG.md` with the new version entry
 
@@ -50,7 +52,7 @@ gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes
 
 ## Checklist
 
-- [ ] Version bumped in `pyproject.toml` and `__init__.py`
+- [ ] Version bumped in `pyproject.toml`, `__init__.py`, `SKILL.md`, and `AGENTS_SECTION.md`
 - [ ] CHANGELOG updated
 - [ ] Docs reviewed and updated (README, CLI Guide, ai_docs.py, SKILL.md, command_reference.md)
 - [ ] Tests pass (`uv run python -m pytest`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-02-14
+
+### Added
+- **New AI Client Support** — Added `nlm skill install` support for:
+  - **Cline** (`~/.cline/skills`) - Terminal-based AI agent
+  - **Antigravity** (`~/.gemini/antigravity/skills`) - Advanced agentic framework
+  - **OpenClaw** (`~/.openclaw/skills`) - Autonomous AI agent
+  - **Codex** (`~/.codex/AGENTS.md`) - Now with version tracking
+- **`nlm setup` support** — Added automatic MCP configuration for:
+  - **Cline** (`nlm setup add cline`)
+  - **Antigravity** (`nlm setup add antigravity`)
+- **`nlm skill update` command** - Update installed AI skills to the latest version. Supports updating all skills or specific tools (e.g., `nlm skill update claude-code`).
+- **Verb-first alias** - `nlm update skill` works identically to `nlm skill update`.
+- **Version tracking** - `AGENTS.md` formats now support version tracking via injected comments.
+
+### Fixed
+- **Skill version validation** - `nlm skill list` now correctly identifies outdated skills and prevents "unknown" version status for Codex.
+- **Package version** - Bumped to `0.3.1` to match release tag.
+
 ## [0.3.0] - 2026-02-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Connect AI assistants (Claude, Gemini, Cursor, etc.) to NotebookLM:
 nlm setup add claude-code
 nlm setup add gemini
 nlm setup add cursor
+nlm setup add cline
+nlm setup add antigravity
+```
 ```
 
 Then use natural language: *"Create a notebook about quantum computing and generate a podcast"*
@@ -67,6 +70,7 @@ Then use natural language: *"Create a notebook about quantum computing and gener
 | Share notebook | `nlm share public/invite` | `notebook_share_*` |
 | Sync Drive sources | `nlm source sync` | `source_sync_drive` |
 | Configure AI tools | `nlm setup add/remove/list` | — |
+| Install AI Skills | `nlm skill install/update` | — |
 | Diagnose issues | `nlm doctor` | — |
 
 📚 **More Documentation:**
@@ -300,6 +304,21 @@ nlm setup list
 
 # Diagnose installation & auth issues
 nlm doctor
+```
+
+### Install AI Skills (Optional)
+
+Install the NotebookLM expert guide for your AI assistant to help it use the tools effectively. Supported for **Cline**, **Antigravity**, **OpenClaw**, **Codex**, **OpenCode**, **Claude Code**, and **Gemini CLI**.
+
+```bash
+# Install skill files
+nlm skill install cline
+nlm skill install openclaw
+nlm skill install codex
+nlm skill install antigravity
+
+# Update skills
+nlm skill update
 ```
 
 ### Remove from a tool

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "notebooklm-mcp-cli"
-version = "0.3.0"
+version = "0.3.1"
 description = "Unified CLI and MCP server for Google NotebookLM"
 readme = "README.md"
 license = "MIT"

--- a/src/notebooklm_tools/__init__.py
+++ b/src/notebooklm_tools/__init__.py
@@ -1,6 +1,6 @@
 """NotebookLM Tools - Unified CLI and MCP server for Google NotebookLM."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 from notebooklm_tools.core.client import NotebookLMClient
 

--- a/src/notebooklm_tools/cli/ai_docs.py
+++ b/src/notebooklm_tools/cli/ai_docs.py
@@ -589,6 +589,8 @@ Install the NotebookLM skill for various AI coding assistants:
 nlm skill list                              # Show installation status for all tools
 nlm skill install <tool>                    # Install at user level (default)
 nlm skill install <tool> --level project    # Install at project level
+nlm skill update                            # Update all outdated skills
+nlm skill update <tool>                     # Update a specific tool's skill
 nlm skill uninstall <tool>                  # Remove installed skill
 nlm skill show                              # Display skill content
 ```
@@ -599,6 +601,8 @@ nlm skill show                              # Display skill content
 - `opencode` - OpenCode AI assistant (`~/.config/opencode/skills/nlm-skill/`)
 - `gemini-cli` - Google Gemini CLI (`~/.gemini/skills/nlm-skill/`)
 - `antigravity` - Antigravity agent framework (`~/.gemini/antigravity/skills/nlm-skill/`)
+- `cline` - Cline CLI terminal agent (`~/.cline/skills/nlm-skill/`)
+- `openclaw` - OpenClaw AI agent framework (`~/.openclaw/skills/nlm-skill/`)
 - `codex` - Codex AI assistant (appends to `~/.codex/AGENTS.md`)
 - `other` - Export all formats to `./nlm-skill-export/` for manual installation
 
@@ -637,6 +641,8 @@ For Codex, it appends a compact section to AGENTS.md with markers for easy remov
 ```bash
 nlm install skill claude-code              # Same as: nlm skill install claude-code
 nlm install skill cursor --level project  # Install for Cursor at project level
+nlm update skill                           # Same as: nlm skill update
+nlm update skill claude-code               # Same as: nlm skill update claude-code
 nlm uninstall skill gemini-cli             # Same as: nlm skill uninstall gemini-cli
 nlm list skills                            # Same as: nlm skill list
 nlm show skill                             # Same as: nlm skill show
@@ -678,10 +684,12 @@ nlm setup add claude-desktop            # Add to Claude Desktop config file
 nlm setup add gemini                    # Add to Gemini CLI config
 nlm setup add cursor                    # Add to Cursor config
 nlm setup add windsurf                  # Add to Windsurf config
+nlm setup add cline                     # Add to Cline CLI config
+nlm setup add antigravity               # Add to Antigravity config
 nlm setup remove <client>               # Remove MCP from client
 ```
 
-**Supported Clients:** claude-code, claude-desktop, gemini, cursor, windsurf, codex
+**Supported Clients:** claude-code, claude-desktop, gemini, cursor, windsurf, cline, antigravity, codex
 
 ---
 

--- a/src/notebooklm_tools/cli/commands/setup.py
+++ b/src/notebooklm_tools/cli/commands/setup.py
@@ -160,6 +160,19 @@ def _windsurf_config_path() -> Path:
         return Path.home() / ".config" / "codeium" / "windsurf" / "mcp_config.json"
 
 
+def _cline_config_path() -> Path:
+    """Get Cline CLI MCP settings path.
+
+    This is the standalone CLI path, NOT the VS Code extension path.
+    """
+    return Path.home() / ".cline" / "data" / "settings" / "cline_mcp_settings.json"
+
+
+def _antigravity_config_path() -> Path:
+    """Get Google Antigravity MCP config path."""
+    return Path.home() / ".gemini" / "antigravity" / "mcp_config.json"
+
+
 # =============================================================================
 # Client definitions
 # =============================================================================
@@ -188,6 +201,16 @@ CLIENT_REGISTRY = {
     "windsurf": {
         "name": "Windsurf",
         "description": "Codeium Windsurf editor",
+        "has_auto_setup": True,
+    },
+    "cline": {
+        "name": "Cline CLI",
+        "description": "Cline CLI terminal agent",
+        "has_auto_setup": True,
+    },
+    "antigravity": {
+        "name": "Antigravity",
+        "description": "Google Antigravity AI IDE",
         "has_auto_setup": True,
     },
     "codex": {
@@ -303,6 +326,38 @@ def _setup_windsurf() -> bool:
     return True
 
 
+def _setup_cline() -> bool:
+    """Add MCP to Cline CLI config."""
+    config_path = _cline_config_path()
+    config = _read_json_config(config_path)
+
+    if _is_configured(config):
+        console.print(f"[green]✓[/green] Already configured in Cline CLI")
+        return True
+
+    _add_mcp_server(config)
+    _write_json_config(config_path, config)
+    console.print(f"[green]✓[/green] Added to Cline CLI")
+    console.print(f"  [dim]{config_path}[/dim]")
+    return True
+
+
+def _setup_antigravity() -> bool:
+    """Add MCP to Google Antigravity config."""
+    config_path = _antigravity_config_path()
+    config = _read_json_config(config_path)
+
+    if _is_configured(config, "notebooklm"):
+        console.print(f"[green]✓[/green] Already configured in Antigravity")
+        return True
+
+    _add_mcp_server(config, key="notebooklm")
+    _write_json_config(config_path, config)
+    console.print(f"[green]✓[/green] Added to Antigravity")
+    console.print(f"  [dim]{config_path}[/dim]")
+    return True
+
+
 # =============================================================================
 # Commands
 # =============================================================================
@@ -327,6 +382,8 @@ def setup_add(
         nlm setup add gemini
         nlm setup add cursor
         nlm setup add windsurf
+        nlm setup add cline
+        nlm setup add antigravity
     """
     if client not in CLIENT_REGISTRY:
         valid = ", ".join(CLIENT_REGISTRY.keys())
@@ -348,6 +405,8 @@ def setup_add(
         "gemini": _setup_gemini,
         "cursor": _setup_cursor,
         "windsurf": _setup_windsurf,
+        "cline": _setup_cline,
+        "antigravity": _setup_antigravity,
     }
 
     success = setup_fn[client]()
@@ -398,6 +457,8 @@ def setup_remove(
         "gemini": _gemini_config_path(),
         "cursor": _cursor_config_path(),
         "windsurf": _windsurf_config_path(),
+        "cline": _cline_config_path(),
+        "antigravity": _antigravity_config_path(),
     }
 
     config_path = config_paths.get(client)
@@ -490,6 +551,20 @@ def setup_list() -> None:
             path = _windsurf_config_path()
             config = _read_json_config(path)
             if _is_configured(config):
+                status = "[green]✓[/green]"
+            config_path = str(path).replace(str(Path.home()), "~")
+
+        elif client_id == "cline":
+            path = _cline_config_path()
+            config = _read_json_config(path)
+            if _is_configured(config):
+                status = "[green]✓[/green]"
+            config_path = str(path).replace(str(Path.home()), "~")
+
+        elif client_id == "antigravity":
+            path = _antigravity_config_path()
+            config = _read_json_config(path)
+            if _is_configured(config, "notebooklm"):
                 status = "[green]✓[/green]"
             config_path = str(path).replace(str(Path.home()), "~")
 

--- a/src/notebooklm_tools/cli/commands/verbs.py
+++ b/src/notebooklm_tools/cli/commands/verbs.py
@@ -77,6 +77,7 @@ from notebooklm_tools.cli.commands.config import (
 from notebooklm_tools.cli.commands.skill import (
     install as skill_install,
     uninstall as skill_uninstall,
+    update as skill_update,
     list_tools as skill_list,
     show as skill_show,
 )
@@ -927,4 +928,22 @@ def uninstall_skill_verb(
 ) -> None:
     """Remove installed NotebookLM skill."""
     skill_uninstall(tool=tool, level=level)
+
+
+# =============================================================================
+# UPDATE verb (for skills)
+# =============================================================================
+
+update_app = typer.Typer(help="Update resources (skills)")
+
+
+@update_app.command("skill")
+def update_skill_verb(
+    tool: Optional[str] = typer.Argument(
+        None,
+        help="Tool to update (omit to update all outdated skills)",
+    ),
+) -> None:
+    """Update outdated skills to the current version."""
+    skill_update(tool=tool)
 

--- a/src/notebooklm_tools/cli/main.py
+++ b/src/notebooklm_tools/cli/main.py
@@ -49,6 +49,7 @@ from notebooklm_tools.cli.commands.verbs import (
     show_app,
     install_app,
     uninstall_app,
+    update_app,
 )
 
 console = Console()
@@ -461,6 +462,7 @@ app.add_typer(set_app, name="set", help="Set values (aliases, config)")
 app.add_typer(show_app, name="show", help="Show information")
 app.add_typer(install_app, name="install", help="Install resources (skills)")
 app.add_typer(uninstall_app, name="uninstall", help="Uninstall resources (skills)")
+app.add_typer(update_app, name="update", help="Update resources (skills)")
 
 
 @app.callback(invoke_without_command=True)

--- a/src/notebooklm_tools/data/AGENTS_SECTION.md
+++ b/src/notebooklm_tools/data/AGENTS_SECTION.md
@@ -60,8 +60,9 @@ For complete command reference, troubleshooting, and workflows, install the full
 # Install via uv
 uv tool install notebooklm-mcp-cli
 
-# Then install skill for your AI tool
-nlm skill install <tool>  # claude-code, opencode, gemini-cli, antigravity, codex
+# Then install/update skill for your AI tool
+nlm skill install <tool>  # Install (claude-code, opencode, gemini-cli, etc)
+nlm skill update <tool>   # Update existing skill
 ```
 
 Or view inline: `nlm --ai`

--- a/src/notebooklm_tools/data/SKILL.md
+++ b/src/notebooklm_tools/data/SKILL.md
@@ -469,6 +469,20 @@ nlm login switch work                        # Switch default profile
 | `auth.browser` | `auto` | Browser for login (auto, chrome, chromium) |
 | `auth.default_profile` | `default` | Profile to use when `--profile` not specified |
 
+### 11. Skill Management
+
+Manage the NotebookLM skill installation for various AI assistants:
+
+```bash
+nlm skill list                              # Show installation status
+nlm skill update                            # Update all outdated skills
+nlm skill update <tool>                     # Update specific skill (e.g., claude-code)
+nlm skill install <tool>                    # Install skill
+nlm skill uninstall <tool>                  # Uninstall skill
+```
+
+**Verb-first aliases**: `nlm update skill`, `nlm list skills`, `nlm install skill`
+
 ## Output Formats
 
 Most list commands support multiple formats:

--- a/uv.lock
+++ b/uv.lock
@@ -858,7 +858,7 @@ wheels = [
 
 [[package]]
 name = "notebooklm-mcp-cli"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
This PR adds support for **Cline**, **Antigravity**, **OpenClaw**, and **Codex** via                                                        
 Usage: nlm setup [OPTIONS] COMMAND [ARGS]...          
                                                       
 Configure MCP server for AI tools                     
                                                       
╭─ Options ───────────────────────────────────────────╮
│ --help          Show this message and exit.         │
╰─────────────────────────────────────────────────────╯
╭─ Commands ──────────────────────────────────────────╮
│ add     Add NotebookLM MCP server to an AI tool.    │
│ remove  Remove NotebookLM MCP server from an AI     │
│         tool.                                       │
│ list    Show supported AI tools and their MCP       │
│         configuration status.                       │
╰─────────────────────────────────────────────────────╯, , and the new **
All installed skills are already at v0.3.1 ✓** command. It also fixes version tracking for installed skills.