### PR TITLE
Preserve non-ASCII characters in CLI JSON output

### DIFF
--- a/src/notebooklm_tools/cli/formatters.py
+++ b/src/notebooklm_tools/cli/formatters.py
@@ -17,6 +17,11 @@ class OutputFormat(str, Enum):
     COMPACT = "compact"
 
 
+def print_json(data: Any) -> None:
+    """Print JSON output while preserving non-ASCII characters."""
+    print(json.dumps(data, indent=2, ensure_ascii=False))
+
+
 def detect_output_format(
     json_flag: bool = False,
     quiet_flag: bool = False,
@@ -298,7 +303,7 @@ class JsonFormatter(Formatter):
             if full and created:
                 item["created_at"] = created if isinstance(created, str) else created.isoformat()
             data.append(item)
-        print(json.dumps(data, indent=2))
+        print_json(data)
 
     def format_sources(
         self,
@@ -327,7 +332,7 @@ class JsonFormatter(Formatter):
                 if full:
                     item['is_stale'] = getattr(src, 'is_stale', False)
             data.append(item)
-        print(json.dumps(data, indent=2))
+        print_json(data)
 
     def format_artifacts(
         self,
@@ -357,7 +362,7 @@ class JsonFormatter(Formatter):
                     item['title'] = getattr(art, 'title', '')
                     item['url'] = getattr(art, 'url', '')
             data.append(item)
-        print(json.dumps(data, indent=2))
+        print_json(data)
 
     def format_item(self, item: Any, title: str = "") -> None:
         if hasattr(item, "model_dump"):
@@ -366,7 +371,7 @@ class JsonFormatter(Formatter):
             data = {k: v for k, v in item.__dict__.items() if not k.startswith("_")}
         else:
             data = {"value": item}
-        print(json.dumps(data, indent=2))
+        print_json(data)
 
 
 class CompactFormatter(Formatter):

--- a/tests/cli/test_formatters.py
+++ b/tests/cli/test_formatters.py
@@ -1,8 +1,13 @@
-
 import pytest
-from unittest.mock import patch, Mock
-import sys
-from notebooklm_tools.cli.formatters import detect_output_format, OutputFormat
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from notebooklm_tools.cli.formatters import (
+    JsonFormatter,
+    OutputFormat,
+    detect_output_format,
+    print_json,
+)
 
 def test_detect_output_format_json_flag():
     # Flag takes precedence
@@ -30,3 +35,25 @@ def test_detect_output_format_title_flag():
     with patch("sys.stdout.isatty", return_value=True):
         assert detect_output_format(title_flag=True) == OutputFormat.COMPACT
 
+
+def test_print_json_preserves_non_ascii(capsys):
+    print_json({"title": "café", "greeting": "こんにちは"})
+
+    output = capsys.readouterr().out
+
+    assert '"title": "café"' in output
+    assert '"greeting": "こんにちは"' in output
+    assert "\\u00e9" not in output
+    assert "\\u3053" not in output
+
+
+def test_json_formatter_format_notebooks_preserves_non_ascii(capsys):
+    formatter = JsonFormatter()
+    notebooks = [SimpleNamespace(id="nb-1", title="Café notes", source_count=2)]
+
+    formatter.format_notebooks(notebooks)
+
+    output = capsys.readouterr().out
+
+    assert '"title": "Café notes"' in output
+    assert "\\u00e9" not in output


### PR DESCRIPTION
## Summary
- add a shared JSON print helper that uses ensure_ascii=False
- replace the JsonFormatter print(json.dumps(...)) call sites with the helper
- add tests covering Unicode-preserving JSON output

## Testing
- uv run --extra dev python -m pytest tests/cli/test_formatters.py