### PR TITLE
Improve Chromium auth resilience and align auth messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ nlm login --manual     # Manual file mode
 
 **How it works:** Auto mode launches a dedicated browser profile (supports Chrome, Arc, Brave, Edge, Chromium, and more), you log in to Google, and cookies are extracted automatically. Your login persists for future auth refreshes.
 
-**Prefer a specific browser?** Set it with `nlm config set auth.browser brave` (or `arc`, `edge`, `chromium`, etc.). Falls back to auto-detection if the preferred browser is not found.
+**Prefer a specific browser?** Set it with `nlm config set auth.browser chromium` (or `brave`, `arc`, `edge`, `chrome`, etc.). Falls back to auto-detection if the preferred browser is not found.
 
 For detailed instructions and troubleshooting, see **[docs/AUTHENTICATION.md](docs/AUTHENTICATION.md)**.
 

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -4,15 +4,16 @@ This guide explains how to authenticate with NotebookLM MCP and CLI.
 
 ## Overview
 
-NotebookLM uses browser cookies for authentication (there is no official API). The CLI/MCP extracts these cookies automatically via Chrome DevTools Protocol (CDP) from any Chromium-based browser.
+NotebookLM uses browser cookies for authentication (there is no official API). The CLI/MCP extracts these cookies automatically from a managed browser session:
+- Chromium-family browsers use Chrome DevTools Protocol (CDP)
 
-**Supported browsers** (in priority order): Google Chrome, Arc (macOS), Brave, Microsoft Edge, Chromium, Vivaldi, Opera.
+**Supported browsers**: Google Chrome, Arc (macOS), Brave, Microsoft Edge, Chromium, Vivaldi, Opera.
 
 **Two authentication methods are available:**
 
 | Method | Best For | Requires |
 |--------|----------|----------|
-| **Auto Mode** (default) | Most users | Any supported browser installed, browser closed |
+| **Auto Mode** (default) | Most users | Any supported Chromium-family browser installed |
 | **File Mode** (`--file`) | Complex setups, troubleshooting | Manual cookie extraction |
 
 ---
@@ -23,8 +24,8 @@ This method launches your browser automatically and extracts cookies after you l
 
 ### Prerequisites
 
-- A supported Chromium-based browser installed (Chrome, Arc, Brave, Edge, Chromium, Vivaldi, or Opera)
-- The browser must be **completely closed** before running
+- A supported browser installed (Chrome, Arc, Brave, Edge, Chromium, Vivaldi, or Opera)
+- Chromium-family browsers should be **completely closed** before running
 
 ### Steps
 
@@ -49,7 +50,7 @@ nlm login --devtools-timeout 15
 
 1. The first available supported browser is detected (or your preferred browser if configured)
 2. A dedicated browser profile is created for authentication
-3. The browser launches with remote debugging enabled
+3. The browser launches with the appropriate automation backend
 4. You log in to NotebookLM via the browser
 5. Cookies, CSRF token, and account email are extracted and cached
 6. The browser is closed automatically
@@ -75,7 +76,7 @@ The dedicated browser profile persists your Google login:
 - **First run:** You must log in to Google
 - **Future runs:** Already logged in, just extracts fresh cookies
 
-This profile is separate from your regular browser profile and includes no extensions.
+This profile is separate from your regular browser profile. Chromium profiles disable extensions.
 
 ---
 

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -223,7 +223,7 @@ nlm config set output.format json       # Change default output format
 | `output.format` | `table` | Default output format (table, json) |
 | `output.color` | `true` | Enable colored output |
 | `output.short_ids` | `true` | Show shortened IDs |
-| `auth.browser` | `auto` | Preferred browser for login (auto, chrome, arc, brave, edge, chromium, vivaldi, opera). Falls back to auto if preferred browser is not found. |
+| `auth.browser` | `auto` | Preferred browser for login (auto, chrome, arc, brave, edge, chromium, vivaldi, opera). Falls back to auto if the preferred browser is not found. |
 | `auth.default_profile` | `default` | Profile to use when `--profile` not specified. **Note:** The MCP Server always uses the active default profile. Changing this setting will instantaneously switch the MCP server's Google account. |
 
 ### Aliases (Shortcuts)

--- a/src/notebooklm_tools/cli/ai_docs.py
+++ b/src/notebooklm_tools/cli/ai_docs.py
@@ -21,7 +21,7 @@ nlm version {version}
 ```bash
 nlm login
 ```
