### PR TITLE
feat: configurable base URL for enterprise NotebookLM support

### DIFF
--- a/src/notebooklm_tools/core/auth.py
+++ b/src/notebooklm_tools/core/auth.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from notebooklm_tools.utils.config import get_base_url
+
 # Use logging instead of print to avoid corrupting MCP stdio protocol
 logger = logging.getLogger(__name__)
 
@@ -477,8 +479,8 @@ class AuthManager:
         headers = {
             "Cookie": cookies_to_header(profile.cookies),
             "Content-Type": "application/x-www-form-urlencoded",
-            "Origin": "https://notebooklm.google.com",
-            "Referer": "https://notebooklm.google.com/",
+            "Origin": get_base_url(),
+            "Referer": f"{get_base_url()}/",
         }
         if profile.csrf_token:
             headers["X-Goog-Csrf-Token"] = profile.csrf_token

--- a/src/notebooklm_tools/core/base.py
+++ b/src/notebooklm_tools/core/base.py
@@ -29,6 +29,7 @@ from .utils import (
     _format_debug_json,
     _parse_url_params,
 )
+from notebooklm_tools.utils.config import get_base_url
 
 # Configure logger (API internals only logged at DEBUG level, usually disabled)
 logger = logging.getLogger("notebooklm_mcp.api")
@@ -52,6 +53,21 @@ class BaseClient:
     from this base class.
     """
 
+    @classmethod
+    def _get_base_url(cls) -> str:
+        return get_base_url()
+
+    @classmethod
+    def _get_batchexecute_url(cls) -> str:
+        return f"{cls._get_base_url()}/_/LabsTailwindUi/data/batchexecute"
+
+    @classmethod
+    def _get_upload_url(cls) -> str:
+        return f"{cls._get_base_url()}/upload/_/"
+
+    # Keep class-level attributes for backward compatibility with code that
+    # reads them directly (e.g. tests). These are the defaults; runtime code
+    # should use the _get_*() methods which respect NOTEBOOKLM_BASE_URL.
     BASE_URL = "https://notebooklm.google.com"
     BATCHEXECUTE_URL = f"{BASE_URL}/_/LabsTailwindUi/data/batchexecute"
     UPLOAD_URL = "https://notebooklm.google.com/upload/_/"
@@ -349,8 +365,8 @@ class BaseClient:
                 cookies=cookies,
                 headers={
                     "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
-                    "Origin": self.BASE_URL,
-                    "Referer": f"{self.BASE_URL}/",
+                    "Origin": self._get_base_url(),
+                    "Referer": f"{self._get_base_url()}/",
                     "X-Same-Domain": "1",
                     "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
                 },
@@ -371,8 +387,8 @@ class BaseClient:
             cookies=cookies,
             headers={
                 "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
-                "Origin": self.BASE_URL,
-                "Referer": f"{self.BASE_URL}/",
+                "Origin": self._get_base_url(),
+                "Referer": f"{self._get_base_url()}/",
                 "X-Same-Domain": "1",
             },
             timeout=30.0,
@@ -417,7 +433,7 @@ class BaseClient:
             params["f.sid"] = self._session_id
 
         query = urllib.parse.urlencode(params)
-        return f"{self.BATCHEXECUTE_URL}?{query}"
+        return f"{self._get_batchexecute_url()}?{query}"
 
     def _parse_response(self, response_text: str) -> Any:
         """Parse the batchexecute response."""
@@ -678,7 +694,7 @@ class BaseClient:
         with httpx.Client(
             cookies=cookies, headers=headers, follow_redirects=True, timeout=15.0
         ) as client:
-            response = client.get(f"{self.BASE_URL}/")
+            response = client.get(f"{self._get_base_url()}/")
 
             # Check if redirected to login (cookies expired)
             if "accounts.google.com" in str(response.url):

--- a/src/notebooklm_tools/core/conversation.py
+++ b/src/notebooklm_tools/core/conversation.py
@@ -272,7 +272,7 @@ class ConversationMixin(BaseClient):
             url_params["f.sid"] = self._session_id
 
         query_string = urllib.parse.urlencode(url_params)
-        url = f"{self.BASE_URL}{self.QUERY_ENDPOINT}?{query_string}"
+        url = f"{self._get_base_url()}{self.QUERY_ENDPOINT}?{query_string}"
 
         response = client.post(url, content=body, timeout=timeout)
         response.raise_for_status()

--- a/src/notebooklm_tools/core/data_types.py
+++ b/src/notebooklm_tools/core/data_types.py
@@ -64,7 +64,8 @@ class Notebook:
     @property
     def url(self) -> str:
         """Get the NotebookLM web URL for this notebook."""
-        return f"https://notebooklm.google.com/notebook/{self.id}"
+        from notebooklm_tools.utils.config import get_base_url
+        return f"{get_base_url()}/notebook/{self.id}"
 
     @property
     def ownership(self) -> str:

--- a/src/notebooklm_tools/core/download.py
+++ b/src/notebooklm_tools/core/download.py
@@ -83,7 +83,7 @@ class DownloadMixin(BaseClient):
             "_PAGE_FETCH_HEADERS",
             {"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"},
         )
-        headers = {**base_headers, "Referer": "https://notebooklm.google.com/"}
+        headers = {**base_headers, "Referer": f"{self._get_base_url()}/"}
 
         # Use httpx.Cookies for proper cross-domain redirect handling
         cookies = self._get_httpx_cookies()

--- a/src/notebooklm_tools/core/sharing.py
+++ b/src/notebooklm_tools/core/sharing.py
@@ -81,7 +81,7 @@ class SharingMixin(BaseClient):
 
         # Construct public link if public
         if is_public:
-            public_link = f"https://notebooklm.google.com/notebook/{notebook_id}"
+            public_link = f"{self._get_base_url()}/notebook/{notebook_id}"
 
         access_level = "public" if is_public else "restricted"
 
@@ -111,7 +111,7 @@ class SharingMixin(BaseClient):
         self._call_rpc(self.RPC_SHARE_NOTEBOOK, params)
 
         if is_public:
-            return f"https://notebooklm.google.com/notebook/{notebook_id}"
+            return f"{self._get_base_url()}/notebook/{notebook_id}"
         return None
 
     def add_collaborator(

--- a/src/notebooklm_tools/core/sources.py
+++ b/src/notebooklm_tools/core/sources.py
@@ -565,14 +565,14 @@ class SourceMixin(BaseClient):
         """
         import json
 
