### PR TITLE
fix(studio): surface revise RPC errors with hints

### DIFF
--- a/src/notebooklm_tools/cli/commands/studio.py
+++ b/src/notebooklm_tools/cli/commands/studio.py
@@ -185,9 +185,7 @@ def studio_rename(
             result = studio_service.rename_artifact(client, artifact_id, new_title)
         console.print(f"[green]✓[/green] Renamed artifact to: {result['new_title']}")
     except (ValidationError, ServiceError) as e:
-        msg = e.user_message if isinstance(e, ServiceError) else str(e)
-        console.print(f"[red]Error:[/red] {msg}")
-        raise typer.Exit(1) from e
+        handle_error(e)
     except NLMError as e:
         handle_error(e, json_output=locals().get("json_output", False))
 
@@ -510,9 +508,7 @@ def revise_slides(
         console.print(f"  Original: {artifact_id}")
         console.print("\n[dim]Run 'nlm studio status <notebook-id>' to check progress.[/dim]")
     except (ValidationError, ServiceError) as e:
-        msg = e.user_message if isinstance(e, ServiceError) else str(e)
-        console.print(f"[red]Error:[/red] {msg}")
-        raise typer.Exit(1) from e
+        handle_error(e)
     except NLMError as e:
         handle_error(e, json_output=locals().get("json_output", False))
 

--- a/src/notebooklm_tools/cli/commands/studio.py
+++ b/src/notebooklm_tools/cli/commands/studio.py
@@ -187,7 +187,7 @@ def studio_rename(
     except (ValidationError, ServiceError) as e:
         handle_error(e)
     except NLMError as e:
-        handle_error(e, json_output=locals().get("json_output", False))
+        handle_error(e)
 
 
 # ========== Audio ==========
@@ -510,7 +510,7 @@ def revise_slides(
     except (ValidationError, ServiceError) as e:
         handle_error(e)
     except NLMError as e:
-        handle_error(e, json_output=locals().get("json_output", False))
+        handle_error(e)
 
 
 # ========== Infographic ==========

--- a/src/notebooklm_tools/core/studio.py
+++ b/src/notebooklm_tools/core/studio.py
@@ -605,7 +605,9 @@ class StudioMixin(BaseClient):
             artifact_data = result[0]
             if isinstance(artifact_data, list) and len(artifact_data) > 0:
                 new_artifact_id = artifact_data[0]
-                title = artifact_data[2] if len(artifact_data) > 2 else None
+                # Studio artifact payloads use index 1 for the title and index 2
+                # for the artifact type code. Reuse the same layout as status polling.
+                title = artifact_data[1] if len(artifact_data) > 1 else None
 
                 return {
                     "artifact_id": new_artifact_id,

--- a/src/notebooklm_tools/mcp/tools/studio.py
+++ b/src/notebooklm_tools/mcp/tools/studio.py
@@ -254,7 +254,7 @@ def studio_status(
         }
     except (ValidationError, ServiceError) as e:
         message = e.user_message if isinstance(e, ServiceError) else str(e)
-        return error_result(message)
+        return error_result(message, hint=getattr(e, "hint", None))
     except Exception as e:
         return error_result(str(e))
 
@@ -362,6 +362,6 @@ def studio_revise(
         }
     except (ValidationError, ServiceError) as e:
         message = e.user_message if isinstance(e, ServiceError) else str(e)
-        return error_result(message)
+        return error_result(message, hint=getattr(e, "hint", None))
     except Exception as e:
         return error_result(str(e))

--- a/src/notebooklm_tools/services/studio.py
+++ b/src/notebooklm_tools/services/studio.py
@@ -16,6 +16,7 @@ from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, TypedDict
 
 from notebooklm_tools.core import constants
+from notebooklm_tools.core.errors import RPCError
 
 from .errors import ServiceError, ValidationError
 
@@ -749,6 +750,17 @@ def revise_artifact(
             artifact_id=artifact_id,
             slide_instructions=converted,
         )
+    except RPCError as e:
+        short_detail = e.detail_type.rsplit(".", 1)[-1] if e.detail_type else ""
+        detail_suffix = f" ({short_detail})" if short_detail else ""
+        raise ServiceError(
+            f"Failed to revise slide deck: {e}{detail_suffix}",
+            user_message=f"Failed to revise slide deck — {e}{detail_suffix}.",
+            hint=(
+                "Verify the artifact_id points to a completed slide deck and retry. "
+                "If it still fails, NotebookLM is rejecting the revision request."
+            ),
+        ) from e
     except Exception as e:
         raise ServiceError(
             f"Failed to revise slide deck: {e}",

--- a/src/notebooklm_tools/services/studio.py
+++ b/src/notebooklm_tools/services/studio.py
@@ -752,10 +752,12 @@ def revise_artifact(
         )
     except RPCError as e:
         short_detail = e.detail_type.rsplit(".", 1)[-1] if e.detail_type else ""
-        detail_suffix = f" ({short_detail})" if short_detail else ""
+        formatted_error = (
+            f"Google API error code {e.error_code} ({short_detail})" if short_detail else str(e)
+        )
         raise ServiceError(
-            f"Failed to revise slide deck: {e}{detail_suffix}",
-            user_message=f"Failed to revise slide deck — {e}{detail_suffix}.",
+            f"Failed to revise slide deck: {formatted_error}",
+            user_message=f"Failed to revise slide deck — {formatted_error}.",
             hint=(
                 "Verify the artifact_id points to a completed slide deck and retry. "
                 "If it still fails, NotebookLM is rejecting the revision request."

--- a/src/notebooklm_tools/services/studio.py
+++ b/src/notebooklm_tools/services/studio.py
@@ -755,13 +755,20 @@ def revise_artifact(
         formatted_error = (
             f"Google API error code {e.error_code} ({short_detail})" if short_detail else str(e)
         )
+        if e.error_code == 7:
+            hint = (
+                "Verify the artifact_id points to a completed slide deck in an editable "
+                "notebook you own. NotebookLM rejects revisions for view-only/shared decks."
+            )
+        else:
+            hint = (
+                "Verify the artifact_id points to a completed slide deck and retry. "
+                "If it still fails, NotebookLM is rejecting the revision request."
+            )
         raise ServiceError(
             f"Failed to revise slide deck: {formatted_error}",
             user_message=f"Failed to revise slide deck — {formatted_error}.",
-            hint=(
-                "Verify the artifact_id points to a completed slide deck and retry. "
-                "If it still fails, NotebookLM is rejecting the revision request."
-            ),
+            hint=hint,
         ) from e
     except Exception as e:
         raise ServiceError(

--- a/tests/cli/test_studio_cli.py
+++ b/tests/cli/test_studio_cli.py
@@ -29,7 +29,10 @@ def test_slides_revise_surfaces_service_hint(runner):
             side_effect=ServiceError(
                 "backend rejected revision",
                 user_message="Failed to revise slide deck — Google API error code 7 (PERMISSION_DENIED).",
-                hint="Verify the artifact_id points to a completed slide deck and retry.",
+                hint=(
+                    "Verify the artifact_id points to a completed slide deck in an editable "
+                    "notebook you own. NotebookLM rejects revisions for view-only/shared decks."
+                ),
             ),
         ),
     ):
@@ -47,4 +50,5 @@ def test_slides_revise_surfaces_service_hint(runner):
     assert result.exit_code == 1
     assert "PERMISSION_DENIED" in result.output
     assert "Hint:" in result.output
-    assert "artifact_id points to a completed slide deck" in result.output
+    assert "editable" in result.output
+    assert "notebook you own" in result.output

--- a/tests/cli/test_studio_cli.py
+++ b/tests/cli/test_studio_cli.py
@@ -1,0 +1,50 @@
+"""Tests for the `nlm slides revise` CLI command."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from notebooklm_tools.cli.commands.studio import slides_app
+from notebooklm_tools.services.errors import ServiceError
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def test_slides_revise_surfaces_service_hint(runner):
+    mock_client = MagicMock()
+    mock_client.__enter__ = lambda s: s
+    mock_client.__exit__ = MagicMock(return_value=False)
+    alias_mgr = MagicMock()
+    alias_mgr.resolve.side_effect = lambda x: x
+
+    with (
+        patch("notebooklm_tools.cli.commands.studio.get_alias_manager", return_value=alias_mgr),
+        patch("notebooklm_tools.cli.commands.studio.get_client", return_value=mock_client),
+        patch(
+            "notebooklm_tools.cli.commands.studio.studio_service.revise_artifact",
+            side_effect=ServiceError(
+                "backend rejected revision",
+                user_message="Failed to revise slide deck — Google API error code 7 (PERMISSION_DENIED).",
+                hint="Verify the artifact_id points to a completed slide deck and retry.",
+            ),
+        ),
+    ):
+        result = runner.invoke(
+            slides_app,
+            [
+                "revise",
+                "art-1",
+                "--slide",
+                "1 Tighten the title",
+                "--confirm",
+            ],
+        )
+
+    assert result.exit_code == 1
+    assert "PERMISSION_DENIED" in result.output
+    assert "Hint:" in result.output
+    assert "artifact_id points to a completed slide deck" in result.output

--- a/tests/core/test_studio.py
+++ b/tests/core/test_studio.py
@@ -245,7 +245,7 @@ class TestStudioMixinMethods:
 
     def test_revise_slide_deck_uses_normalized_failed_status(self):
         mixin = StudioMixin(cookies={"test": "cookie"}, csrf_token="test")
-        mixin._call_rpc = MagicMock(return_value=[["art-2", None, "Revised Deck", None, 4]])
+        mixin._call_rpc = MagicMock(return_value=[["art-2", "Revised Deck", 8, None, 4]])
 
         result = mixin.revise_slide_deck("art-1", [(0, "Tighten slide title")])
 

--- a/tests/core/test_studio.py
+++ b/tests/core/test_studio.py
@@ -242,6 +242,7 @@ class TestStudioMixinMethods:
 
         assert result["artifact_id"] is None
         assert result["status"] == "unknown"
+
     def test_revise_slide_deck_uses_normalized_failed_status(self):
         mixin = StudioMixin(cookies={"test": "cookie"}, csrf_token="test")
         mixin._call_rpc = MagicMock(return_value=[["art-2", None, "Revised Deck", None, 4]])

--- a/tests/core/test_studio.py
+++ b/tests/core/test_studio.py
@@ -242,7 +242,6 @@ class TestStudioMixinMethods:
 
         assert result["artifact_id"] is None
         assert result["status"] == "unknown"
-
     def test_revise_slide_deck_uses_normalized_failed_status(self):
         mixin = StudioMixin(cookies={"test": "cookie"}, csrf_token="test")
         mixin._call_rpc = MagicMock(return_value=[["art-2", None, "Revised Deck", None, 4]])

--- a/tests/services/test_studio.py
+++ b/tests/services/test_studio.py
@@ -293,7 +293,7 @@ class TestGetStudioStatus:
 class TestReviseArtifact:
     """Test revise_artifact function."""
 
-    def test_rpc_error_preserves_structured_detail_and_hint(self, mock_client):
+    def test_rpc_error_uses_short_detail_name_and_hint(self, mock_client):
         mock_client.revise_slide_deck.side_effect = RPCError(
             "API error (code 7): PERMISSION_DENIED",
             error_code=7,
@@ -309,11 +309,29 @@ class TestReviseArtifact:
             )
 
         err = exc_info.value
-        assert "PERMISSION_DENIED" in err.user_message
+        assert "Google API error code 7" in err.user_message
         assert "code 7" in err.user_message
         assert "ReviseSlideDeckErrorDetail" in err.user_message
+        assert "type.googleapis.com" not in err.user_message
         assert err.hint is not None
         assert "artifact_id" in err.hint
+
+    def test_rpc_error_without_detail_type_preserves_original_message(self, mock_client):
+        mock_client.revise_slide_deck.side_effect = RPCError(
+            "API error (code 7): PERMISSION_DENIED",
+            error_code=7,
+        )
+
+        with pytest.raises(ServiceError) as exc_info:
+            revise_artifact(
+                mock_client,
+                "art-123",
+                [{"slide": 1, "instruction": "Tighten the title"}],
+            )
+
+        err = exc_info.value
+        assert "PERMISSION_DENIED" in err.user_message
+        assert err.hint is not None
 
 
 class TestRenameArtifact:

--- a/tests/services/test_studio.py
+++ b/tests/services/test_studio.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from notebooklm_tools.core.errors import RPCError
 from notebooklm_tools.services.errors import ServiceError, ValidationError
 from notebooklm_tools.services.studio import (
     VALID_ARTIFACT_TYPES,
@@ -14,6 +15,7 @@ from notebooklm_tools.services.studio import (
     get_studio_status,
     rename_artifact,
     resolve_code,
+    revise_artifact,
     validate_artifact_type,
 )
 
@@ -286,6 +288,32 @@ class TestGetStudioStatus:
         mock_client.poll_studio_status.side_effect = RuntimeError("fail")
         with pytest.raises(ServiceError, match="Failed to poll"):
             get_studio_status(mock_client, "nb-1")
+
+
+class TestReviseArtifact:
+    """Test revise_artifact function."""
+
+    def test_rpc_error_preserves_structured_detail_and_hint(self, mock_client):
+        mock_client.revise_slide_deck.side_effect = RPCError(
+            "API error (code 7): PERMISSION_DENIED",
+            error_code=7,
+            detail_type="type.googleapis.com/notebooklm.ReviseSlideDeckErrorDetail",
+            detail_data=[1],
+        )
+
+        with pytest.raises(ServiceError) as exc_info:
+            revise_artifact(
+                mock_client,
+                "art-123",
+                [{"slide": 1, "instruction": "Tighten the title"}],
+            )
+
+        err = exc_info.value
+        assert "PERMISSION_DENIED" in err.user_message
+        assert "code 7" in err.user_message
+        assert "ReviseSlideDeckErrorDetail" in err.user_message
+        assert err.hint is not None
+        assert "artifact_id" in err.hint
 
 
 class TestRenameArtifact:

--- a/tests/services/test_studio.py
+++ b/tests/services/test_studio.py
@@ -314,7 +314,8 @@ class TestReviseArtifact:
         assert "ReviseSlideDeckErrorDetail" in err.user_message
         assert "type.googleapis.com" not in err.user_message
         assert err.hint is not None
-        assert "artifact_id" in err.hint
+        assert "editable notebook you own" in err.hint
+        assert "view-only/shared decks" in err.hint
 
     def test_rpc_error_without_detail_type_preserves_original_message(self, mock_client):
         mock_client.revise_slide_deck.side_effect = RPCError(
@@ -332,6 +333,7 @@ class TestReviseArtifact:
         err = exc_info.value
         assert "PERMISSION_DENIED" in err.user_message
         assert err.hint is not None
+        assert "editable notebook you own" in err.hint
 
 
 class TestRenameArtifact:

--- a/tests/test_mcp_studio.py
+++ b/tests/test_mcp_studio.py
@@ -16,7 +16,10 @@ def test_studio_revise_preserves_hint_on_service_error():
             side_effect=ServiceError(
                 "backend rejected revision",
                 user_message="Failed to revise slide deck — Google API error code 7 (PERMISSION_DENIED).",
-                hint="Verify the artifact_id points to a completed slide deck and retry.",
+                hint=(
+                    "Verify the artifact_id points to a completed slide deck in an editable "
+                    "notebook you own. NotebookLM rejects revisions for view-only/shared decks."
+                ),
             ),
         ),
     ):
@@ -29,4 +32,4 @@ def test_studio_revise_preserves_hint_on_service_error():
 
     assert result["status"] == "error"
     assert "PERMISSION_DENIED" in result["error"]
-    assert result["hint"] == "Verify the artifact_id points to a completed slide deck and retry."
+    assert "editable notebook you own" in result["hint"]

--- a/tests/test_mcp_studio.py
+++ b/tests/test_mcp_studio.py
@@ -1,0 +1,32 @@
+"""Unit tests for MCP studio tools."""
+
+from unittest.mock import MagicMock, patch
+
+from notebooklm_tools.mcp.tools import studio
+from notebooklm_tools.services.errors import ServiceError
+
+
+def test_studio_revise_preserves_hint_on_service_error():
+    mock_client = MagicMock()
+
+    with (
+        patch("notebooklm_tools.mcp.tools.studio.get_client", return_value=mock_client),
+        patch(
+            "notebooklm_tools.mcp.tools.studio.studio_service.revise_artifact",
+            side_effect=ServiceError(
+                "backend rejected revision",
+                user_message="Failed to revise slide deck — Google API error code 7 (PERMISSION_DENIED).",
+                hint="Verify the artifact_id points to a completed slide deck and retry.",
+            ),
+        ),
+    ):
+        result = studio.studio_revise(
+            notebook_id="nb-1",
+            artifact_id="art-1",
+            slide_instructions=[{"slide": 1, "instruction": "Tighten the title"}],
+            confirm=True,
+        )
+
+    assert result["status"] == "error"
+    assert "PERMISSION_DENIED" in result["error"]
+    assert result["hint"] == "Verify the artifact_id points to a completed slide deck and retry."


### PR DESCRIPTION
## Summary
This patch hardens `studio_revise` / `nlm slides revise` error handling so structured NotebookLM RPC failures are preserved instead of being collapsed into the generic `Could not revise slide deck.` message.

This is a diagnosability fix, not a claim that NotebookLM's backend revise endpoint now succeeds live.

## Before
Live revise failures surfaced as a generic error:
- CLI: `Error: Could not revise slide deck.`
- MCP: `{ "status": "error", "error": "Could not revise slide deck." }`

That discarded the structured RPC detail returned by NotebookLM.

## After
Structured RPC failures are preserved through the service, CLI, and MCP layers.

Example live output now:
- CLI: `Failed to revise slide deck — API error (code 7): PERMISSION_DENIED.`
- CLI hint: `Verify the artifact_id points to a completed slide deck and retry. If it still fails, NotebookLM is rejecting the revision request.`
- MCP: `{"status":"error","error":"Failed to revise slide deck — API error (code 7): PERMISSION_DENIED.","hint":"..."}`

## Exact live repro
CLI:
```bash
HOME=/tmp/nlm-manual-qAbPCF/home NOTEBOOKLM_MCP_CLI_PATH=/tmp/nlm-manual-qAbPCF/storage NLM_PROFILE=eval \
uv run nlm slides revise 7391095d-32a3-4b21-bf85-130068311da1 --slide '1 Shorten the title slightly' -y
```

MCP:
```python
from notebooklm_tools.mcp.tools import studio
studio.studio_revise(
    notebook_id='4085e211-fdb0-4802-b973-b43b9f99b6f7',
    artifact_id='7391095d-32a3-4b21-bf85-130068311da1',
    slide_instructions=[{'slide': 1, 'instruction': 'Shorten the title slightly'}],
    confirm=True,
)
```

## What changed
- Catch `RPCError` explicitly in `services.studio.revise_artifact()` and convert it into a richer `ServiceError` with preserved code/detail plus hint.
- Preserve `hint` in the MCP `studio_revise` error payload.
- Route CLI `slides revise` service failures through the shared CLI error handler so hints are rendered consistently.
- Add regression coverage for the service, MCP, and CLI layers.

## Verification
Automated:
- `uv run --dev pytest tests/services/test_studio.py tests/core/test_studio.py tests/test_mcp_studio.py tests/cli/test_studio_cli.py -v`
- `uv run --dev --with pytest-asyncio pytest -v --tb=short -m 'not e2e'`
- `uv run --dev ruff check .`
- `uv run --dev ruff format --check .`

Live:
- CLI repro now shows `PERMISSION_DENIED` plus a hint instead of the generic message.
- MCP repro now returns the structured error plus `hint` instead of the generic message.
