### PR TITLE
feat(cli): make --youtube / -y repeatable for bulk source add

### DIFF
--- a/src/notebooklm_tools/cli/commands/source.py
+++ b/src/notebooklm_tools/cli/commands/source.py
@@ -58,7 +58,7 @@ def add_source(
     url: Optional[list[str]] = typer.Option(None, "--url", "-u", help="URL to add (repeatable for bulk)"),
     text: Optional[str] = typer.Option(None, "--text", "-t", help="Text content to add"),
     drive: Optional[str] = typer.Option(None, "--drive", "-d", help="Google Drive document ID"),
-    youtube: Optional[str] = typer.Option(None, "--youtube", "-y", help="YouTube URL"),
+    youtube: Optional[list[str]] = typer.Option(None, "--youtube", "-y", help="YouTube URL (repeatable for bulk)"),
     file: Optional[str] = typer.Option(None, "--file", "-f", help="Local file to upload (PDF, etc.)"),
     title: str = typer.Option("", "--title", help="Title for the source"),
     doc_type: str = typer.Option("doc", "--type", help="Drive doc type: doc, slides, sheets, pdf"),
@@ -72,6 +72,7 @@ def add_source(
         nlm source add <notebook-id> --url https://a.com --url https://b.com
         nlm source add <notebook-id> --url https://example.com --wait
         nlm source add <notebook-id> --file document.pdf --wait
+        nlm source add <notebook-id> --youtube https://youtu.be/a --youtube https://youtu.be/b
     """
     notebook_id = get_alias_manager().resolve(notebook_id)
 
@@ -81,8 +82,14 @@ def add_source(
         urls = [urls]
     has_url = len(urls) > 0
 
+    # Normalize youtube list: typer gives None or a list
+    youtubes = youtube or []
+    if isinstance(youtubes, str):
+        youtubes = [youtubes]
+    has_youtube = len(youtubes) > 0
+
     # Validate that exactly one source type is provided (CLI-specific UX)
-    source_count = sum(1 for x in [has_url, text, drive, youtube, file] if x)
+    source_count = sum(1 for x in [has_url, text, drive, has_youtube, file] if x)
     if source_count == 0:
         console.print("[red]Error:[/red] Please specify a source: --url, --text, --file, --drive, or --youtube")
         raise typer.Exit(1)
@@ -92,15 +99,16 @@ def add_source(
 
     try:
         with get_client(profile) as client:
-            # Bulk URL add: multiple --url flags
-            if has_url and len(urls) > 1:
+            # Bulk URL add: multiple --url and/or --youtube flags (both are URLs to the API)
+            all_urls = urls + youtubes
+            if len(all_urls) > 1:
                 if wait:
-                    console.print(f"[blue]Adding {len(urls)} URLs and waiting for processing...[/blue]")
+                    console.print(f"[blue]Adding {len(all_urls)} URLs and waiting for processing...[/blue]")
                 else:
-                    console.print(f"[blue]Adding {len(urls)} URLs...[/blue]")
+                    console.print(f"[blue]Adding {len(all_urls)} URLs...[/blue]")
                 bulk_result = sources_service.add_sources(
                     client, notebook_id,
-                    [{"source_type": "url", "url": u} for u in urls],
+                    [{"source_type": "url", "url": u} for u in all_urls],
                     wait=wait,
                 )
                 ready_msg = " (ready)" if wait else ""
@@ -111,8 +119,8 @@ def add_source(
                 return
 
             # Single URL add (including youtube)
-            if youtube:
-                source_type, source_url = "url", youtube
+            if has_youtube:
+                source_type, source_url = "url", youtubes[0]
             elif has_url:
                 source_type, source_url = "url", urls[0]
             else:

--- a/tests/cli/test_source_add.py
+++ b/tests/cli/test_source_add.py
@@ -1,0 +1,230 @@
+"""Tests for the `nlm source add` CLI command, focusing on --youtube bulk support."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from typer.testing import CliRunner
+
+from notebooklm_tools.cli.commands.source import app
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_client():
+    client = MagicMock()
+    client.__enter__ = lambda s: s
+    client.__exit__ = MagicMock(return_value=False)
+    client.add_url_source.return_value = {"id": "src-1", "title": "YouTube Video"}
+    return client
+
+
+def _patch_deps(mock_client, add_source_result=None, add_sources_result=None):
+    """Return a list of context-manager patches for CLI dependencies."""
+    alias_mgr = MagicMock()
+    alias_mgr.resolve.side_effect = lambda x: x  # identity
+
+    single_result = add_source_result or {"source_type": "url", "source_id": "src-1", "title": "YouTube Video"}
+    bulk_result = add_sources_result or {
+        "results": [
+            {"source_type": "url", "source_id": "src-1", "title": "Video A"},
+            {"source_type": "url", "source_id": "src-2", "title": "Video B"},
+        ],
+        "added_count": 2,
+    }
+
+    return [
+        patch("notebooklm_tools.cli.commands.source.get_alias_manager", return_value=alias_mgr),
+        patch("notebooklm_tools.cli.commands.source.get_client", return_value=mock_client),
+        patch("notebooklm_tools.cli.commands.source.sources_service.add_source", return_value=single_result),
+        patch("notebooklm_tools.cli.commands.source.sources_service.add_sources", return_value=bulk_result),
+    ]
+
+
+class TestYoutubeSingle:
+    """Single --youtube flag: existing behaviour must be preserved."""
+
+    def test_single_youtube_calls_add_source(self, runner, mock_client):
+        with _patch_deps(mock_client)[0], _patch_deps(mock_client)[1], \
+             patch("notebooklm_tools.cli.commands.source.get_alias_manager") as m_alias, \
+             patch("notebooklm_tools.cli.commands.source.get_client") as m_client, \
+             patch("notebooklm_tools.cli.commands.source.sources_service.add_source") as m_add, \
+             patch("notebooklm_tools.cli.commands.source.sources_service.add_sources") as m_bulk:
+
+            m_alias.return_value.resolve.side_effect = lambda x: x
+            m_client.return_value = mock_client
+            m_add.return_value = {"source_type": "url", "source_id": "src-1", "title": "My Video"}
+            m_bulk.return_value = {"results": [], "added_count": 0}
+
+            result = runner.invoke(app, ["add", "nb-123", "--youtube", "https://youtu.be/abc"])
+
+        assert result.exit_code == 0
+        m_add.assert_called_once()
+        call_kwargs = m_add.call_args
+        assert call_kwargs.kwargs["url"] == "https://youtu.be/abc"
+        m_bulk.assert_not_called()
+
+    def test_single_youtube_output_shows_title(self, runner, mock_client):
+        with patch("notebooklm_tools.cli.commands.source.get_alias_manager") as m_alias, \
+             patch("notebooklm_tools.cli.commands.source.get_client") as m_client, \
+             patch("notebooklm_tools.cli.commands.source.sources_service.add_source") as m_add, \
+             patch("notebooklm_tools.cli.commands.source.sources_service.add_sources"):
+
+            m_alias.return_value.resolve.side_effect = lambda x: x
+            m_client.return_value = mock_client
+            m_add.return_value = {"source_type": "url", "source_id": "src-1", "title": "My Video"}
+
+            result = runner.invoke(app, ["add", "nb-123", "--youtube", "https://youtu.be/abc"])
+
+        assert result.exit_code == 0
+        assert "My Video" in result.output
+
+
+class TestYoutubeBulk:
+    """Multiple --youtube flags: new bulk behaviour."""
+
+    def test_bulk_youtube_calls_add_sources(self, runner, mock_client):
+        bulk_result = {
+            "results": [
+                {"source_type": "url", "source_id": "src-1", "title": "Video A"},
+                {"source_type": "url", "source_id": "src-2", "title": "Video B"},
+            ],
+            "added_count": 2,
+        }
+
+        with patch("notebooklm_tools.cli.commands.source.get_alias_manager") as m_alias, \
+             patch("notebooklm_tools.cli.commands.source.get_client") as m_client, \
+             patch("notebooklm_tools.cli.commands.source.sources_service.add_source") as m_add, \
+             patch("notebooklm_tools.cli.commands.source.sources_service.add_sources") as m_bulk:
+
+            m_alias.return_value.resolve.side_effect = lambda x: x
+            m_client.return_value = mock_client
+            m_bulk.return_value = bulk_result
+
+            result = runner.invoke(app, [
+                "add", "nb-123",
+                "--youtube", "https://youtu.be/aaa",
+                "--youtube", "https://youtu.be/bbb",
+            ])
+
+        assert result.exit_code == 0
+        m_add.assert_not_called()
+        m_bulk.assert_called_once()
+        sources_arg = m_bulk.call_args.args[2]
+        assert sources_arg == [
+            {"source_type": "url", "url": "https://youtu.be/aaa"},
+            {"source_type": "url", "url": "https://youtu.be/bbb"},
+        ]
+
+    def test_bulk_youtube_output_shows_count_and_titles(self, runner, mock_client):
+        bulk_result = {
+            "results": [
+                {"source_type": "url", "source_id": "src-1", "title": "Video A"},
+                {"source_type": "url", "source_id": "src-2", "title": "Video B"},
+            ],
+            "added_count": 2,
+        }
+
+        with patch("notebooklm_tools.cli.commands.source.get_alias_manager") as m_alias, \
+             patch("notebooklm_tools.cli.commands.source.get_client") as m_client, \
+             patch("notebooklm_tools.cli.commands.source.sources_service.add_source"), \
+             patch("notebooklm_tools.cli.commands.source.sources_service.add_sources") as m_bulk:
+
+            m_alias.return_value.resolve.side_effect = lambda x: x
+            m_client.return_value = mock_client
+            m_bulk.return_value = bulk_result
+
+            result = runner.invoke(app, [
+                "add", "nb-123",
+                "--youtube", "https://youtu.be/aaa",
+                "--youtube", "https://youtu.be/bbb",
+            ])
+
+        assert result.exit_code == 0
+        assert "Video A" in result.output
+        assert "Video B" in result.output
+        assert "2 source(s) added" in result.output
+
+    def test_bulk_youtube_three_urls(self, runner, mock_client):
+        bulk_result = {
+            "results": [{"source_type": "url", "source_id": f"src-{i}", "title": f"Video {i}"} for i in range(3)],
+            "added_count": 3,
+        }
+
+        with patch("notebooklm_tools.cli.commands.source.get_alias_manager") as m_alias, \
+             patch("notebooklm_tools.cli.commands.source.get_client") as m_client, \
+             patch("notebooklm_tools.cli.commands.source.sources_service.add_source"), \
+             patch("notebooklm_tools.cli.commands.source.sources_service.add_sources") as m_bulk:
+
+            m_alias.return_value.resolve.side_effect = lambda x: x
+            m_client.return_value = mock_client
+            m_bulk.return_value = bulk_result
+
+            result = runner.invoke(app, [
+                "add", "nb-123",
+                "-y", "https://youtu.be/a",
+                "-y", "https://youtu.be/b",
+                "-y", "https://youtu.be/c",
+            ])
+
+        assert result.exit_code == 0
+        sources_arg = m_bulk.call_args.args[2]
+        assert len(sources_arg) == 3
+
+
+class TestMixedUrlAndYoutube:
+    """--url and --youtube together should both be treated as URLs in bulk."""
+
+    def test_url_and_youtube_together_use_bulk_path(self, runner, mock_client):
+        bulk_result = {
+            "results": [
+                {"source_type": "url", "source_id": "src-1", "title": "Web Page"},
+                {"source_type": "url", "source_id": "src-2", "title": "YouTube Video"},
+            ],
+            "added_count": 2,
+        }
+
+        with patch("notebooklm_tools.cli.commands.source.get_alias_manager") as m_alias, \
+             patch("notebooklm_tools.cli.commands.source.get_client") as m_client, \
+             patch("notebooklm_tools.cli.commands.source.sources_service.add_source") as m_add, \
+             patch("notebooklm_tools.cli.commands.source.sources_service.add_sources") as m_bulk:
+
+            m_alias.return_value.resolve.side_effect = lambda x: x
+            m_client.return_value = mock_client
+            m_bulk.return_value = bulk_result
+
+            result = runner.invoke(app, [
+                "add", "nb-123",
+                "--url", "https://example.com",
+                "--youtube", "https://youtu.be/abc",
+            ])
+
+        # --url and --youtube are different source types, should be rejected
+        assert result.exit_code != 0
+        assert "one source type" in result.output
+        m_add.assert_not_called()
+        m_bulk.assert_not_called()
+
+
+class TestYoutubeValidation:
+    """Input validation edge cases."""
+
+    def test_no_source_type_errors(self, runner):
+        result = runner.invoke(app, ["add", "nb-123"])
+        assert result.exit_code != 0
+        assert "specify a source" in result.output
+
+    def test_youtube_and_text_together_errors(self, runner, mock_client):
+        with patch("notebooklm_tools.cli.commands.source.get_alias_manager") as m_alias:
+            m_alias.return_value.resolve.side_effect = lambda x: x
+
+            result = runner.invoke(app, [
+                "add", "nb-123",
+                "--youtube", "https://youtu.be/abc",
+                "--text", "some text",
+            ])
+
+        assert result.exit_code != 0
+        assert "one source type" in result.output


### PR DESCRIPTION
Multiple --youtube flags now batch into a single API call, matching the existing --url bulk behaviour. Mixed --url + --youtube (different source types) is still rejected. Adds CLI tests covering single, bulk, and validation paths.