### PR TITLE
docs: capture shared-state setup and revision notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Then use natural language: *"Create a notebook about quantum computing and gener
 - **[MCP Guide](docs/MCP_GUIDE.md)** — All 35 MCP tools with examples
 - **[Authentication](docs/AUTHENTICATION.md)** — Setup and troubleshooting
 - **[API Reference](docs/API_REFERENCE.md)** — Internal API docs for contributors
+- **[Revision History](REVISION_HISTORY.md)** — Repo-local integration and operator notes
 
 ## Important Disclaimer
 
@@ -332,18 +333,44 @@ nlm doctor
 
 ### Install AI Skills (Optional)
 
-Install the NotebookLM expert guide for your AI assistant to help it use the tools effectively. Supported for **Cline**, **Antigravity**, **OpenClaw**, **Codex**, **OpenCode**, **Claude Code**, and **Gemini CLI**.
+Install the NotebookLM expert guide for your AI assistant to help it use the tools effectively. Supported for **Cline**, **Antigravity**, **OpenClaw**, **OpenCode**, **Claude Code**, and **Gemini CLI / Codex-compatible agents**.
 
 ```bash
 # Install skill files
+nlm skill install claude-code
+nlm skill install agents      # Gemini CLI, Codex, and other .agents/skills consumers
 nlm skill install cline
 nlm skill install openclaw
-nlm skill install codex
 nlm skill install antigravity
+nlm skill install other --level project   # Export all client formats for reuse
 
 # Update skills
 nlm skill update
 ```
+
+### Shared-State Deployment Example
+
+One validated deployment pattern is to keep NotebookLM state in a durable shared path and have both the CLI and MCP server use that same location:
+
+```bash
+export NOTEBOOKLM_MCP_CLI_PATH="<NLM_DATA_ROOT>"
+
+uv tool install notebooklm-mcp-cli
+nlm setup add codex
+nlm skill install agents
+nlm skill install other --level project
+nlm config set auth.browser brave
+nlm login
+nlm login --check
+```
+
+Operational notes from that setup:
+
+- Set `NOTEBOOKLM_MCP_CLI_PATH` in the shell/profile that normally launches manual `nlm` commands so CLI use and MCP-launched use share the same auth, profiles, and cached state.
+- If a generated Codex MCP entry does not include `NOTEBOOKLM_MCP_CLI_PATH`, patch the client config so the launched `notebooklm-mcp` process inherits it.
+- `nlm skill install agents` is the right path for Codex and other `.agents/skills` consumers; use `nlm skill install other --level project` when you want a reusable exported bundle for future client installs.
+- The same shared data root and exported skill bundle can be reused later for Claude Code or other agent runtimes without creating a second NotebookLM state tree.
+- See [REVISION_HISTORY.md](REVISION_HISTORY.md) for a concise summary of the validated `mcp_stuff` promotion and install workflow.
 
 ### Remove from a tool
 

--- a/REVISION_HISTORY.md
+++ b/REVISION_HISTORY.md
@@ -1,0 +1,26 @@
+# Revision History
+
+This file records repo-local integration and operator notes that complement the upstream release-focused [CHANGELOG.md](CHANGELOG.md).
+
+## 2026-03-22
+
+### mcp_stuff Promotion And Shared-State Setup Summary
+
+- Promoted the repo from `pending_mcps/notebooklm-mcp-cli` to top-level `mcp_stuff/notebooklm-mcp-cli`.
+- Installed the package with `uv` and validated the unified `nlm` CLI plus `notebooklm-mcp` server workflow.
+- Configured Codex with an env-aware `notebooklm-mcp` entry so NotebookLM state resolves through `NOTEBOOKLM_MCP_CLI_PATH` instead of a separate default home-path tree.
+- Used a durable data root under `/Volumes/Data/_ai/_mcp/mcp-data/notebooklm-mcp-cli` so manual CLI use, Codex MCP launches, and future client reuse can share profiles and auth state.
+- Installed the cross-tool NotebookLM skill via `nlm skill install agents` and exported the reusable bundle with `nlm skill install other --level project` for future Claude Code and Ollama-adjacent agent setup.
+- Set the preferred auth browser, completed browser-based login, and verified the saved profile with `nlm login --check`.
+
+### Validation Notes
+
+- Confirmed the Codex MCP entry resolves to `notebooklm-mcp` with `NOTEBOOKLM_MCP_CLI_PATH` set.
+- Confirmed `nlm setup list` shows Codex configured.
+- Confirmed `nlm skill list` shows the skill install succeeded.
+- Confirmed both direct env-based invocation and a fresh shell loading the shared env path can run `nlm login --check` successfully.
+
+### Caveats
+
+- In this validated shared-state deployment, `nlm doctor` did not fully recognize the env-aware Codex entry even though direct MCP and auth checks succeeded.
+- Machine-local shell exports, MCP client config files, and authentication material are intentionally not tracked in git; only the workflow and operational notes are recorded here.


### PR DESCRIPTION
Summary:
- add a repo-local `REVISION_HISTORY.md` for operator-facing integration notes
- update README skill guidance to use `nlm skill install agents` for Codex-compatible agents
- document a validated shared-state deployment pattern using `NOTEBOOKLM_MCP_CLI_PATH`

Why:
- preserve the `mcp_stuff` promotion and install/auth work in the child repo
- correct README guidance to match the current cross-tool skill path and shared-state deployment pattern

Scope:
- `README.md`
- `REVISION_HISTORY.md`

Behavior / Impact:
- README now points readers to repo-local integration notes and documents a reusable shared-state setup for Codex, future Claude Code use, and other agent runtimes
- skill guidance now reflects the current `.agents/skills` workflow rather than the stale `codex` example
- revision history records the validated promotion/setup workflow without mixing it into release notes

Validation:
- `git diff --check`
- reviewed the README and `REVISION_HISTORY.md` diff against `origin/main`
- verified only the intended doc files were present on the clean PR branch before commit

Risks / Limits:
- documents one validated deployment pattern rather than claiming every client setup path behaves identically
- machine-local env exports, client config files, and auth state remain intentionally untracked