-        url = f"{self.UPLOAD_URL}?authuser=0"
+        url = f"{self._get_upload_url()}?authuser=0"
         cookies = self._get_httpx_cookies()
 
         headers = {
             "Accept": "*/*",
             "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
-            "Origin": "https://notebooklm.google.com",
-            "Referer": "https://notebooklm.google.com/",
+            "Origin": self._get_base_url(),
+            "Referer": f"{self._get_base_url()}/",
             "x-goog-authuser": "0",
             "x-goog-upload-command": "start",
             "x-goog-upload-header-content-length": str(file_size),
@@ -621,8 +621,8 @@ class SourceMixin(BaseClient):
         headers = {
             "Accept": "*/*",
             "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-            "Origin": "https://notebooklm.google.com",
-            "Referer": "https://notebooklm.google.com/",
+            "Origin": self._get_base_url(),
+            "Referer": f"{self._get_base_url()}/",
             "x-goog-authuser": "0",
             "x-goog-upload-command": "upload, finalize",
             "x-goog-upload-offset": "0",

--- a/src/notebooklm_tools/mcp/tools/studio.py
+++ b/src/notebooklm_tools/mcp/tools/studio.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from ...services import ServiceError, ValidationError
 from ...services import studio as studio_service
-from ...utils.config import get_default_language
+from ...utils.config import get_base_url, get_default_language
 from ._utils import coerce_list, get_client, logged_tool
 
 
@@ -161,7 +161,7 @@ def studio_create(
         )
         return {
             "status": "success",
-            "notebook_url": f"https://notebooklm.google.com/notebook/{notebook_id}",
+            "notebook_url": f"{get_base_url()}/notebook/{notebook_id}",
             **result,
         }
     except (ValidationError, ServiceError) as e:
@@ -231,7 +231,7 @@ def studio_status(
                 "in_progress": result["in_progress"],
             },
             "artifacts": result["artifacts"],
-            "notebook_url": f"https://notebooklm.google.com/notebook/{notebook_id}",
+            "notebook_url": f"{get_base_url()}/notebook/{notebook_id}",
         }
     except (ValidationError, ServiceError) as e:
         return {
@@ -338,7 +338,7 @@ def studio_revise(
         )
         return {
             "status": "success",
-            "notebook_url": f"https://notebooklm.google.com/notebook/{notebook_id}",
+            "notebook_url": f"{get_base_url()}/notebook/{notebook_id}",
             **result,
         }
     except (ValidationError, ServiceError) as e:

--- a/src/notebooklm_tools/services/notebooks.py
+++ b/src/notebooklm_tools/services/notebooks.py
@@ -3,6 +3,7 @@
 from typing import TypedDict
 
 from ..core.client import NotebookLMClient
+from ..utils.config import get_base_url
 from .errors import CreationError, NotFoundError, ServiceError, ValidationError
 
 
@@ -173,7 +174,7 @@ def get_notebook(
                 "notebook_id": nb_id,
                 "title": title,
                 "source_count": len(sources),
-                "url": f"https://notebooklm.google.com/notebook/{nb_id}",
+                "url": f"{get_base_url()}/notebook/{nb_id}",
                 "sources": sources,
             }
 
@@ -183,7 +184,7 @@ def get_notebook(
             "notebook_id": nb.id,
             "title": getattr(nb, "title", "Untitled"),
             "source_count": getattr(nb, "source_count", 0),
-            "url": getattr(nb, "url", f"https://notebooklm.google.com/notebook/{nb.id}"),
+            "url": getattr(nb, "url", f"{get_base_url()}/notebook/{nb.id}"),
             "sources": [],
         }
 

--- a/src/notebooklm_tools/utils/browser.py
+++ b/src/notebooklm_tools/utils/browser.py
@@ -5,10 +5,11 @@ import re
 from pathlib import Path
 
 from notebooklm_tools.core.exceptions import AuthenticationError
+from notebooklm_tools.utils.config import get_base_url
 
 # NotebookLM domain for cookie filtering
 NOTEBOOKLM_DOMAIN = ".google.com"
-NOTEBOOKLM_URL = "https://notebooklm.google.com"
+NOTEBOOKLM_URL = get_base_url()
 
 
 def parse_cookies_from_file(file_path: str | Path) -> dict[str, str]:

--- a/src/notebooklm_tools/utils/cdp.py
+++ b/src/notebooklm_tools/utils/cdp.py
@@ -44,6 +44,7 @@ def _normalize_ws_url(url: str | None) -> str | None:
 
 
 from notebooklm_tools.core.exceptions import AuthenticationError  # noqa: E402
+from notebooklm_tools.utils.config import get_base_url  # noqa: E402
 
 __all__ = [
     "get_chrome_path",
@@ -58,7 +59,7 @@ __all__ = [
 
 CDP_DEFAULT_PORT = 9222
 CDP_PORT_RANGE = range(9222, 9232)  # Ports to scan for existing/available
-NOTEBOOKLM_URL = "https://notebooklm.google.com/"
+NOTEBOOKLM_URL = f"{get_base_url()}/"
 
 import logging as _logging  # noqa: E402
 
@@ -569,7 +570,7 @@ def find_or_create_notebooklm_page_by_cdp_url(cdp_http_url: str) -> dict | None:
 
     for page in pages:
         url = page.get("url", "")
-        if "notebooklm.google.com" in url:
+        if _is_notebooklm_url(url):
             return page
 
     try:
@@ -698,6 +699,11 @@ def navigate_to_url(ws_url: str, url: str) -> None:
     execute_cdp_command(ws_url, "Page.navigate", {"url": url})
 
 
+def _is_notebooklm_url(url: str) -> bool:
+    """Check if a URL belongs to any NotebookLM domain (personal or enterprise)."""
+    return "notebooklm.google.com" in url or "notebooklm.cloud.google.com" in url
+
+
 def is_logged_in(url: str) -> bool:
     """Check login status by URL.
 
@@ -705,7 +711,7 @@ def is_logged_in(url: str) -> bool:
     """
     if "accounts.google.com" in url:
         return False
-    return "notebooklm.google.com" in url
+    return _is_notebooklm_url(url)
 
 
 def extract_build_label(html: str) -> str:
@@ -885,7 +891,7 @@ def extract_cookies_from_page(
     if not page:
         raise AuthenticationError(
             message="Failed to open NotebookLM page",
-            hint="Try manually navigating to notebooklm.google.com and try again.",
+            hint=f"Try manually navigating to {get_base_url()} and try again.",
         )
 
     ws_url = _normalize_ws_url(page.get("webSocketDebuggerUrl"))
@@ -897,7 +903,7 @@ def extract_cookies_from_page(
 
     # Navigate to NotebookLM if needed
     current_url = page.get("url", "")
-    if "notebooklm.google.com" not in current_url:
+    if not _is_notebooklm_url(current_url):
         navigate_to_url(ws_url, NOTEBOOKLM_URL)
 
     # Check login status

--- a/src/notebooklm_tools/utils/config.py
+++ b/src/notebooklm_tools/utils/config.py
@@ -20,6 +20,16 @@ from pydantic import BaseModel, Field
 STORAGE_DIR_NAME = ".notebooklm-mcp-cli"
 
 
+def get_base_url() -> str:
+    """Get the NotebookLM base URL.
+
+    Defaults to the personal URL (https://notebooklm.google.com).
+    Set NOTEBOOKLM_BASE_URL to override, e.g. for enterprise:
+        export NOTEBOOKLM_BASE_URL=https://notebooklm.cloud.google.com
+    """
+    return os.environ.get("NOTEBOOKLM_BASE_URL", "https://notebooklm.google.com").rstrip("/")
+
+
 def get_default_language() -> str:
     """Get default language from NOTEBOOKLM_HL env var, falling back to 'en'.
 


### PR DESCRIPTION
## Summary

- Adds `NOTEBOOKLM_BASE_URL` environment variable to configure the NotebookLM base URL
- Defaults to `https://notebooklm.google.com` (personal) for backward compatibility
- Enterprise users can set `export NOTEBOOKLM_BASE_URL=https://notebooklm.cloud.google.com`
- Replaces ~25 hardcoded URL references across 12 files with a single centralized `get_base_url()` function
- CDP domain checks now recognize both `notebooklm.google.com` and `notebooklm.cloud.google.com`

## Motivation

Enterprise/Google Workspace accounts use `https://notebooklm.cloud.google.com` while personal accounts use `https://notebooklm.google.com`. The tool currently only works with personal accounts because all URLs are hardcoded to the personal domain.

## Usage

```bash
# Personal (default, no change needed)
nlm login

# Enterprise
export NOTEBOOKLM_BASE_URL=https://notebooklm.cloud.google.com
nlm login
```

## Test plan

- [x] All 619 existing tests pass (14 pre-existing async test failures unrelated to this change)
- [ ] Verify personal URL still works with no env var set (backward compatible)
- [ ] Verify enterprise URL works with `NOTEBOOKLM_BASE_URL=https://notebooklm.cloud.google.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)