### PR TITLE
docs: remove extra backticks in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ nlm setup add cursor
 nlm setup add cline
 nlm setup add antigravity
 ```
-```
 
 Then use natural language: *"Create a notebook about quantum computing and generate a podcast"*
 


### PR DESCRIPTION
Removed extra backticks (` ``` `) in `README.md` to fix the code block formatting.