### PR TITLE
feat: add support for more audio/video/image formats

### DIFF
--- a/src/notebooklm_tools/core/sources.py
+++ b/src/notebooklm_tools/core/sources.py
@@ -700,7 +700,12 @@ class SourceMixin(BaseClient):
             raise FileValidationError(f"File is empty: {file_path}")
 
         # Validate file type
-        supported_extensions = {'.pdf', '.txt', '.md', '.docx', '.csv', '.mp3', '.mp4', '.jpg', '.jpeg', '.png'}
+        supported_extensions = {
+            '.pdf', '.txt', '.md', '.docx', '.csv',  # Documents
+            '.mp3', '.m4a', '.wav', '.aac', '.flac', '.ogg', '.webm',  # Audio
+            '.mp4', '.mov', '.avi', '.mkv', '.webm',  # Video
+            '.jpg', '.jpeg', '.png', '.gif', '.webp',  # Images
+        }
         file_extension = file_path.suffix.lower()
         if file_extension not in supported_extensions:
             raise FileValidationError(


### PR DESCRIPTION
## Summary
- Add support for additional audio formats: .m4a, .wav, .aac, .flac, .ogg, .webm
- Add support for additional video formats: .mov, .avi, .mkv, .webm
- Add support for additional image formats: .gif, .webp
- Organize `supported_extensions` by category for better maintainability

## Motivation
The original implementation only supported a limited set of audio formats (.mp3, .mp4). 
This prevented users from uploading common audio files like .m4a (common on macOS/iOS) 
and other popular formats.

## Changes
Modified `src/notebooklm_tools/core/sources.py`:
- Expanded `supported_extensions` set with additional formats
- Organized by category (Documents, Audio, Video, Images) with comments
- All formats are already supported by Google's resumable upload API

## Testing
- ✅ Successfully uploaded .m4a file (55MB, 1 hour audio)
- ✅ Successfully uploaded .mp3 file
- ✅ Files processed correctly by NotebookLM

## Impact
- No breaking changes
- Backwards compatible (all original formats still supported)
- Minimal code change (only modified `supported_extensions` set)

Fixes issues where users get `FileValidationError` for valid audio files.