### PR TITLE
fix: add thread-safety for concurrent MCP tool calls

### DIFF
--- a/src/notebooklm_tools/core/base.py
+++ b/src/notebooklm_tools/core/base.py
@@ -13,6 +13,7 @@ import logging
 import os
 import random
 import re
+import threading
 import urllib.parse
 from typing import Any
 
@@ -295,6 +296,14 @@ class BaseClient:
         # Values: None (unresolved), "v1" (izAoDd), "v2" (ozz5Z)
         self._source_rpc_version: str | None = None
 
+        # Lock for thread-safe access to mutable instance state.
+        # FastMCP dispatches sync tool functions into a thread pool, so
+        # concurrent MCP tool calls share this singleton client instance.
+        # The lock protects: _client, _reqid_counter, _conversation_cache,
+        # _source_rpc_version, csrf_token, _session_id, cookies.
+        # It is never held during network I/O.
+        self._state_lock = threading.Lock()
+
         # Only refresh CSRF token if not provided - tokens actually last hours/days, not minutes
         # The retry logic in _call_rpc() handles expired tokens gracefully
         if not self.csrf_token:
@@ -364,12 +373,17 @@ class BaseClient:
     # =========================================================================
 
     def _get_client(self) -> httpx.Client:
-        """Get or create HTTP client."""
-        if self._client is None:
+        """Get or create HTTP client (thread-safe)."""
+        if self._client is not None:
+            return self._client
+        with self._state_lock:
+            # Double-checked locking: re-check inside lock
+            if self._client is not None:
+                return self._client
             # Use cookies object directly
             cookies = self._get_httpx_cookies()
 
