### PR TITLE
Convert dev extra to PEP 735 dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 
 
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",


### PR DESCRIPTION
This should fix `uv run --dev` failing in CI