### PR TITLE
fix(desktop-extension): keep Windows launcher stdio attached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **API `poll_studio_status` bypassing auth recovery** — The core `poll_studio_status` helper function was making raw HTTP calls and dodging the standard `_call_rpc` pipeline. This caused it to immediately fail on `400 Bad Request` exceptions whenever the user's `build_label` or session tokens went stale. The polling function now correctly wraps its logic in `_call_rpc`, securing free auth recovery loops, retries, and unified debug capability during studio polling.
+- **Windows Claude Desktop `.mcpb` launcher disconnect (Issue #150)** — The bundled `run_server.py` launcher now keeps the MCP stdio transport attached on Windows by spawning `uvx --from notebooklm-mcp-cli notebooklm-mcp` with inherited standard streams instead of replacing the Python process with `os.execvp()`. This prevents Claude Desktop from disconnecting immediately after startup.
 
 ## [0.5.21] - 2026-04-11
 

--- a/desktop-extension/run_server.py
+++ b/desktop-extension/run_server.py
@@ -12,6 +12,7 @@ Bundled inside the .mcpb extension and invoked via manifest.json:
 import os
 import platform
 import shutil
+import subprocess
 import sys
 
 
@@ -56,6 +57,25 @@ def _find_uvx() -> str | None:
     return None
 
 
+def _launch_server(uvx: str, args: list[str] | None = None) -> None:
+    """Launch the MCP server, preserving stdio for Claude Desktop."""
+    command = [uvx, "--from", "notebooklm-mcp-cli", "notebooklm-mcp", *(args or [])]
+
+    if platform.system() == "Windows":
+        # On Windows, replacing the current Python process can break the stdio
+        # handles Claude Desktop uses for the MCP transport.
+        result = subprocess.run(
+            command,
+            stdin=sys.stdin,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+            check=False,
+        )
+        sys.exit(result.returncode)
+
+    os.execvp(uvx, command)
+
+
 def main() -> None:
     """Find uvx and launch the NotebookLM MCP server."""
     uvx = _find_uvx()
@@ -70,8 +90,7 @@ def main() -> None:
         )
         sys.exit(1)
 
-    # Replace this process with the MCP server
-    os.execvp(uvx, [uvx, "--from", "notebooklm-mcp-cli", "notebooklm-mcp", *sys.argv[1:]])
+    _launch_server(uvx, sys.argv[1:])
 
 
 if __name__ == "__main__":

--- a/tests/test_run_server.py
+++ b/tests/test_run_server.py
@@ -1,0 +1,111 @@
+"""Tests for the desktop extension launcher."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+RUN_SERVER_PATH = Path(__file__).resolve().parents[1] / "desktop-extension" / "run_server.py"
+
+
+def load_run_server_module():
+    spec = importlib.util.spec_from_file_location("test_run_server_module", RUN_SERVER_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_find_uvx_checks_windows_install_locations(monkeypatch):
+    module = load_run_server_module()
+    expected = str(Path("/tmp/AppData/Local/uv/uvx.exe"))
+
+    monkeypatch.setattr(module.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(module.platform, "system", lambda: "Windows")
+    monkeypatch.setenv("LOCALAPPDATA", str(Path("/tmp/AppData/Local")))
+    monkeypatch.setattr(
+        module.os.path,
+        "expanduser",
+        lambda _value: str(Path("/tmp/home")),
+    )
+    monkeypatch.setattr(module.os.path, "isfile", lambda path: path == expected)
+    monkeypatch.setattr(module.os, "access", lambda path, mode: path == expected)
+
+    assert module._find_uvx() == expected
+
+
+def test_launch_server_execs_in_place_on_non_windows(monkeypatch):
+    module = load_run_server_module()
+    seen = {}
+
+    def fake_execvp(executable, argv):
+        seen["executable"] = executable
+        seen["argv"] = argv
+        raise RuntimeError("stop after execvp")
+
+    monkeypatch.setattr(module.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(module.os, "execvp", fake_execvp)
+
+    with pytest.raises(RuntimeError, match="stop after execvp"):
+        module._launch_server("/usr/local/bin/uvx", ["--transport", "stdio"])
+
+    assert seen == {
+        "executable": "/usr/local/bin/uvx",
+        "argv": [
+            "/usr/local/bin/uvx",
+            "--from",
+            "notebooklm-mcp-cli",
+            "notebooklm-mcp",
+            "--transport",
+            "stdio",
+        ],
+    }
+
+
+def test_launch_server_uses_subprocess_on_windows(monkeypatch):
+    module = load_run_server_module()
+    seen = {}
+
+    def fake_run(argv, **kwargs):
+        seen["argv"] = argv
+        seen["kwargs"] = kwargs
+        return SimpleNamespace(returncode=23)
+
+    monkeypatch.setattr(module.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit) as exc_info:
+        module._launch_server("C:/Users/test/AppData/Local/uv/uvx.exe", ["--transport", "stdio"])
+
+    assert exc_info.value.code == 23
+    assert seen["argv"] == [
+        "C:/Users/test/AppData/Local/uv/uvx.exe",
+        "--from",
+        "notebooklm-mcp-cli",
+        "notebooklm-mcp",
+        "--transport",
+        "stdio",
+    ]
+    assert seen["kwargs"] == {
+        "stdin": module.sys.stdin,
+        "stdout": module.sys.stdout,
+        "stderr": module.sys.stderr,
+        "check": False,
+    }
+
+
+def test_main_exits_with_helpful_error_when_uvx_missing(monkeypatch, capsys):
+    module = load_run_server_module()
+
+    monkeypatch.setattr(module, "_find_uvx", lambda: None)
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.main()
+
+    assert exc_info.value.code == 1
+    assert "Could not find 'uvx'" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- keep the bundled `.mcpb` launcher attached to Claude Desktop stdio on Windows
- preserve `os.execvp()` behavior on macOS/Linux
- add focused launcher tests and changelog coverage for issue #150

## Root cause
`desktop-extension/run_server.py` replaced the Python launcher process with `os.execvp(...)` on every platform. On Windows, that handoff can break the stdio handles Claude Desktop uses for the MCP transport, which matches the disconnect reported in #150.

## What changed
- add `_launch_server()` to isolate platform-specific launch behavior
- use `subprocess.run(..., stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr)` on Windows and exit with the child return code
- keep `execvp` on Unix-like platforms
- add a regression test file that loads the standalone launcher by path and covers Windows, non-Windows, and missing-`uvx` behavior
- document the fix in `CHANGELOG.md`

## Verification
- `uv run pytest tests/test_run_server.py tests/cli/test_setup_opencode.py`
- `uv run ruff check desktop-extension/run_server.py tests/test_run_server.py`
- `uv run python3 scripts/build_mcpb.py` (smoke check only; reverted generated manifest/artifact changes afterward)

## Notes
- I could not perform a live Windows 11 + Claude Desktop runtime validation from this macOS environment, so that final confirmation still needs a Windows repro environment.

Fixes #150