### PR TITLE
fix: preserve non-ASCII characters in JSON output (ensure_ascii=False)

### DIFF
--- a/src/notebooklm_tools/cli/commands/config.py
+++ b/src/notebooklm_tools/cli/commands/config.py
@@ -4,6 +4,7 @@ import typer
 from rich.console import Console
 from rich.syntax import Syntax
 
+from notebooklm_tools.cli.formatters import print_json
 from notebooklm_tools.utils.config import _config_to_toml, get_config, save_config
 
 console = Console()
@@ -22,9 +23,7 @@ def show_config(
     config = get_config()
 
     if json_output:
-        import json
-
-        print(json.dumps(config.model_dump(), indent=2))
+        print_json(config.model_dump())
     else:
         # Print as TOML syntax highlighted
         toml_str = _config_to_toml(config)

--- a/src/notebooklm_tools/cli/commands/export.py
+++ b/src/notebooklm_tools/cli/commands/export.py
@@ -3,6 +3,7 @@
 import typer
 from rich.console import Console
 
+from notebooklm_tools.cli.formatters import print_json
 from notebooklm_tools.cli.utils import get_client, handle_error
 from notebooklm_tools.core.alias import get_alias_manager
 from notebooklm_tools.core.exceptions import NLMError
@@ -53,9 +54,7 @@ def export_artifact(
             )
 
         if json_output:
-            import json
-
-            print(json.dumps(result, indent=2))
+            print_json(result)
             return
 
         console.print(f"[green]✓[/green] {result['message']}")

--- a/src/notebooklm_tools/cli/commands/note.py
+++ b/src/notebooklm_tools/cli/commands/note.py
@@ -4,6 +4,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from notebooklm_tools.cli.formatters import print_json
 from notebooklm_tools.cli.utils import get_client, handle_error
 from notebooklm_tools.core.alias import get_alias_manager
 from notebooklm_tools.core.exceptions import NLMError
@@ -37,9 +38,7 @@ def list_notes(
             for note in notes:
                 console.print(note["id"])
         elif json_output:
-            import json
-
-            print(json.dumps(result, indent=2))
+            print_json(result)
         else:
             if not notes:
                 console.print(f"[dim]No notes found in notebook {notebook_id}[/dim]")

--- a/src/notebooklm_tools/cli/commands/share.py
+++ b/src/notebooklm_tools/cli/commands/share.py
@@ -4,6 +4,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from notebooklm_tools.cli.formatters import print_json
 from notebooklm_tools.cli.utils import get_client, handle_error
 from notebooklm_tools.core.alias import get_alias_manager
 from notebooklm_tools.core.exceptions import NLMError
@@ -31,9 +32,7 @@ def share_status(
             result = sharing_service.get_share_status(client, notebook_id)
 
         if json_output:
-            import json
-
-            print(json.dumps(result, indent=2))
+            print_json(result)
             return
 
         # Rich output

--- a/src/notebooklm_tools/core/alias.py
+++ b/src/notebooklm_tools/core/alias.py
@@ -55,7 +55,7 @@ class AliasManager:
         """Save aliases to disk."""
         self.config_dir.mkdir(parents=True, exist_ok=True)
         data = {name: entry.to_dict() for name, entry in self._aliases.items()}
-        self.aliases_file.write_text(json.dumps(data, indent=2))
+        self.aliases_file.write_text(json.dumps(data, indent=2, ensure_ascii=False))
 
     def set_alias(self, name: str, value: str, alias_type: str = "unknown") -> None:
         """Set an alias with optional type."""

--- a/src/notebooklm_tools/core/auth.py
+++ b/src/notebooklm_tools/core/auth.py
@@ -409,7 +409,7 @@ class AuthManager:
         self.profile_dir.chmod(0o700)
 
         # Save cookies
-        self.cookies_file.write_text(json.dumps(cookies, indent=2), encoding="utf-8")
+        self.cookies_file.write_text(json.dumps(cookies, indent=2, ensure_ascii=False), encoding="utf-8")
         self.cookies_file.chmod(0o600)
 
         # Save metadata
@@ -420,7 +420,7 @@ class AuthManager:
             "build_label": build_label,
             "last_validated": datetime.now().isoformat(),
         }
-        self.metadata_file.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+        self.metadata_file.write_text(json.dumps(metadata, indent=2, ensure_ascii=False), encoding="utf-8")
         self.metadata_file.chmod(0o600)
 
         self._profile = Profile(

--- a/src/notebooklm_tools/core/base.py
+++ b/src/notebooklm_tools/core/base.py
@@ -389,10 +389,10 @@ class BaseClient:
         """Build the batchexecute request body."""
         # The params need to be JSON-encoded, then wrapped in the RPC structure
         # Use separators to match Chrome's compact format (no spaces)
-        params_json = json.dumps(params, separators=(",", ":"))
+        params_json = json.dumps(params, separators=(",", ":"), ensure_ascii=False)
 
         f_req = [[[rpc_id, params_json, None, "generic"]]]
-        f_req_json = json.dumps(f_req, separators=(",", ":"))
+        f_req_json = json.dumps(f_req, separators=(",", ":"), ensure_ascii=False)
 
         # URL encode (safe='' encodes all characters including /)
         body_parts = [f"f.req={urllib.parse.quote(f_req_json, safe='')}"]

--- a/src/notebooklm_tools/core/conversation.py
+++ b/src/notebooklm_tools/core/conversation.py
@@ -249,10 +249,10 @@ class ConversationMixin(BaseClient):
         ]
 
         # Use compact JSON format matching Chrome (no spaces)
-        params_json = json.dumps(params, separators=(",", ":"))
+        params_json = json.dumps(params, separators=(",", ":"), ensure_ascii=False)
 
         f_req = [None, params_json]
-        f_req_json = json.dumps(f_req, separators=(",", ":"))
+        f_req_json = json.dumps(f_req, separators=(",", ":"), ensure_ascii=False)
 
         # URL encode with safe='' to encode all characters including /
         body_parts = [f"f.req={urllib.parse.quote(f_req_json, safe='')}"]

--- a/src/notebooklm_tools/core/download.py
+++ b/src/notebooklm_tools/core/download.py
@@ -1067,7 +1067,7 @@ class DownloadMixin(BaseClient):
             questions = app_data.get("quiz", [])
             if output_format == "markdown":
                 return self._format_quiz_markdown(title, questions)
-            return json.dumps({"title": title, "questions": questions}, indent=2)
+            return json.dumps({"title": title, "questions": questions}, indent=2, ensure_ascii=False)
 
         # Flashcards
         cards = app_data.get("flashcards", [])
@@ -1076,7 +1076,7 @@ class DownloadMixin(BaseClient):
 
         # Normalize JSON format: {"f": "...", "b": "..."} -> {"front": "...", "back": "..."}
         normalized = [{"front": c.get("f", ""), "back": c.get("b", "")} for c in cards]
-        return json.dumps({"title": title, "cards": normalized}, indent=2)
+        return json.dumps({"title": title, "cards": normalized}, indent=2, ensure_ascii=False)
 
     async def _download_interactive_artifact(
         self,

--- a/src/notebooklm_tools/core/sources.py
+++ b/src/notebooklm_tools/core/sources.py
@@ -584,7 +584,8 @@ class SourceMixin(BaseClient):
                 "PROJECT_ID": notebook_id,
                 "SOURCE_NAME": filename,
                 "SOURCE_ID": source_id,
-            }
+            },
+            ensure_ascii=False,
         )
 
         with httpx.Client(timeout=60.0, cookies=cookies) as client:


### PR DESCRIPTION
Python's json.dumps() defaults to ensure_ascii=True, which converts non-ASCII characters (e.g., Chinese, Japanese, Korean) to \uXXXX escape sequences. This makes JSON output unreadable for humans when notebooks, notes, or queries contain non-ASCII text.

This commit adds ensure_ascii=False to all json.dumps() calls that handle user content:

- CLI commands (note, share, export, config): use the existing print_json() helper from formatters.py which already had the fix
- Core RPC layer (base.py, conversation.py): API request bodies
- Core persistence (alias.py, auth.py): config file writes
- Core output (download.py, sources.py): artifact export and uploads

Some json.dumps() calls are intentionally left unchanged:
- utils/cdp.py: Chrome DevTools Protocol (no user content)
- mcp/tools/_utils.py: debug logging only
- cli/commands/setup.py: MCP server config (ASCII-only keys/values)