-            self._client = httpx.Client(
+            client = httpx.Client(
                 cookies=cookies,
                 headers={
                     "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
@@ -383,8 +397,9 @@ class BaseClient:
 
             # Explicitly set headers if needed, though constructor handles most
             if self.csrf_token:
-                self._client.headers["X-Goog-Csrf-Token"] = self.csrf_token
+                client.headers["X-Goog-Csrf-Token"] = self.csrf_token
 
+            self._client = client
         return self._client
 
     def _get_async_client(self) -> httpx.AsyncClient:
@@ -662,7 +677,8 @@ class BaseClient:
         if not _retry:
             try:
                 self._refresh_auth_tokens()
-                self._client = None
+                with self._state_lock:
+                    self._client = None
                 return self._call_rpc(rpc_id, params, path, timeout, _retry=True)
             except ValueError:
                 # CSRF refresh failed (cookies expired) - continue to layer 2
@@ -670,7 +686,8 @@ class BaseClient:
 
         # Layer 2 & 3: Reload from disk or run headless auth (deep retry)
         if not _deep_retry and self._try_reload_or_headless_auth():
-            self._client = None
+            with self._state_lock:
+                self._client = None
             return self._call_rpc(rpc_id, params, path, timeout, _retry=True, _deep_retry=True)
 
         # All recovery attempts failed
@@ -738,17 +755,18 @@ class BaseClient:
                     f"The page structure may have changed."
                 )
 
-            self.csrf_token = csrf_token
-
             # Extract session ID (FdrFJe) - optional but helps
             sid_match = re.search(r'"FdrFJe":"([^"]+)"', html)
-            if sid_match:
-                self._session_id = sid_match.group(1)
 
             # Extract build label (cfb2h) - keeps bl param current
             bl_match = re.search(r'"cfb2h":"([^"]+)"', html)
-            if bl_match:
-                self._bl = bl_match.group(1)
+
+            with self._state_lock:
+                self.csrf_token = csrf_token
+                if sid_match:
+                    self._session_id = sid_match.group(1)
+                if bl_match:
+                    self._bl = bl_match.group(1)
 
             # Cache the extracted tokens to avoid re-fetching the page on next request
             self._update_cached_tokens()
@@ -804,9 +822,10 @@ class BaseClient:
             # Always reload from disk when auth fails - current tokens are known-bad
             # The cached tokens may be fresher (user ran nlm login)
             # or the same, but worth retrying with a fresh CSRF token extraction
-            self.cookies = cached.cookies
-            self.csrf_token = ""  # Force re-extraction of CSRF token
-            self._session_id = ""  # Force re-extraction of session ID
+            with self._state_lock:
+                self.cookies = cached.cookies
+                self.csrf_token = ""  # Force re-extraction of CSRF token
+                self._session_id = ""  # Force re-extraction of session ID
             return True
 
         # Try headless auth if Chrome profile exists
@@ -815,9 +834,10 @@ class BaseClient:
 
             tokens = run_headless_auth()
             if tokens:
-                self.cookies = tokens.cookies
-                self.csrf_token = tokens.csrf_token
-                self._session_id = tokens.session_id
+                with self._state_lock:
+                    self.cookies = tokens.cookies
+                    self.csrf_token = tokens.csrf_token
+                    self._session_id = tokens.session_id
                 return True
         except Exception as e:
             logger.debug(f"Headless auth failed: {e}")

--- a/src/notebooklm_tools/core/conversation.py
+++ b/src/notebooklm_tools/core/conversation.py
@@ -74,7 +74,8 @@ class ConversationMixin(BaseClient):
         Returns:
             List in Chrome's expected format, or None if no history exists
         """
-        turns = self._conversation_cache.get(conversation_id, [])
+        with self._state_lock:
+            turns = list(self._conversation_cache.get(conversation_id, []))
         if not turns:
             return None
 
@@ -89,23 +90,26 @@ class ConversationMixin(BaseClient):
 
     def _cache_conversation_turn(self, conversation_id: str, query: str, answer: str) -> None:
         """Cache a conversation turn for future follow-up queries."""
-        if conversation_id not in self._conversation_cache:
-            self._conversation_cache[conversation_id] = []
+        with self._state_lock:
+            if conversation_id not in self._conversation_cache:
+                self._conversation_cache[conversation_id] = []
 
-        turn_number = len(self._conversation_cache[conversation_id]) + 1
-        turn = ConversationTurn(query=query, answer=answer, turn_number=turn_number)
-        self._conversation_cache[conversation_id].append(turn)
+            turn_number = len(self._conversation_cache[conversation_id]) + 1
+            turn = ConversationTurn(query=query, answer=answer, turn_number=turn_number)
+            self._conversation_cache[conversation_id].append(turn)
 
     def clear_conversation(self, conversation_id: str) -> bool:
         """Clear the conversation cache for a specific conversation."""
-        if conversation_id in self._conversation_cache:
-            del self._conversation_cache[conversation_id]
-            return True
-        return False
+        with self._state_lock:
+            if conversation_id in self._conversation_cache:
+                del self._conversation_cache[conversation_id]
+                return True
+            return False
 
     def get_conversation_history(self, conversation_id: str) -> list[dict] | None:
         """Get the conversation history for a specific conversation."""
-        turns = self._conversation_cache.get(conversation_id)
+        with self._state_lock:
+            turns = list(self._conversation_cache.get(conversation_id, []))
         if not turns:
             return None
 
@@ -167,7 +171,8 @@ class ConversationMixin(BaseClient):
             path=f"/notebook/{notebook_id}",
         )
         # Also clear local cache if present
-        self._conversation_cache.pop(conversation_id, None)
+        with self._state_lock:
+            self._conversation_cache.pop(conversation_id, None)
         return result is not None
 
     # =========================================================================
@@ -261,11 +266,13 @@ class ConversationMixin(BaseClient):
         # Add trailing & to match NotebookLM's format
         body = "&".join(body_parts) + "&"
 
-        self._reqid_counter += 100000  # Increment counter
+        with self._state_lock:
+            self._reqid_counter += 100000
+            reqid = self._reqid_counter
         url_params = {
             "bl": os.environ.get("NOTEBOOKLM_BL") or getattr(self, "_bl", "") or self._BL_FALLBACK,
             "hl": os.environ.get("NOTEBOOKLM_HL", "en"),
-            "_reqid": str(self._reqid_counter),
+            "_reqid": str(reqid),
             "rt": "c",
         }
         if self._session_id:
@@ -286,11 +293,12 @@ class ConversationMixin(BaseClient):
         # This is the key mechanism for chat history persistence — the server
         # returns its own conversation ID which tracks the chat across sessions.
         if server_conv_id and server_conv_id != conversation_id:
-            # Migrate local cache to the server-assigned ID
-            if conversation_id in self._conversation_cache:
-                self._conversation_cache[server_conv_id] = self._conversation_cache.pop(
-                    conversation_id
-                )
+            with self._state_lock:
+                # Migrate local cache to the server-assigned ID
+                if conversation_id in self._conversation_cache:
+                    self._conversation_cache[server_conv_id] = self._conversation_cache.pop(
+                        conversation_id
+                    )
             conversation_id = server_conv_id
 
         # Cache this turn for future follow-ups (only if we got an answer)
@@ -298,8 +306,9 @@ class ConversationMixin(BaseClient):
             self._cache_conversation_turn(conversation_id, query_text, answer_text)
 
         # Calculate turn number
-        turns = self._conversation_cache.get(conversation_id, [])
-        turn_number = len(turns)
+        with self._state_lock:
+            turns = self._conversation_cache.get(conversation_id, [])
+            turn_number = len(turns)
 
         return {
             "answer": answer_text,

--- a/src/notebooklm_tools/core/sources.py
+++ b/src/notebooklm_tools/core/sources.py
@@ -319,20 +319,26 @@ class SourceMixin(BaseClient):
 
         try:
             # Use cached RPC version if already resolved
-            if self._source_rpc_version == "v2":
+            with self._state_lock:
+                version = self._source_rpc_version
+            if version == "v2":
                 result = self._add_url_source_v2(notebook_id, url, source_path)
-            elif self._source_rpc_version == "v1":
+            elif version == "v1":
                 result = self._add_url_source_v1(notebook_id, url, source_path)
             else:
                 # First call — try v1, fallback to v2 on INVALID_ARGUMENT
                 try:
                     result = self._add_url_source_v1(notebook_id, url, source_path)
-                    self._source_rpc_version = "v1"
+                    with self._state_lock:
+                        if self._source_rpc_version is None:
+                            self._source_rpc_version = "v1"
                 except RPCError as e:
                     if e.error_code == 3:
                         # Legacy RPC rejected — try the new endpoint
                         result = self._add_url_source_v2(notebook_id, url, source_path)
-                        self._source_rpc_version = "v2"
+                        with self._state_lock:
+                            if self._source_rpc_version is None:
+                                self._source_rpc_version = "v2"
                     else:
                         raise
         except httpx.TimeoutException:
@@ -432,19 +438,25 @@ class SourceMixin(BaseClient):
         source_path = f"/notebook/{notebook_id}"
 
         try:
-            if self._source_rpc_version == "v2":
+            with self._state_lock:
+                version = self._source_rpc_version
+            if version == "v2":
                 result = self._add_url_sources_v2(notebook_id, urls, source_path)
-            elif self._source_rpc_version == "v1":
+            elif version == "v1":
                 result = self._add_url_sources_v1(notebook_id, urls, source_path)
             else:
                 # First call — try v1, fallback to v2 on INVALID_ARGUMENT
                 try:
                     result = self._add_url_sources_v1(notebook_id, urls, source_path)
-                    self._source_rpc_version = "v1"
+                    with self._state_lock:
+                        if self._source_rpc_version is None:
+                            self._source_rpc_version = "v1"
                 except RPCError as e:
                     if e.error_code == 3:
                         result = self._add_url_sources_v2(notebook_id, urls, source_path)
-                        self._source_rpc_version = "v2"
+                        with self._state_lock:
+                            if self._source_rpc_version is None:
+                                self._source_rpc_version = "v2"
                     else:
                         raise
         except httpx.TimeoutException:

--- a/tests/core/test_thread_safety.py
+++ b/tests/core/test_thread_safety.py
@@ -1,0 +1,167 @@
+# tests/core/test_thread_safety.py
+"""Tests for thread-safety of NotebookLMClient shared state.
+
+FastMCP dispatches sync tool functions into a thread pool, so concurrent
+MCP tool calls share the same NotebookLMClient singleton. These tests
+verify that the internal locking prevents race conditions.
+"""
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from unittest.mock import patch
+
+import pytest
+
+
+def _make_client():
+    """Create a NotebookLMClient with mocked auth (no network)."""
+    from notebooklm_tools.core.base import BaseClient
+    from notebooklm_tools.core.client import NotebookLMClient
+
+    with patch.object(BaseClient, "_refresh_auth_tokens"):
+        return NotebookLMClient(cookies={"test": "cookie"}, csrf_token="test_token")
+
+
+class TestReqidCounter:
+    """Verify _reqid_counter produces unique values under concurrent access."""
+
+    def test_sequential_uniqueness(self):
+        client = _make_client()
+        values = set()
+        for _ in range(100):
+            with client._state_lock:
+                client._reqid_counter += 100000
+                values.add(client._reqid_counter)
+        assert len(values) == 100
+
+    def test_concurrent_uniqueness(self):
+        client = _make_client()
+        results = []
+
+        def increment():
+            with client._state_lock:
+                client._reqid_counter += 100000
+                return client._reqid_counter
+
+        with ThreadPoolExecutor(max_workers=10) as executor:
+            futures = [executor.submit(increment) for _ in range(200)]
+            for f in as_completed(futures):
+                results.append(f.result())
+
+        # All 200 values must be unique
+        assert len(set(results)) == 200
+
+
+class TestConversationCache:
+    """Verify _conversation_cache operations are safe under concurrent writes."""
+
+    def test_concurrent_cache_turns(self):
+        client = _make_client()
+        conv_id = "test-conv"
+
+        def cache_turn(i):
+            client._cache_conversation_turn(conv_id, f"q{i}", f"a{i}")
+
+        with ThreadPoolExecutor(max_workers=10) as executor:
+            futures = [executor.submit(cache_turn, i) for i in range(50)]
+            for f in as_completed(futures):
+                f.result()  # raise if any failed
+
+        # All 50 turns should be present
+        turns = client._conversation_cache[conv_id]
+        assert len(turns) == 50
+        # Turn numbers should be 1..50 (unique, sequential)
+        turn_numbers = sorted(t.turn_number for t in turns)
+        assert turn_numbers == list(range(1, 51))
+
+    def test_concurrent_different_conversations(self):
+        client = _make_client()
+
+        def cache_turn(conv_idx, turn_idx):
+            conv_id = f"conv-{conv_idx}"
+            client._cache_conversation_turn(conv_id, f"q{turn_idx}", f"a{turn_idx}")
+
+        with ThreadPoolExecutor(max_workers=10) as executor:
+            futures = []
+            for conv in range(5):
+                for turn in range(20):
+                    futures.append(executor.submit(cache_turn, conv, turn))
+            for f in as_completed(futures):
+                f.result()
+
+        # Each conversation should have exactly 20 turns
+        for conv in range(5):
+            assert len(client._conversation_cache[f"conv-{conv}"]) == 20
+
+    def test_concurrent_clear_and_write(self):
+        client = _make_client()
+        conv_id = "test-conv"
+
+        # Pre-populate
+        client._cache_conversation_turn(conv_id, "q0", "a0")
+
+        errors = []
+
+        def writer():
+            try:
+                for i in range(20):
+                    client._cache_conversation_turn(conv_id, f"q{i}", f"a{i}")
+            except Exception as e:
+                errors.append(e)
+
+        def clearer():
+            try:
+                for _ in range(5):
+                    client.clear_conversation(conv_id)
+            except Exception as e:
+                errors.append(e)
+
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            futures = [executor.submit(writer) for _ in range(2)]
+            futures.append(executor.submit(clearer))
+            for f in as_completed(futures):
+                f.result()
+
+        # No exceptions should have been raised
+        assert not errors
+
+
+class TestGetClient:
+    """Verify _get_client double-checked locking."""
+
+    def test_concurrent_client_creation(self):
+        client = _make_client()
+        assert client._client is None
+
+        results = []
+
+        def get():
+            return id(client._get_client())
+
+        with ThreadPoolExecutor(max_workers=10) as executor:
+            futures = [executor.submit(get) for _ in range(20)]
+            for f in as_completed(futures):
+                results.append(f.result())
+
+        # All threads should get the same httpx.Client instance
+        assert len(set(results)) == 1
+
+
+class TestSourceRpcVersion:
+    """Verify _source_rpc_version is safely read/written."""
+
+    def test_concurrent_version_write(self):
+        client = _make_client()
+        assert client._source_rpc_version is None
+
+        def set_version(version):
+            with client._state_lock:
+                if client._source_rpc_version is None:
+                    client._source_rpc_version = version
+
+        with ThreadPoolExecutor(max_workers=10) as executor:
+            futures = [executor.submit(set_version, "v1") for _ in range(20)]
+            for f in as_completed(futures):
+                f.result()
+
+        # Should be set exactly once
+        assert client._source_rpc_version == "v1"

--- a/tests/core/test_url_source_fallback.py
+++ b/tests/core/test_url_source_fallback.py
@@ -33,9 +33,12 @@ def _make_client() -> SourceMixin:
     We patch __init__ entirely because BaseClient.__init__ requires
     real cookies / CSRF setup that we don't need for unit tests.
     """
+    import threading
+
     with patch.object(SourceMixin, "__init__", lambda self: None):
         client = SourceMixin()
     client._source_rpc_version = None
+    client._state_lock = threading.Lock()
     client._call_rpc = MagicMock(return_value=MOCK_SOURCE_RESPONSE)
     return client
 


### PR DESCRIPTION
## Problem

FastMCP dispatches sync tool functions via `anyio.to_thread.run_sync` into a thread pool (`fastmcp/tools/function_tool.py:258,281`). When multiple MCP tool calls run concurrently — either from parallel AI agent requests or from internal `ThreadPoolExecutor` in batch/cross-notebook operations — they share the same `NotebookLMClient` singleton.

The client's mutable instance state has **no synchronization**, causing race conditions that manifest as "cross-talk" — results from one notebook leaking into another.

## Root Cause

The global singleton `_client` in `mcp/tools/_utils.py` is protected by `_client_lock` for **initialization only** (PR #74). However, the **per-instance mutable state** is completely unprotected:

| State | Location | Race Condition |
|-------|----------|----------------|
| `_reqid_counter` | conversation.py:264 | Non-atomic `+= 100000` produces duplicate request IDs |
| `_conversation_cache` | conversation.py:77-302 | Unsynchronized dict ops corrupt conversation history |
| `_source_rpc_version` | sources.py:322-449 | TOCTOU in version detection causes redundant fallback |
| `_client` (httpx) | base.py:366-388,665,673 | Lazy init and auth invalidation have check-then-act races |
| Auth tokens | base.py:741-820 | Concurrent refresh leaves inconsistent csrf/session state |

## Fix

Add a single `threading.Lock` (`self._state_lock`) to `BaseClient.__init__` and protect all critical sections. The lock is **never held during network I/O** — only for short in-memory operations (counter increment, dict access, reference swap), so contention is negligible.

This follows the existing project pattern (`_client_lock` in `_utils.py:19`, `_pending_lock` in `services/chat.py:22`).

### Changes

- **`core/base.py`**: Add `_state_lock`; double-checked locking for `_get_client()`; protect auth token mutations and client invalidation
- **`core/conversation.py`**: Protect `_reqid_counter` increment (capture to local var); protect all `_conversation_cache` operations including cache key migration
- **`core/sources.py`**: Protect `_source_rpc_version` read/write with `if None` guard to avoid overwriting another thread's resolution

### Files Modified

- `src/notebooklm_tools/core/base.py`
- `src/notebooklm_tools/core/conversation.py`
- `src/notebooklm_tools/core/sources.py`
- `tests/core/test_thread_safety.py` (new)
- `tests/core/test_url_source_fallback.py` (add `_state_lock` to mocked client)

## Test plan

- [x] New thread-safety tests: concurrent `_reqid_counter` uniqueness, `_conversation_cache` consistency, `_get_client` singleton guarantee, `_source_rpc_version` write safety (7 tests)
- [x] Full test suite: 709 passed, 0 failures