### PR TITLE
Fix: handle HTTP 400 as auth failure for CSRF token recovery

### DIFF
--- a/src/notebooklm_tools/cli/main.py
+++ b/src/notebooklm_tools/cli/main.py
@@ -185,6 +185,7 @@ def login_callback(
                 cookies=p.cookies,
                 csrf_token=p.csrf_token or "",
                 session_id=p.session_id or "",
+                build_label=p.build_label or "",
             ) as client:
                 notebooks = client.list_notebooks()
 

--- a/src/notebooklm_tools/core/base.py
+++ b/src/notebooklm_tools/core/base.py
@@ -670,8 +670,12 @@ class BaseClient:
                 # Exhausted retries, re-raise
                 raise
 
-            # Check for auth failures (401/403 HTTP)
-            is_http_auth = e.response.status_code in (401, 403)
+            # Check for auth failures (400/401/403 HTTP)
+            # 400 is included because Google returns "400 Bad Request" when
+            # the CSRF token (at= body param) is expired or invalid, rather
+            # than a 401/403.  Our Layer-1 recovery (_refresh_auth_tokens)
+            # re-extracts a fresh CSRF token from the page, which fixes this.
+            is_http_auth = e.response.status_code in (400, 401, 403)
             if not is_http_auth:
                 # Not a retryable or auth error, re-raise immediately
                 raise


### PR DESCRIPTION
## Problem

Google returns `400 Bad Request` when the CSRF token (`at=` body param) is expired or invalid, rather than `401`/`403`. The existing auth recovery logic in `_call_rpc()` only triggered for `401/403`, so a stale CSRF token produced a raw `HTTPStatusError` traceback instead of graceful auto-recovery.

## Root Cause

Reproduced with controlled tests:

| Test | CSRF | build_label | Result |
|------|------|-------------|--------|
| Bad CSRF, no bl | `STALE_TOKEN` | Missing (stale fallback) | **400 Bad Request** ❌ |
| Bad CSRF, correct bl | `STALE_TOKEN` | From profile | **400 Bad Request** ❌ |
| Empty CSRF (auto-refresh) | Auto-extracted | Auto-extracted | **SUCCESS** ✅ |

The 400 is caused by the invalid CSRF token, not the stale `bl`. The Layer-1 recovery (`_refresh_auth_tokens`) already handles this perfectly — it just never got a chance to run.

## Changes

### `src/notebooklm_tools/core/base.py`
- Add `400` to the auth-retry status codes in `_call_rpc()`
- Documented why: Google uses 400 for expired CSRF, our Layer-1 recovery fixes it

### `src/notebooklm_tools/cli/main.py`
- Pass `build_label` in `nlm login --check` client creation (was missing, causing unnecessary fallback to 3-month-stale `_BL_FALLBACK`)

## Verification

- Live smoke test: bad CSRF token now auto-recovers instead of crashing
- Full test suite: 754 passed, 37 skipped, 0 failures

Closes #147