### PR TITLE
feat: add OpenCode support to `nlm setup` (add/remove/list)

### DIFF
--- a/src/notebooklm_tools/cli/commands/setup.py
+++ b/src/notebooklm_tools/cli/commands/setup.py
@@ -33,6 +33,11 @@ app = typer.Typer(
 # MCP server command - the binary that clients will execute
 MCP_SERVER_CMD = "notebooklm-mcp"
 
+# Default MCP tool call timeout in milliseconds (5 minutes).
+# NotebookLM operations (query, source add, research, studio) can take 60-120+ seconds.
+# OpenCode's default MCP SDK timeout is 60s, which is too short.
+OPENCODE_MCP_TIMEOUT_MS = 300_000
+
 
 def _find_mcp_server_path() -> Optional[str]:
     """Find the full path to the notebooklm-mcp binary."""
@@ -126,6 +131,11 @@ def _codex_config_path() -> Path:
     return Path.home() / ".codex"
 
 
+def _opencode_config_path() -> Path:
+    """Get OpenCode global config path."""
+    return Path.home() / ".config" / "opencode" / "opencode.json"
+
+
 # =============================================================================
 # Client definitions
 # =============================================================================
@@ -164,6 +174,11 @@ CLIENT_REGISTRY = {
     "codex": {
         "name": "Codex CLI",
         "description": "OpenAI Codex CLI",
+        "has_auto_setup": True,
+    },
+    "opencode": {
+        "name": "OpenCode",
+        "description": "OpenCode terminal AI assistant",
         "has_auto_setup": True,
     },
 }
@@ -349,6 +364,53 @@ enabled = true
         return True
 
 
+def _setup_opencode() -> bool:
+    """Add MCP to OpenCode config.
+
+    Configures both the MCP server entry and a global ``experimental.mcp_timeout``
+    so that long-running NotebookLM operations (query, source add, research, studio)
+    don't hit OpenCode's default 60-second MCP request timeout.
+    """
+    config_path = _opencode_config_path()
+    config = _read_json_config(config_path)
+
+    mcp = config.get("mcp", {})
+    if "notebooklm" in mcp or "notebooklm-mcp" in mcp:
+        # Still ensure timeout is set even if server entry already exists
+        _ensure_opencode_timeout(config)
+        _write_json_config(config_path, config)
+        console.print(f"[green]✓[/green] Already configured in OpenCode")
+        return True
+
+    mcp["notebooklm"] = {
+        "type": "local",
+        "command": [MCP_SERVER_CMD],
+        "enabled": True,
+        "timeout": OPENCODE_MCP_TIMEOUT_MS,
+    }
+    config["mcp"] = mcp
+
+    # Set global experimental timeout (proven reliable across OpenCode versions)
+    _ensure_opencode_timeout(config)
+
+    _write_json_config(config_path, config)
+    console.print(f"[green]✓[/green] Added to OpenCode")
+    console.print(f"  [dim]{config_path}[/dim]")
+    return True
+
+
+def _ensure_opencode_timeout(config: dict) -> None:
+    """Set ``experimental.mcp_timeout`` if not already present.
+
+    The per-server ``timeout`` field is reportedly unreliable in some OpenCode
+    versions, so we also set the global experimental timeout as a fallback.
+    Only writes the value if the user hasn't already set a custom timeout.
+    """
+    experimental = config.setdefault("experimental", {})
+    if "mcp_timeout" not in experimental:
+        experimental["mcp_timeout"] = OPENCODE_MCP_TIMEOUT_MS
+
+
 def _detect_tool(client_id: str) -> bool:
     """Check if an AI tool is installed/present on the system.
 
@@ -377,6 +439,10 @@ def _detect_tool(client_id: str) -> bool:
         "codex": lambda: (
             shutil.which("codex") is not None
             or _codex_config_path().exists()
+        ),
+        "opencode": lambda: (
+            shutil.which("opencode") is not None
+            or _opencode_config_path().exists()
         ),
     }
     check_fn = checks.get(client_id)
@@ -431,7 +497,10 @@ def _is_already_configured(client_id: str) -> bool:
                     config = tomllib.loads(toml_path.read_text())
                     mcp = config.get("mcp_servers", {})
                     return "notebooklm" in mcp or "notebooklm-mcp" in mcp
-            return False
+        elif client_id == "opencode":
+            config = _read_json_config(_opencode_config_path())
+            mcp = config.get("mcp", {})
+            return "notebooklm" in mcp or "notebooklm-mcp" in mcp
     except Exception:
         pass
     return False
@@ -533,6 +602,7 @@ def _setup_all() -> None:
         "cline": _setup_cline,
         "antigravity": _setup_antigravity,
         "codex": _setup_codex,
+        "opencode": _setup_opencode,
     }
 
     success_count = 0
@@ -661,6 +731,7 @@ def setup_add(
         nlm setup add windsurf
         nlm setup add cline
         nlm setup add antigravity
+        nlm setup add opencode
         nlm setup add json
         nlm setup add all         # Interactive — detect and configure all
     """
@@ -694,6 +765,7 @@ def setup_add(
         "cline": _setup_cline,
         "antigravity": _setup_antigravity,
         "codex": _setup_codex,
+        "opencode": _setup_opencode,
     }
 
     success = setup_fn[client]()
@@ -773,6 +845,36 @@ def _remove_single(client: str) -> bool:
                 return False
         else:
             console.print("[yellow]Warning:[/yellow] 'codex' command not found")
+            return False
+
+    # OpenCode uses "mcp" key, not "mcpServers"
+    if client == "opencode":
+        config_path = _opencode_config_path()
+        if not config_path.exists():
+            console.print(f"[dim]No config file found for OpenCode.[/dim]")
+            return False
+        config = _read_json_config(config_path)
+        mcp = config.get("mcp", {})
+        removed = False
+        for key in ["notebooklm-mcp", "notebooklm"]:
+            if key in mcp:
+                del mcp[key]
+                removed = True
+        if removed:
+            config["mcp"] = mcp
+            # Clean up experimental.mcp_timeout if no other MCP servers remain
+            if not mcp:
+                experimental = config.get("experimental", {})
+                experimental.pop("mcp_timeout", None)
+                if not experimental:
+                    config.pop("experimental", None)
+                else:
+                    config["experimental"] = experimental
+            _write_json_config(config_path, config)
+            console.print(f"[green]✓[/green] Removed from OpenCode")
+            return True
+        else:
+            console.print(f"[dim]NotebookLM MCP was not configured in OpenCode.[/dim]")
             return False
 
     # JSON config-based clients
@@ -942,7 +1044,15 @@ def setup_list() -> None:
             else:
                 config_path = "not installed"
 
-        table.add_row(info["name"], info["description"], status, config_path)
+        elif client_id == "opencode":
+            path = _opencode_config_path()
+            config = _read_json_config(path)
+            mcp = config.get("mcp", {})
+            if "notebooklm" in mcp or "notebooklm-mcp" in mcp:
+                status = "[green]✓[/green]"
+            config_path = str(path).replace(str(Path.home()), "~")
+
+        table.add_row(str(info["name"]), str(info["description"]), status, config_path)
 
     console.print(table)
     console.print("\n[dim]Add MCP server:  nlm setup add <client>[/dim]")

--- a/tests/cli/test_setup_opencode.py
+++ b/tests/cli/test_setup_opencode.py
@@ -1,0 +1,394 @@
+"""Tests for OpenCode client support in `nlm setup add/remove/list`.
+
+Verifies that the OpenCode integration correctly handles the different
+config schema (uses "mcp" key instead of "mcpServers", command as array).
+"""
+
+import json
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+
+from notebooklm_tools.cli.commands.setup import (
+    _opencode_config_path,
+    _setup_opencode,
+    _is_already_configured,
+    _detect_tool,
+    _remove_single,
+    CLIENT_REGISTRY,
+    MCP_SERVER_CMD,
+    OPENCODE_MCP_TIMEOUT_MS,
+)
+
+
+class TestOpenCodeRegistry:
+    """Verify OpenCode is properly registered in CLIENT_REGISTRY."""
+
+    def test_opencode_in_registry(self):
+        assert "opencode" in CLIENT_REGISTRY
+
+    def test_opencode_has_auto_setup(self):
+        assert CLIENT_REGISTRY["opencode"]["has_auto_setup"] is True
+
+    def test_opencode_name(self):
+        assert CLIENT_REGISTRY["opencode"]["name"] == "OpenCode"
+
+
+class TestOpenCodeConfigPath:
+    """Verify config path resolution."""
+
+    def test_config_path_is_global(self):
+        path = _opencode_config_path()
+        assert path == Path.home() / ".config" / "opencode" / "opencode.json"
+
+
+class TestSetupOpenCode:
+    """Test _setup_opencode() writes correct config format."""
+
+    def test_creates_config_from_scratch(self, tmp_path):
+        config_path = tmp_path / "opencode.json"
+        with patch(
+            "notebooklm_tools.cli.commands.setup._opencode_config_path",
+            return_value=config_path,
+        ):
+            result = _setup_opencode()
+
+        assert result is True
+        config = json.loads(config_path.read_text())
+        assert "mcp" in config
+        assert "notebooklm" in config["mcp"]
+        entry = config["mcp"]["notebooklm"]
+        assert entry["type"] == "local"
+        assert entry["command"] == [MCP_SERVER_CMD]
+        assert entry["enabled"] is True
+        assert entry["timeout"] == OPENCODE_MCP_TIMEOUT_MS
+
+    def test_preserves_existing_config_keys(self, tmp_path):
+        config_path = tmp_path / "opencode.json"
+        existing = {
+            "$schema": "https://opencode.ai/config.json",
+            "provider": {"test": {}},
+            "model": "test-model",
+        }
+        config_path.write_text(json.dumps(existing))
+
+        with patch(
+            "notebooklm_tools.cli.commands.setup._opencode_config_path",
+            return_value=config_path,
+        ):
+            _setup_opencode()
+
+        config = json.loads(config_path.read_text())
+        assert config["$schema"] == "https://opencode.ai/config.json"
+        assert config["provider"] == {"test": {}}
+        assert config["model"] == "test-model"
+        assert "notebooklm" in config["mcp"]
+
+    def test_skips_if_already_configured(self, tmp_path):
+        config_path = tmp_path / "opencode.json"
+        existing = {"mcp": {"notebooklm": {"type": "local", "command": ["notebooklm-mcp"]}}}
+        config_path.write_text(json.dumps(existing))
+
+        with patch(
+            "notebooklm_tools.cli.commands.setup._opencode_config_path",
+            return_value=config_path,
+        ):
+            result = _setup_opencode()
+
+        assert result is True
+        # Config should be unchanged (no double write)
+
+    def test_uses_mcp_key_not_mcpservers(self, tmp_path):
+        config_path = tmp_path / "opencode.json"
+        with patch(
+            "notebooklm_tools.cli.commands.setup._opencode_config_path",
+            return_value=config_path,
+        ):
+            _setup_opencode()
+
+        config = json.loads(config_path.read_text())
+        assert "mcpServers" not in config
+        assert "mcp" in config
+
+    def test_command_is_array_not_string(self, tmp_path):
+        config_path = tmp_path / "opencode.json"
+        with patch(
+            "notebooklm_tools.cli.commands.setup._opencode_config_path",
+            return_value=config_path,
+        ):
+            _setup_opencode()
+
+        config = json.loads(config_path.read_text())
+        command = config["mcp"]["notebooklm"]["command"]
+        assert isinstance(command, list)
+        assert command == [MCP_SERVER_CMD]
+
+
+class TestIsAlreadyConfigured:
+    """Test _is_already_configured() for OpenCode."""
+
+    def test_detects_notebooklm_key(self, tmp_path):
+        config_path = tmp_path / "opencode.json"
+        config_path.write_text(json.dumps({
+            "mcp": {"notebooklm": {"type": "local"}}
+        }))
+        with patch(
+            "notebooklm_tools.cli.commands.setup._opencode_config_path",
+            return_value=config_path,
+        ):
+            assert _is_already_configured("opencode") is True
+
+    def test_detects_notebooklm_mcp_key(self, tmp_path):
+        config_path = tmp_path / "opencode.json"
+        config_path.write_text(json.dumps({
+            "mcp": {"notebooklm-mcp": {"type": "local"}}
+        }))
+        with patch(
+            "notebooklm_tools.cli.commands.setup._opencode_config_path",
+            return_value=config_path,
+        ):
+            assert _is_already_configured("opencode") is True
+
+    def test_returns_false_when_not_configured(self, tmp_path):
+        config_path = tmp_path / "opencode.json"
+        config_path.write_text(json.dumps({"mcp": {}}))
+        with patch(
+            "notebooklm_tools.cli.commands.setup._opencode_config_path",
+            return_value=config_path,
+        ):
+            assert _is_already_configured("opencode") is False
+
+    def test_returns_false_when_no_config_file(self, tmp_path):
+        config_path = tmp_path / "nonexistent.json"
+        with patch(
+            "notebooklm_tools.cli.commands.setup._opencode_config_path",
+            return_value=config_path,
+        ):
+            assert _is_already_configured("opencode") is False
+
+
+class TestDetectTool:
+    """Test _detect_tool() for OpenCode."""
+
+    def test_detects_via_which(self):
+        with patch("shutil.which", return_value="/usr/bin/opencode"):
+            assert _detect_tool("opencode") is True
+
+    def test_detects_via_config_file(self, tmp_path):
+        config_path = tmp_path / "opencode.json"
+        config_path.write_text("{}")
+        with (
+            patch("shutil.which", return_value=None),
+            patch(
+                "notebooklm_tools.cli.commands.setup._opencode_config_path",
+                return_value=config_path,
+            ),
+        ):
+            assert _detect_tool("opencode") is True
+
+    def test_not_detected_when_absent(self, tmp_path):
+        config_path = tmp_path / "nonexistent.json"
+        with (
+            patch("shutil.which", return_value=None),
+            patch(
+                "notebooklm_tools.cli.commands.setup._opencode_config_path",
+                return_value=config_path,
+            ),
+        ):
+            assert _detect_tool("opencode") is False
+
+
+class TestRemoveOpenCode:
+    """Test _remove_single() for OpenCode."""
+
+    def test_removes_notebooklm_entry(self, tmp_path):
+        config_path = tmp_path / "opencode.json"
+        config = {
+            "model": "test",
+            "mcp": {
+                "notebooklm": {"type": "local", "command": ["notebooklm-mcp"]},
+                "other-server": {"type": "local", "command": ["other"]},
+            },
+        }
+        config_path.write_text(json.dumps(config))
+
+        with patch(
+            "notebooklm_tools.cli.commands.setup._opencode_config_path",
+            return_value=config_path,
+        ):
+            result = _remove_single("opencode")
+
+        assert result is True
+        updated = json.loads(config_path.read_text())
+        assert "notebooklm" not in updated["mcp"]
+        assert "other-server" in updated["mcp"]
+        assert updated["model"] == "test"
+
+    def test_removes_notebooklm_mcp_entry(self, tmp_path):
+        config_path = tmp_path / "opencode.json"
+        config = {"mcp": {"notebooklm-mcp": {"type": "local"}}}
+        config_path.write_text(json.dumps(config))
+
+        with patch(
+            "notebooklm_tools.cli.commands.setup._opencode_config_path",
+            return_value=config_path,
+        ):
+            result = _remove_single("opencode")
+
+        assert result is True
+        updated = json.loads(config_path.read_text())
+        assert "notebooklm-mcp" not in updated["mcp"]
+
+    def test_returns_false_when_not_configured(self, tmp_path):
+        config_path = tmp_path / "opencode.json"
+        config_path.write_text(json.dumps({"mcp": {}}))
+
+        with patch(
+            "notebooklm_tools.cli.commands.setup._opencode_config_path",
+            return_value=config_path,
+        ):
+            result = _remove_single("opencode")
+
+        assert result is False
+
+    def test_returns_false_when_no_config_file(self, tmp_path):
+        config_path = tmp_path / "nonexistent.json"
+        with patch(
+            "notebooklm_tools.cli.commands.setup._opencode_config_path",
+            return_value=config_path,
+        ):
+            result = _remove_single("opencode")
+
+        assert result is False
+
+
+class TestOpenCodeTimeout:
+    """Test MCP timeout configuration for OpenCode."""
+
+    def test_sets_experimental_mcp_timeout(self, tmp_path):
+        config_path = tmp_path / "opencode.json"
+        with patch(
+            "notebooklm_tools.cli.commands.setup._opencode_config_path",
+            return_value=config_path,
+        ):
+            _setup_opencode()
+
+        config = json.loads(config_path.read_text())
+        assert config["experimental"]["mcp_timeout"] == OPENCODE_MCP_TIMEOUT_MS
+
+    def test_sets_per_server_timeout(self, tmp_path):
+        config_path = tmp_path / "opencode.json"
+        with patch(
+            "notebooklm_tools.cli.commands.setup._opencode_config_path",
+            return_value=config_path,
+        ):
+            _setup_opencode()
+
+        config = json.loads(config_path.read_text())
+        assert config["mcp"]["notebooklm"]["timeout"] == OPENCODE_MCP_TIMEOUT_MS
+
+    def test_preserves_existing_experimental_mcp_timeout(self, tmp_path):
+        """If user set a custom mcp_timeout, don't overwrite it."""
+        config_path = tmp_path / "opencode.json"
+        existing = {"experimental": {"mcp_timeout": 600_000}}
+        config_path.write_text(json.dumps(existing))
+
+        with patch(
+            "notebooklm_tools.cli.commands.setup._opencode_config_path",
+            return_value=config_path,
+        ):
+            _setup_opencode()
+
+        config = json.loads(config_path.read_text())
+        assert config["experimental"]["mcp_timeout"] == 600_000
+
+    def test_preserves_other_experimental_keys(self, tmp_path):
+        config_path = tmp_path / "opencode.json"
+        existing = {"experimental": {"some_flag": True}}
+        config_path.write_text(json.dumps(existing))
+
+        with patch(
+            "notebooklm_tools.cli.commands.setup._opencode_config_path",
+            return_value=config_path,
+        ):
+            _setup_opencode()
+
+        config = json.loads(config_path.read_text())
+        assert config["experimental"]["some_flag"] is True
+        assert config["experimental"]["mcp_timeout"] == OPENCODE_MCP_TIMEOUT_MS
+
+    def test_adds_timeout_when_already_configured(self, tmp_path):
+        """Even if server entry exists, ensure timeout is set."""
+        config_path = tmp_path / "opencode.json"
+        existing = {"mcp": {"notebooklm": {"type": "local", "command": ["notebooklm-mcp"]}}}
+        config_path.write_text(json.dumps(existing))
+
+        with patch(
+            "notebooklm_tools.cli.commands.setup._opencode_config_path",
+            return_value=config_path,
+        ):
+            _setup_opencode()
+
+        config = json.loads(config_path.read_text())
+        assert config["experimental"]["mcp_timeout"] == OPENCODE_MCP_TIMEOUT_MS
+
+    def test_remove_cleans_experimental_timeout_when_no_servers(self, tmp_path):
+        """Remove should clean up experimental.mcp_timeout when no MCP servers left."""
+        config_path = tmp_path / "opencode.json"
+        config = {
+            "mcp": {"notebooklm": {"type": "local"}},
+            "experimental": {"mcp_timeout": OPENCODE_MCP_TIMEOUT_MS},
+        }
+        config_path.write_text(json.dumps(config))
+
+        with patch(
+            "notebooklm_tools.cli.commands.setup._opencode_config_path",
+            return_value=config_path,
+        ):
+            _remove_single("opencode")
+
+        updated = json.loads(config_path.read_text())
+        assert "experimental" not in updated
+
+    def test_remove_keeps_experimental_timeout_when_other_servers(self, tmp_path):
+        """Remove should keep experimental.mcp_timeout if other MCP servers remain."""
+        config_path = tmp_path / "opencode.json"
+        config = {
+            "mcp": {
+                "notebooklm": {"type": "local"},
+                "other-server": {"type": "local", "command": ["other"]},
+            },
+            "experimental": {"mcp_timeout": OPENCODE_MCP_TIMEOUT_MS},
+        }
+        config_path.write_text(json.dumps(config))
+
+        with patch(
+            "notebooklm_tools.cli.commands.setup._opencode_config_path",
+            return_value=config_path,
+        ):
+            _remove_single("opencode")
+
+        updated = json.loads(config_path.read_text())
+        assert updated["experimental"]["mcp_timeout"] == OPENCODE_MCP_TIMEOUT_MS
+
+    def test_remove_keeps_other_experimental_keys(self, tmp_path):
+        """Remove should only clean mcp_timeout, not other experimental keys."""
+        config_path = tmp_path / "opencode.json"
+        config = {
+            "mcp": {"notebooklm": {"type": "local"}},
+            "experimental": {
+                "mcp_timeout": OPENCODE_MCP_TIMEOUT_MS,
+                "other_flag": True,
+            },
+        }
+        config_path.write_text(json.dumps(config))
+
+        with patch(
+            "notebooklm_tools.cli.commands.setup._opencode_config_path",
+            return_value=config_path,
+        ):
+            _remove_single("opencode")
+
+        updated = json.loads(config_path.read_text())
+        assert "mcp_timeout" not in updated["experimental"]
+        assert updated["experimental"]["other_flag"] is True


### PR DESCRIPTION
Add OpenCode as a supported client in the setup command, enabling `nlm setup add opencode` to configure the NotebookLM MCP server.

OpenCode uses a different config schema than other tools:
- Config key: "mcp" (not "mcpServers")
- Command format: array (not string)
- Config path: ~/.config/opencode/opencode.json

Changes:
- Add _opencode_config_path() and _setup_opencode()
- Register in CLIENT_REGISTRY, _detect_tool, _is_already_configured
- Add to setup_add, _setup_all, _remove_single, setup_list
- Preserves all existing config keys when writing
- Add unit tests (20 tests) for all OpenCode setup functions