-This opens NotebookLM in your browser (Chrome, Arc, Brave, Edge, or any Chromium-based browser) and extracts cookies automatically.
+This opens NotebookLM in your browser (Chrome, Arc, Brave, Edge, Chromium, or another supported Chromium-family browser) and extracts cookies automatically.
 Output on success: `✓ Successfully authenticated!`
 
 ### Check If Already Authenticated

--- a/src/notebooklm_tools/data/references/command_reference.md
+++ b/src/notebooklm_tools/data/references/command_reference.md
@@ -37,7 +37,7 @@ nlm --help             # Show help and exit
 
 ### nlm login
 
-Authenticate with NotebookLM using Chrome DevTools Protocol.
+Authenticate with NotebookLM using the managed browser auth flow.
 
 ```bash
 nlm login [OPTIONS]
@@ -50,7 +50,7 @@ nlm login [OPTIONS]
 | `--provider` | | Auth provider: `builtin` (default) or `openclaw` |
 | `--cdp-url` | | CDP endpoint URL for external provider mode (default: `http://127.0.0.1:18800`) |
 | `--legacy` | `-l` | Use browser-cookie3 fallback (not recommended) |
-| `--browser` | `-b` | Browser for legacy mode (chrome, firefox, edge) |
+| `--browser` | `-b` | Browser for legacy mode (chrome, chromium, edge) |
 | `--manual` | `-m` | Import cookies from file |
 | `--file` | `-f` | Cookie file path for manual mode |
 

