### PR TITLE
fix: correct slides verb default format and add verb defaults tests

### DIFF
--- a/src/notebooklm_tools/cli/commands/verbs.py
+++ b/src/notebooklm_tools/cli/commands/verbs.py
@@ -196,7 +196,7 @@ def create_infographic_verb(
 @create_app.command("slides")
 def create_slides_verb(
     notebook: str = typer.Argument(..., help="Notebook ID or alias"),
-    format_opt: Optional[str] = typer.Option(None, "--format", "-f", help="Format: detailed, presenter"),
+    format_opt: Optional[str] = typer.Option(None, "--format", "-f", help="Format: detailed_deck, presenter_slides"),
     length: Optional[str] = typer.Option(None, "--length", "-l", help="Length: short, default"),
     language: Optional[str] = typer.Option(None, "--language", help="BCP-47 language code"),
     focus: Optional[str] = typer.Option(None, "--focus", help="Optional focus topic"),
@@ -207,7 +207,7 @@ def create_slides_verb(
     """Create a slide deck."""
     create_slides(
         notebook_id=notebook,
-        format=format_opt or "detailed",
+        format=format_opt or "detailed_deck",
         length=length or "default",
         language=language or "",
         focus=focus or "",

--- a/tests/cli/test_verbs_defaults.py
+++ b/tests/cli/test_verbs_defaults.py
@@ -1,0 +1,84 @@
+"""Tests that verb command fallback defaults match valid CodeMapper values.
+
+Verbs in verbs.py use `xxx or "fallback"` patterns to provide defaults
+when the user doesn't specify an option. These fallbacks must match the
+valid names in core/constants.py CodeMapper instances, otherwise the
+downstream service/core layer will reject them.
+"""
+
+import pytest
+
+from notebooklm_tools.core import constants
+
+
+class TestAudioVerbDefaults:
+    """Verify create_audio_verb fallback defaults are valid."""
+
+    def test_format_default_is_valid(self):
+        assert "deep_dive" in constants.AUDIO_FORMATS.names
+
+    def test_length_default_is_valid(self):
+        assert "default" in constants.AUDIO_LENGTHS.names
+
+
+class TestVideoVerbDefaults:
+    """Verify create_video_verb fallback defaults are valid."""
+
+    def test_format_default_is_valid(self):
+        assert "explainer" in constants.VIDEO_FORMATS.names
+
+    def test_style_default_is_valid(self):
+        assert "auto_select" in constants.VIDEO_STYLES.names
+
+
+class TestReportVerbDefaults:
+    """Verify create_report_verb fallback defaults are valid."""
+
+    def test_format_default_is_valid(self):
+        assert "Briefing Doc" == constants.REPORT_FORMAT_BRIEFING_DOC
+
+
+class TestSlidesVerbDefaults:
+    """Verify create_slides_verb fallback defaults are valid."""
+
+    def test_format_default_is_valid(self):
+        assert "detailed_deck" in constants.SLIDE_DECK_FORMATS.names
+
+    def test_length_default_is_valid(self):
+        assert "default" in constants.SLIDE_DECK_LENGTHS.names
+
+
+class TestInfographicVerbDefaults:
+    """Verify create_infographic_verb fallback defaults are valid."""
+
+    def test_orientation_default_is_valid(self):
+        assert "landscape" in constants.INFOGRAPHIC_ORIENTATIONS.names
+
+    def test_detail_default_is_valid(self):
+        assert "standard" in constants.INFOGRAPHIC_DETAILS.names
+
+
+class TestFlashcardsVerbDefaults:
+    """Verify create_flashcards_verb fallback defaults are valid."""
+
+    def test_difficulty_default_is_valid(self):
+        assert "medium" in constants.FLASHCARD_DIFFICULTIES.names
+
+
+class TestAllVerbDefaultsConsistency:
+    """Cross-check that verbs.py fallback strings resolve without error."""
+
+    @pytest.mark.parametrize("name,mapper", [
+        ("deep_dive", constants.AUDIO_FORMATS),
+        ("default", constants.AUDIO_LENGTHS),
+        ("explainer", constants.VIDEO_FORMATS),
+        ("auto_select", constants.VIDEO_STYLES),
+        ("detailed_deck", constants.SLIDE_DECK_FORMATS),
+        ("default", constants.SLIDE_DECK_LENGTHS),
+        ("landscape", constants.INFOGRAPHIC_ORIENTATIONS),
+        ("standard", constants.INFOGRAPHIC_DETAILS),
+        ("medium", constants.FLASHCARD_DIFFICULTIES),
+    ])
+    def test_default_resolves_to_valid_code(self, name, mapper):
+        code = mapper.get_code(name)
+        assert isinstance(code, int)


### PR DESCRIPTION
## Summary

- Fix `create_slides_verb` in `verbs.py` using invalid default format `"detailed"` instead of `"detailed_deck"`, which caused `nlm create slides` to fail when `--format` was not specified
- Add `tests/cli/test_verbs_defaults.py` with 19 tests validating all verb fallback defaults against `CodeMapper` entries in `constants.py`

## Bug Details

`create_slides_verb` used `format_opt or "detailed"` as the fallback, but `SLIDE_DECK_FORMATS` only accepts `"detailed_deck"` or `"presenter_slides"`. The help text also showed truncated names (`"detailed, presenter"`).

**Before:**
```
$ nlm create slides <notebook_id>
Error: Unknown slide format 'detailed'. Valid options: detailed_deck, presenter_slides
```

**After:** Works correctly with `"detailed_deck"` as the default.

## Test Plan

- [x] All 19 verb default validation tests pass (`uv run pytest tests/cli/test_verbs_defaults.py -v`)
- [x] Verified all other verb defaults (audio, video, report, infographic, flashcards) are correct
- [x] No other mismatched defaults found

## Suggested Follow-up: CLI Unit Test Coverage

Currently, CLI command tests are minimal (only `formatters.detect_output_format` is covered). Areas that would benefit from unit tests:

- **CLI command functions** (`studio.py`'s `create_audio`, `create_slides`, etc.) via `typer.testing.CliRunner`
- **`_run_create()` shared logic** (language resolution via `get_default_language()`, spinner behavior, error handling)
- **MCP tool handlers** (`mcp/tools/studio.py`'s `studio_create`, etc.) unit tests with mocked clients
- **`formatters.py`** remaining methods (`format_notebooks`, `format_sources`, `format_artifacts`, etc.)