--- a/src/notebooklm_tools/utils/auth_browser.py
+++ b/src/notebooklm_tools/utils/auth_browser.py
@@ -1,0 +1,107 @@
+"""Browser/backend selection for interactive and headless authentication."""
+
+import json
+from typing import Any
+
+from notebooklm_tools.core.exceptions import AuthenticationError
+from notebooklm_tools.utils.config import get_config, get_profile_dir
+
+CHROMIUM_BROWSER_KEYS = {"auto", "chrome", "arc", "brave", "edge", "chromium", "vivaldi", "opera"}
+
+
+def _normalize_browser(preferred: str | None = None) -> str:
+    if preferred is None:
+        preferred = get_config().auth.browser
+    return (preferred or "auto").lower().strip()
+
+
+def get_supported_auth_browsers() -> list[str]:
+    """Return user-facing browser names for auth."""
+    from notebooklm_tools.utils.cdp import get_supported_browsers as get_supported_chromium_browsers
+
+    return get_supported_chromium_browsers()
+
+
+def select_auth_backend(preferred: str | None = None) -> dict[str, str] | None:
+    """Pick the best available auth backend for the configured browser."""
+    from notebooklm_tools.utils.cdp import _get_chromium_path, get_browser_display_name
+
+    preferred = _normalize_browser(preferred)
+
+    chromium_path = _get_chromium_path(preferred if preferred in CHROMIUM_BROWSER_KEYS else "auto")
+    if chromium_path:
+        return {"backend": "chromium_cdp", "browser": get_browser_display_name()}
+
+    return None
+
+
+def extract_cookies_via_browser(
+    *,
+    profile_name: str = "default",
+    clear_profile: bool = False,
+    login_timeout: int = 300,
+    wait_for_login: bool = True,
+    preferred: str | None = None,
+) -> tuple[dict[str, Any], dict[str, str]]:
+    """Extract auth cookies using the selected backend."""
+    backend = select_auth_backend(preferred)
+    if not backend:
+        browsers = get_supported_auth_browsers()
+        if len(browsers) > 1:
+            browser_text = ", ".join(browsers[:-1]) + f", or {browsers[-1]}"
+        else:
+            browser_text = browsers[0]
+        raise AuthenticationError(
+            message="No supported browser found",
+            hint=f"Install {browser_text}, or use 'nlm login --manual' to import cookies from a file.",
+        )
+
+    from notebooklm_tools.utils.cdp import extract_cookies_via_cdp
+
+    result = extract_cookies_via_cdp(
+        auto_launch=True,
+        wait_for_login=wait_for_login,
+        login_timeout=login_timeout,
+        profile_name=profile_name,
+        clear_profile=clear_profile,
+    )
+    return result, backend
+
+
+def _get_saved_browser_backend(profile_name: str) -> str | None:
+    metadata_file = get_profile_dir(profile_name) / "metadata.json"
+    if not metadata_file.exists():
+        return None
+    try:
+        metadata = json.loads(metadata_file.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    value = metadata.get("browser_backend")
+    return value if isinstance(value, str) and value else None
+
+
+def run_headless_auth(profile_name: str = "default", timeout: int = 30) -> Any | None:
+    """Try headless auth using the profile's saved backend, then reasonable fallbacks."""
+    preferred_backend = _get_saved_browser_backend(profile_name)
+    attempts: list[str] = []
+
+    if preferred_backend == "chromium_cdp":
+        attempts.append(preferred_backend)
+
+    selected = select_auth_backend()
+    if selected and selected["backend"] not in attempts:
+        attempts.append(selected["backend"])
+
+    if "chromium_cdp" not in attempts:
+        attempts.append("chromium_cdp")
+
+    for backend in attempts:
+        if backend == "chromium_cdp":
+            from notebooklm_tools.utils.cdp import run_headless_auth as run_headless_chromium_auth
+
+            tokens = run_headless_chromium_auth(timeout=timeout, profile_name=profile_name)
+            if tokens:
+                return tokens
+            continue
+
+    return None

--- a/src/notebooklm_tools/utils/cdp.py
+++ b/src/notebooklm_tools/utils/cdp.py
@@ -74,6 +74,31 @@ import logging as _logging  # noqa: E402
 _logger = _logging.getLogger(__name__)
 
 
+def _cdp_http_base(port: int) -> str:
+    """Return the local CDP HTTP base URL using IPv4 loopback explicitly."""
+    return f"http://127.0.0.1:{port}"
+
+
+def _summarize_browser_startup_failure(process: subprocess.Popen | None) -> str | None:
+    """Best-effort summary when the launched browser exits before CDP is ready."""
+    if process is None or process.poll() is None or process.stderr is None:
+        return None
+
+    try:
+        stderr = process.stderr.read().decode("utf-8", errors="replace").strip()
+    except Exception:
+        return None
+
+    if not stderr:
+        return None
+
+    lines = [line.strip() for line in stderr.splitlines() if line.strip()]
+    if not lines:
+        return None
+
+    return lines[-1]
+
+
 # =============================================================================
 # Port-to-Profile Mapping
 # =============================================================================
@@ -308,10 +333,10 @@ def _get_preferred_browser() -> str:
         return "auto"
 
 
-def get_chrome_path() -> str | None:
+def _get_chromium_path(preferred: str | None = None) -> str | None:
     """Return the path/executable for the first available Chromium-based browser.
 
-    Respects the ``auth.browser`` config setting:
+    Respects the ``auth.browser`` config setting when ``preferred`` is omitted:
     - ``auto`` (default): tries browsers in priority order.
     - A specific name (e.g. ``brave``): tries that browser first, then
       falls back to the full priority list if not found.
@@ -320,7 +345,15 @@ def get_chrome_path() -> str | None:
     Valid names: auto, chrome, arc, brave, edge, chromium, vivaldi, opera.
     """
     global _detected_browser_name
-    preferred = _get_preferred_browser()
+    if preferred is None:
+        preferred = _get_preferred_browser()
+        if preferred not in {"auto", *_BROWSER_CONFIG_MAP}:
+            preferred = "auto"
+    preferred = preferred.lower().strip()
+
+    if preferred not in {"auto", *_BROWSER_CONFIG_MAP}:
+        return None
+
     preferred_names = _BROWSER_CONFIG_MAP.get(preferred, [])
 
     def _found(name: str, path: str, fallback: bool = False) -> str:
@@ -368,6 +401,11 @@ def get_chrome_path() -> str | None:
         return None
 
     return None
+
+
+def get_chrome_path() -> str | None:
+    """Return the path/executable for the first available Chromium-based browser."""
+    return _get_chromium_path()
 
 
 def get_supported_browsers() -> list[str]:
@@ -436,6 +474,24 @@ def find_existing_nlm_chrome(
             _clear_port_map(port)
 
     # No mapped instance found for this profile
+    return None, None
+
+
+def find_any_existing_cdp_browser(port_range: range = CDP_PORT_RANGE) -> tuple[int | None, str | None]:
+    """Find a single reachable CDP browser in our local port range.
+
+    This is a fallback for environments where the browser is already running
+    with remote debugging enabled but wasn't launched by this tool, so no
+    port-map entry exists yet.
+    """
+    matches: list[tuple[int, str]] = []
+    for port in port_range:
+        debugger_url = get_debugger_url(port, tries=1, timeout=2)
+        if debugger_url:
+            matches.append((port, debugger_url))
+
+    if len(matches) == 1:
+        return matches[0]
     return None, None
 
 
@@ -554,7 +610,7 @@ def get_debugger_url(
     """Get the WebSocket debugger URL for Chrome."""
     for attempt in range(tries):
         try:
-            response = httpx_client.get(f"http://localhost:{port}/json/version", timeout=timeout)
+            response = httpx_client.get(f"{_cdp_http_base(port)}/json/version", timeout=timeout)
             data = response.json()
             return _normalize_ws_url(data.get("webSocketDebuggerUrl"))
         except Exception:
@@ -607,7 +663,7 @@ def find_or_create_notebooklm_page_by_cdp_url(cdp_http_url: str) -> dict | None:
 
 def find_or_create_notebooklm_page(port: int = CDP_DEFAULT_PORT) -> dict | None:
     """Find an existing NotebookLM page or create a new one."""
-    return find_or_create_notebooklm_page_by_cdp_url(f"http://localhost:{port}")
+    return find_or_create_notebooklm_page_by_cdp_url(_cdp_http_base(port))
 
 
 def execute_cdp_command(
@@ -819,6 +875,8 @@ def extract_cookies_via_cdp(
     existing_port, debugger_url = None, None
     if not clear_profile:
         existing_port, debugger_url = find_existing_nlm_chrome(profile_name=profile_name)
+        if not debugger_url:
+            existing_port, debugger_url = find_any_existing_cdp_browser()
 
     if existing_port:
         port = existing_port
@@ -858,16 +916,20 @@ def extract_cookies_via_cdp(
                 hint="Try 'nlm login --manual' to import cookies from a file.",
             )
 
-        # Non-Chrome browsers (Brave, Edge, etc.) may take longer to start,
-        # so allow up to 10 seconds for the CDP debugger to become available.
-        debugger_url = get_debugger_url(port, tries=10)
+        # Snap Chromium and some Chromium forks can take noticeably longer
+        # to expose CDP than the browser window itself takes to appear.
+        debugger_url = get_debugger_url(port, tries=30)
 
     if not debugger_url:
+        startup_error = _summarize_browser_startup_failure(_chrome_process)
+        hint = "Use 'nlm login --manual' to import cookies from a file."
+        if startup_error:
+            hint = f"{hint} Browser startup error: {startup_error}"
         raise AuthenticationError(
             message=f"Cannot connect to browser on port {port}",
-            hint="Use 'nlm login --manual' to import cookies from a file.",
+            hint=hint,
         )
-    result = extract_cookies_from_page(f"http://localhost:{port}", wait_for_login, login_timeout)
+    result = extract_cookies_from_page(_cdp_http_base(port), wait_for_login, login_timeout)
     result["reused_existing"] = reused_existing
     return result
 

--- a/src/notebooklm_tools/utils/cdp.py
+++ b/src/notebooklm_tools/utils/cdp.py
@@ -477,7 +477,9 @@ def find_existing_nlm_chrome(
     return None, None
 
 
-def find_any_existing_cdp_browser(port_range: range = CDP_PORT_RANGE) -> tuple[int | None, str | None]:
+def find_any_existing_cdp_browser(
+    port_range: range = CDP_PORT_RANGE,
+) -> tuple[int | None, str | None]:
     """Find a single reachable CDP browser in our local port range.
 
     This is a fallback for environments where the browser is already running

--- a/src/notebooklm_tools/utils/config.py
+++ b/src/notebooklm_tools/utils/config.py
@@ -116,6 +116,13 @@ def get_chrome_profile_dir(profile_name: str = "default") -> Path:
     return chrome_dir
 
 
+def get_firefox_profile_dir(profile_name: str = "default") -> Path:
+    """Get Firefox profile directory kept for backwards compatibility."""
+    firefox_dir = get_storage_dir() / "firefox-profiles" / profile_name
+    firefox_dir.mkdir(parents=True, exist_ok=True)
+    return firefox_dir
+
+
 def get_config_file() -> Path:
     """Get the config file path."""
     return get_storage_dir() / "config.toml"
@@ -339,7 +346,10 @@ class AuthConfig(BaseModel):
 
     browser: str = Field(
         default="auto",
-        description="Browser for auth: auto, chrome, arc, brave, edge, chromium, vivaldi, opera",
+        description=(
+            "Browser for auth: auto, chrome, arc, brave, edge, chromium, "
+            "vivaldi, opera"
+        ),
     )
     default_profile: str = Field(default="default", description="Default profile name")
 

--- a/src/notebooklm_tools/utils/config.py
+++ b/src/notebooklm_tools/utils/config.py
@@ -346,10 +346,7 @@ class AuthConfig(BaseModel):
 
     browser: str = Field(
         default="auto",
-        description=(
-            "Browser for auth: auto, chrome, arc, brave, edge, chromium, "
-            "vivaldi, opera"
-        ),
+        description=("Browser for auth: auto, chrome, arc, brave, edge, chromium, vivaldi, opera"),
     )
     default_profile: str = Field(default="default", description="Default profile name")
 

--- a/tests/test_auth_browser.py
+++ b/tests/test_auth_browser.py
@@ -1,5 +1,6 @@
 """Tests for supported authentication browser behavior."""
 
+import json
 from unittest.mock import patch
 
 
@@ -54,17 +55,17 @@ def test_get_chromium_path_ignores_explicit_firefox_preference():
     assert _get_chromium_path("firefox") is None
 
 
-def test_auth_manager_persists_legacy_browser_backend(tmp_path, monkeypatch):
+def test_saved_legacy_browser_backend_is_read_from_metadata(tmp_path, monkeypatch):
     from notebooklm_tools.core.auth import AuthManager
+    from notebooklm_tools.utils.auth_browser import _get_saved_browser_backend
 
     monkeypatch.setenv("NOTEBOOKLM_MCP_CLI_PATH", str(tmp_path))
 
     auth = AuthManager("default")
-    auth.save_profile(
-        cookies={"SID": "sid", "HSID": "hsid"},
-        email="user@example.com",
-        browser_backend="firefox_playwright",
-    )
+    auth.save_profile(cookies={"SID": "sid", "HSID": "hsid"}, email="user@example.com")
 
-    profile = auth.load_profile(force_reload=True)
-    assert profile.browser_backend == "firefox_playwright"
+    metadata = json.loads(auth.metadata_file.read_text(encoding="utf-8"))
+    metadata["browser_backend"] = "firefox_playwright"
+    auth.metadata_file.write_text(json.dumps(metadata), encoding="utf-8")
+
+    assert _get_saved_browser_backend("default") == "firefox_playwright"

--- a/tests/test_auth_browser.py
+++ b/tests/test_auth_browser.py
@@ -1,0 +1,70 @@
+"""Tests for supported authentication browser behavior."""
+
+from unittest.mock import patch
+
+
+def test_select_auth_backend_ignores_firefox_preference_and_uses_chromium():
+    from notebooklm_tools.utils.auth_browser import select_auth_backend
+
+    with (
+        patch("notebooklm_tools.utils.cdp._get_chromium_path", return_value="chromium"),
+        patch("notebooklm_tools.utils.cdp.get_browser_display_name", return_value="Chromium"),
+    ):
+        backend = select_auth_backend("firefox")
+
+    assert backend == {"backend": "chromium_cdp", "browser": "Chromium"}
+
+
+def test_select_auth_backend_auto_prefers_chromium_when_available():
+    from notebooklm_tools.utils.auth_browser import select_auth_backend
+
+    with (
+        patch("notebooklm_tools.utils.cdp._get_chromium_path", return_value="google-chrome"),
+        patch("notebooklm_tools.utils.cdp.get_browser_display_name", return_value="Google Chrome"),
+    ):
+        backend = select_auth_backend("auto")
+
+    assert backend == {"backend": "chromium_cdp", "browser": "Google Chrome"}
+
+
+def test_select_auth_backend_returns_none_when_no_chromium_browser_available():
+    from notebooklm_tools.utils.auth_browser import select_auth_backend
+
+    with patch("notebooklm_tools.utils.cdp._get_chromium_path", return_value=None):
+        backend = select_auth_backend("auto")
+
+    assert backend is None
+
+
+def test_supported_auth_browsers_excludes_firefox():
+    from notebooklm_tools.utils.auth_browser import get_supported_auth_browsers
+
+    with patch(
+        "notebooklm_tools.utils.cdp.get_supported_browsers",
+        return_value=["Google Chrome", "Chromium"],
+    ):
+        browsers = get_supported_auth_browsers()
+
+    assert browsers == ["Google Chrome", "Chromium"]
+
+
+def test_get_chromium_path_ignores_explicit_firefox_preference():
+    from notebooklm_tools.utils.cdp import _get_chromium_path
+
+    assert _get_chromium_path("firefox") is None
+
+
+def test_auth_manager_persists_legacy_browser_backend(tmp_path, monkeypatch):
+    from notebooklm_tools.core.auth import AuthManager
+
+    monkeypatch.setenv("NOTEBOOKLM_MCP_CLI_PATH", str(tmp_path))
+
+    auth = AuthManager("default")
+    auth.save_profile(
+        cookies={"SID": "sid", "HSID": "hsid"},
+        email="user@example.com",
+        browser_backend="firefox_playwright",
+    )
+
+    profile = auth.load_profile(force_reload=True)
+    assert profile.browser_backend == "firefox_playwright"

--- a/tests/test_auth_migration.py
+++ b/tests/test_auth_migration.py
@@ -206,6 +206,70 @@ class TestBrowserDetection:
             "No user-local (AppData) entries found in Windows candidate list"
         )
 
+
+class TestCDPStartupHandling:
+    """Tests for CDP startup timing and diagnostics."""
+
+    def test_get_debugger_url_uses_ipv4_loopback(self):
+        """CDP version probe should use 127.0.0.1 consistently."""
+        from notebooklm_tools.utils.cdp import get_debugger_url
+
+        with patch("notebooklm_tools.utils.cdp.httpx_client.get") as mock_get:
+            mock_get.return_value.json.return_value = {
+                "webSocketDebuggerUrl": "ws://localhost:9222/devtools/browser/test"
+            }
+
+            url = get_debugger_url(9222)
+
+        mock_get.assert_called_once_with("http://127.0.0.1:9222/json/version", timeout=5)
+        assert url == "ws://127.0.0.1:9222/devtools/browser/test"
+
+    def test_extract_cookies_waits_longer_for_cdp_debugger(self):
+        """Slow browser startups should get a longer CDP wait window."""
+        from notebooklm_tools.utils.cdp import extract_cookies_via_cdp
+
+        with (
+            patch("notebooklm_tools.utils.cdp.find_existing_nlm_chrome", return_value=(None, None)),
+            patch("notebooklm_tools.utils.cdp.find_any_existing_cdp_browser", return_value=(None, None)),
+            patch("notebooklm_tools.utils.cdp.is_profile_locked", return_value=False),
+            patch("notebooklm_tools.utils.cdp.get_chrome_path", return_value="chromium"),
+            patch("notebooklm_tools.utils.cdp.find_available_port", return_value=9222),
+            patch("notebooklm_tools.utils.cdp.launch_chrome", return_value=True),
+            patch(
+                "notebooklm_tools.utils.cdp.get_debugger_url",
+                return_value="ws://127.0.0.1:9222/devtools/browser/test",
+            ) as mock_get_debugger_url,
+            patch(
+                "notebooklm_tools.utils.cdp.extract_cookies_from_page",
+                return_value={"cookies": [], "csrf_token": "", "session_id": "", "email": ""},
+            ),
+        ):
+            extract_cookies_via_cdp()
+
+        mock_get_debugger_url.assert_called_once_with(9222, tries=30)
+
+    def test_extract_cookies_reuses_single_existing_cdp_browser(self):
+        """A single reachable existing CDP browser should be reused."""
+        from notebooklm_tools.utils.cdp import extract_cookies_via_cdp
+
+        with (
+            patch("notebooklm_tools.utils.cdp.find_existing_nlm_chrome", return_value=(None, None)),
+            patch(
+                "notebooklm_tools.utils.cdp.find_any_existing_cdp_browser",
+                return_value=(9222, "ws://127.0.0.1:9222/devtools/browser/test"),
+            ),
+            patch("notebooklm_tools.utils.cdp.launch_chrome") as mock_launch_chrome,
+            patch(
+                "notebooklm_tools.utils.cdp.extract_cookies_from_page",
+                return_value={"cookies": [], "csrf_token": "", "session_id": "", "email": ""},
+            ) as mock_extract,
+        ):
+            result = extract_cookies_via_cdp()
+
+        mock_launch_chrome.assert_not_called()
+        mock_extract.assert_called_once_with("http://127.0.0.1:9222", True, 300)
+        assert result["reused_existing"] is True
+
     # ------------------------------------------------------------------
     # get_chrome_path — macOS
     # ------------------------------------------------------------------
@@ -412,6 +476,7 @@ class TestBrowserErrorMessages:
             patch("notebooklm_tools.utils.cdp.platform.system", return_value="Darwin"),
             patch("notebooklm_tools.utils.cdp.get_chrome_path", return_value=None),
             patch("notebooklm_tools.utils.cdp.find_existing_nlm_chrome", return_value=(None, None)),
+            patch("notebooklm_tools.utils.cdp.find_any_existing_cdp_browser", return_value=(None, None)),
             patch("notebooklm_tools.utils.cdp.is_profile_locked", return_value=False),
         ):
             with pytest.raises(AuthenticationError) as exc_info:
@@ -430,6 +495,7 @@ class TestBrowserErrorMessages:
             patch("notebooklm_tools.utils.cdp.platform.system", return_value="Linux"),
             patch("notebooklm_tools.utils.cdp.get_chrome_path", return_value=None),
             patch("notebooklm_tools.utils.cdp.find_existing_nlm_chrome", return_value=(None, None)),
+            patch("notebooklm_tools.utils.cdp.find_any_existing_cdp_browser", return_value=(None, None)),
             patch("notebooklm_tools.utils.cdp.is_profile_locked", return_value=False),
         ):
             with pytest.raises(AuthenticationError) as exc_info:
@@ -449,6 +515,7 @@ class TestBrowserErrorMessages:
             patch("notebooklm_tools.utils.cdp.platform.system", return_value="Windows"),
             patch("notebooklm_tools.utils.cdp.get_chrome_path", return_value=None),
             patch("notebooklm_tools.utils.cdp.find_existing_nlm_chrome", return_value=(None, None)),
+            patch("notebooklm_tools.utils.cdp.find_any_existing_cdp_browser", return_value=(None, None)),
             patch("notebooklm_tools.utils.cdp.is_profile_locked", return_value=False),
         ):
             with pytest.raises(AuthenticationError) as exc_info:
@@ -467,6 +534,7 @@ class TestBrowserErrorMessages:
         with (  # noqa: SIM117
             patch("notebooklm_tools.utils.cdp.get_chrome_path", return_value=None),
             patch("notebooklm_tools.utils.cdp.find_existing_nlm_chrome", return_value=(None, None)),
+            patch("notebooklm_tools.utils.cdp.find_any_existing_cdp_browser", return_value=(None, None)),
             patch("notebooklm_tools.utils.cdp.is_profile_locked", return_value=False),
         ):
             with pytest.raises(AuthenticationError) as exc_info:
@@ -481,6 +549,7 @@ class TestBrowserErrorMessages:
         with (  # noqa: SIM117
             patch("notebooklm_tools.utils.cdp.get_chrome_path", return_value=None),
             patch("notebooklm_tools.utils.cdp.find_existing_nlm_chrome", return_value=(None, None)),
+            patch("notebooklm_tools.utils.cdp.find_any_existing_cdp_browser", return_value=(None, None)),
             patch("notebooklm_tools.utils.cdp.is_profile_locked", return_value=False),
         ):
             with pytest.raises(AuthenticationError) as exc_info:
@@ -496,6 +565,7 @@ class TestBrowserErrorMessages:
         with (  # noqa: SIM117
             patch("notebooklm_tools.utils.cdp.get_chrome_path", return_value="/some/browser"),
             patch("notebooklm_tools.utils.cdp.find_existing_nlm_chrome", return_value=(None, None)),
+            patch("notebooklm_tools.utils.cdp.find_any_existing_cdp_browser", return_value=(None, None)),
             patch("notebooklm_tools.utils.cdp.is_profile_locked", return_value=False),
             patch("notebooklm_tools.utils.cdp.find_available_port", return_value=9222),
             patch("notebooklm_tools.utils.cdp.launch_chrome", return_value=False),

--- a/tests/test_auth_migration.py
+++ b/tests/test_auth_migration.py
@@ -230,7 +230,10 @@ class TestCDPStartupHandling:
 
         with (
             patch("notebooklm_tools.utils.cdp.find_existing_nlm_chrome", return_value=(None, None)),
-            patch("notebooklm_tools.utils.cdp.find_any_existing_cdp_browser", return_value=(None, None)),
+            patch(
+                "notebooklm_tools.utils.cdp.find_any_existing_cdp_browser",
+                return_value=(None, None),
+            ),
             patch("notebooklm_tools.utils.cdp.is_profile_locked", return_value=False),
             patch("notebooklm_tools.utils.cdp.get_chrome_path", return_value="chromium"),
             patch("notebooklm_tools.utils.cdp.find_available_port", return_value=9222),
@@ -476,7 +479,10 @@ class TestBrowserErrorMessages:
             patch("notebooklm_tools.utils.cdp.platform.system", return_value="Darwin"),
             patch("notebooklm_tools.utils.cdp.get_chrome_path", return_value=None),
             patch("notebooklm_tools.utils.cdp.find_existing_nlm_chrome", return_value=(None, None)),
-            patch("notebooklm_tools.utils.cdp.find_any_existing_cdp_browser", return_value=(None, None)),
+            patch(
+                "notebooklm_tools.utils.cdp.find_any_existing_cdp_browser",
+                return_value=(None, None),
+            ),
             patch("notebooklm_tools.utils.cdp.is_profile_locked", return_value=False),
         ):
             with pytest.raises(AuthenticationError) as exc_info:
@@ -495,7 +501,10 @@ class TestBrowserErrorMessages:
             patch("notebooklm_tools.utils.cdp.platform.system", return_value="Linux"),
             patch("notebooklm_tools.utils.cdp.get_chrome_path", return_value=None),
             patch("notebooklm_tools.utils.cdp.find_existing_nlm_chrome", return_value=(None, None)),
-            patch("notebooklm_tools.utils.cdp.find_any_existing_cdp_browser", return_value=(None, None)),
+            patch(
+                "notebooklm_tools.utils.cdp.find_any_existing_cdp_browser",
+                return_value=(None, None),
+            ),
             patch("notebooklm_tools.utils.cdp.is_profile_locked", return_value=False),
         ):
             with pytest.raises(AuthenticationError) as exc_info:
@@ -515,7 +524,10 @@ class TestBrowserErrorMessages:
             patch("notebooklm_tools.utils.cdp.platform.system", return_value="Windows"),
             patch("notebooklm_tools.utils.cdp.get_chrome_path", return_value=None),
             patch("notebooklm_tools.utils.cdp.find_existing_nlm_chrome", return_value=(None, None)),
-            patch("notebooklm_tools.utils.cdp.find_any_existing_cdp_browser", return_value=(None, None)),
+            patch(
+                "notebooklm_tools.utils.cdp.find_any_existing_cdp_browser",
+                return_value=(None, None),
+            ),
             patch("notebooklm_tools.utils.cdp.is_profile_locked", return_value=False),
         ):
             with pytest.raises(AuthenticationError) as exc_info:
@@ -534,7 +546,10 @@ class TestBrowserErrorMessages:
         with (  # noqa: SIM117
             patch("notebooklm_tools.utils.cdp.get_chrome_path", return_value=None),
             patch("notebooklm_tools.utils.cdp.find_existing_nlm_chrome", return_value=(None, None)),
-            patch("notebooklm_tools.utils.cdp.find_any_existing_cdp_browser", return_value=(None, None)),
+            patch(
+                "notebooklm_tools.utils.cdp.find_any_existing_cdp_browser",
+                return_value=(None, None),
+            ),
             patch("notebooklm_tools.utils.cdp.is_profile_locked", return_value=False),
         ):
             with pytest.raises(AuthenticationError) as exc_info:
@@ -549,7 +564,10 @@ class TestBrowserErrorMessages:
         with (  # noqa: SIM117
             patch("notebooklm_tools.utils.cdp.get_chrome_path", return_value=None),
             patch("notebooklm_tools.utils.cdp.find_existing_nlm_chrome", return_value=(None, None)),
-            patch("notebooklm_tools.utils.cdp.find_any_existing_cdp_browser", return_value=(None, None)),
+            patch(
+                "notebooklm_tools.utils.cdp.find_any_existing_cdp_browser",
+                return_value=(None, None),
+            ),
             patch("notebooklm_tools.utils.cdp.is_profile_locked", return_value=False),
         ):
             with pytest.raises(AuthenticationError) as exc_info:
@@ -565,7 +583,10 @@ class TestBrowserErrorMessages:
         with (  # noqa: SIM117
             patch("notebooklm_tools.utils.cdp.get_chrome_path", return_value="/some/browser"),
             patch("notebooklm_tools.utils.cdp.find_existing_nlm_chrome", return_value=(None, None)),
-            patch("notebooklm_tools.utils.cdp.find_any_existing_cdp_browser", return_value=(None, None)),
+            patch(
+                "notebooklm_tools.utils.cdp.find_any_existing_cdp_browser",
+                return_value=(None, None),
+            ),
             patch("notebooklm_tools.utils.cdp.is_profile_locked", return_value=False),
             patch("notebooklm_tools.utils.cdp.find_available_port", return_value=9222),
             patch("notebooklm_tools.utils.cdp.launch_chrome", return_value=False),


### PR DESCRIPTION
## Summary
- make Chromium/CDP auth more resilient by using IPv4 loopback consistently, waiting longer for CDP startup, and surfacing early browser startup errors
- reuse a single existing reachable CDP browser instead of trying to launch a conflicting second Chromium instance
- align auth selection, config text, docs, and tests with the actual Chromium-based login flow presented in main

## Testing
- uv run pytest tests/test_auth_migration.py tests/test_auth_browser.py tests/test_api_client.py