### PR TITLE
fix: WSL2 auth broken on Chrome 136+ (localhost-only CDP)

### DIFF
--- a/docs/WSL_SETUP.md
+++ b/docs/WSL_SETUP.md
@@ -23,16 +23,26 @@ NotebookLM MCP now includes WSL2-aware authentication that:
 
 ### Chrome Remote Debugging Address
 
-The `--wsl` flag launches Chrome with `--remote-debugging-address=0.0.0.0`, which
-binds the DevTools Protocol to all network interfaces (not just localhost). This
-is necessary because WSL2 uses a virtual network bridge, and connections from
-WSL to Windows must traverse this virtual network.
+Chrome (v136+) ignores `--remote-debugging-address=0.0.0.0` and binds the
+DevTools Protocol to `127.0.0.1` only. Since WSL2 uses a virtual network
+bridge, a **netsh port proxy** is required to forward traffic from the WSL
+virtual network to Chrome's localhost listener.
+
+The `--wsl` flag launches Chrome on port **9223** (localhost) and connects
+via port **9222** (the proxy port accessible from WSL).
+
+**One-time setup** (run in an elevated PowerShell):
+```powershell
+netsh interface portproxy add v4tov4 listenport=9222 listenaddress=0.0.0.0 connectport=9223 connectaddress=127.0.0.1
+```
 
 **Mitigations in place:**
 - **Windows Firewall**: Only connections from `LocalSubnet` (WSL virtual network)
   are allowed to reach port 9222
+- **Port proxy**: Only forwards to localhost:9223; Chrome is never exposed
+  directly on the network
 - **Temporary profiles**: Each Chrome instance uses a fresh, isolated profile
-  that is cleaned up after authentication
+  on the Windows filesystem that is cleaned up after authentication
 - **Short-lived**: Remote debugging is only active during the explicit `nlm login --wsl`
   command and terminated immediately after
 - **No external exposure**: The Windows Firewall rule prevents connections from
@@ -53,7 +63,23 @@ Download: https://www.google.com/chrome/
 
 **Important:** Before running `nlm login --wsl`, **close all Chrome windows** on Windows. Chrome's remote debugging requires a fresh instance.
 
-### 2. Authenticate
+### 2. Set up the port proxy (one-time)
+
+Chrome (v136+) only binds its debug port to localhost, so a Windows port proxy
+is needed to make it reachable from WSL.
+
+Run in an **elevated PowerShell** (Run as Administrator):
+
+```powershell
+netsh interface portproxy add v4tov4 listenport=9222 listenaddress=0.0.0.0 connectport=9223 connectaddress=127.0.0.1
+```
+
+This persists across reboots. Verify with:
+```powershell
+netsh interface portproxy show v4tov4
+```
+
+### 3. Authenticate
 
 ```bash
 nlm login --wsl
@@ -62,14 +88,15 @@ nlm login --wsl
 This will:
 - Detect your Windows IP address from WSL
 - **Check Windows Firewall setup** (prompts with instructions)
-- Launch Chrome on Windows with remote debugging
+- Launch Chrome on Windows on port 9223 with remote debugging
+- Connect via the port proxy on port 9222
 - Open NotebookLM in Chrome
 - Wait for you to log in
 - Extract cookies automatically
 - Close Chrome
 - Save credentials to your profile
 
-### 3. Verify
+### 4. Verify
 
 ```bash
 nlm login --check
@@ -82,13 +109,14 @@ When you run `nlm login --wsl`:
 
 ```
 WSL Terminal
-    ↓  detects Windows host IP (from /etc/resolv.conf)
+    ↓  detects Windows host IP (from default gateway)
     ↓  launches /mnt/c/Program Files/Google/Chrome/Application/chrome.exe
 Windows Chrome
-    ↓  starts on 127.0.0.1:9222 (Windows side)
-    ↓  port accessible from WSL via Windows host IP
+    ↓  starts on 127.0.0.1:9223 (Windows side, localhost only)
+netsh portproxy
+    ↓  forwards 0.0.0.0:9222 → 127.0.0.1:9223
 WSL Auth Script
-    ↓  connects to http://172.x.x.x:9222
+    ↓  connects to http://172.x.x.x:9222 (via port proxy)
     ↓  opens notebooklm.google.com tab
     ↓  waits for login
     ↓  extracts cookies via CDP

--- a/src/notebooklm_tools/cli/main.py
+++ b/src/notebooklm_tools/cli/main.py
@@ -268,6 +268,12 @@ def login_callback(
                 from notebooklm_tools.utils.wsl import DEFAULT_WSL_CDP_PORT
 
                 wsl_port = DEFAULT_WSL_CDP_PORT
+                # Chrome binds to localhost only (newer Chrome ignores
+                # --remote-debugging-address=0.0.0.0), so we launch it
+                # on a different port and rely on a netsh portproxy rule
+                # (listenport=wsl_port -> connectport=chrome_port) to
+                # bridge WSL traffic to localhost.
+                chrome_port = wsl_port + 1
                 windows_ip = get_windows_host_ip()
 
                 if not windows_ip:
@@ -278,8 +284,8 @@ def login_callback(
                 wsl_cdp_url = f"http://{windows_ip}:{wsl_port}"
 
                 console.print("[bold]WSL2 detected - launching Windows Chrome[/bold]")
-                console.print(f"[dim]Windows host: {windows_ip}:{wsl_port}[/dim]")
-                console.print("[dim]Chrome will bind to 0.0.0.0 to allow WSL connections[/dim]")
+                console.print(f"[dim]Windows host: {windows_ip}:{wsl_port} (proxy) -> localhost:{chrome_port} (Chrome)[/dim]")
+                console.print("[dim]Chrome binds to localhost; netsh portproxy bridges WSL[/dim]")
 
                 # Check Windows Firewall
 
@@ -314,7 +320,7 @@ def login_callback(
                 console.print()
 
                 try:
-                    chrome_process = launch_windows_chrome(wsl_port)
+                    chrome_process = launch_windows_chrome(chrome_port)
                     console.print(f"[dim]Chrome PID: {chrome_process.pid}[/dim]")
                 except RuntimeError as e:
                     console.print(f"[red]Error:[/red] {e}")

--- a/src/notebooklm_tools/utils/wsl.py
+++ b/src/notebooklm_tools/utils/wsl.py
@@ -211,21 +211,42 @@ def launch_windows_chrome(
     # C:\Program Files\... -> /mnt/c/Program Files/...
     wsl_chrome = Path("/mnt/c") / chrome_path[3:].replace("\\", "/")
 
-    # Create a temp profile directory for clean Chrome instance
+    # Create a temp profile directory on the WINDOWS filesystem.
+    # Using WSL's /tmp causes "Profile error occurred" because Chrome
+    # struggles with UNC paths (\\wsl.localhost\...) for its profile dir.
     import tempfile
 
-    temp_dir = tempfile.mkdtemp(prefix="nlm-chrome-")
-    windows_temp = subprocess.run(
-        ["wslpath", "-w", temp_dir],
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout.strip()
+    try:
+        win_temp_base = subprocess.run(
+            ["powershell.exe", "-Command", "echo $env:TEMP"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        # Create a unique subdir name
+        import uuid
+
+        windows_temp = f"{win_temp_base}\\nlm-chrome-{uuid.uuid4().hex[:8]}"
+        # Convert to WSL path for cleanup tracking
+        temp_dir = subprocess.run(
+            ["wslpath", "-u", windows_temp],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    except Exception:
+        # Fallback to WSL temp (may cause profile error but won't crash)
+        temp_dir = tempfile.mkdtemp(prefix="nlm-chrome-")
+        windows_temp = subprocess.run(
+            ["wslpath", "-w", temp_dir],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
 
     args = [
         str(wsl_chrome),
         f"--remote-debugging-port={port}",
-        "--remote-debugging-address=0.0.0.0",
         f"--user-data-dir={windows_temp}",  # CRITICAL: Fresh profile for separate instance
         "--no-first-run",
         "--no-default-browser-check",


### PR DESCRIPTION
## Summary

`nlm login --wsl` fails on Chrome 136+ because:

1. **Chrome ignores `--remote-debugging-address=0.0.0.0`** — newer Chrome restricts the DevTools Protocol to `127.0.0.1` only, so WSL2 cannot reach it across the virtual network bridge.
2. **Temp profile created on WSL filesystem** — Chrome gets a `--user-data-dir=\\wsl.localhost\...\tmp\...` UNC path, which causes "Profile error occurred" on launch.

### Changes

- **Port proxy approach**: Launch Chrome on port 9223 (localhost), connect from WSL via port 9222 through a `netsh interface portproxy` rule. This avoids relying on `--remote-debugging-address=0.0.0.0`.
- **Windows-native temp profiles**: Create temp Chrome profiles in `%TEMP%` on the Windows filesystem instead of WSL's `/tmp`.
- **Removed `--remote-debugging-address=0.0.0.0`**: No longer needed or effective.
- **Updated `docs/WSL_SETUP.md`**: Documents the one-time port proxy setup, revised security section, and updated architecture diagram.

### One-time user setup required

Users need to run this once in an elevated PowerShell:

```powershell
netsh interface portproxy add v4tov4 listenport=9222 listenaddress=0.0.0.0 connectport=9223 connectaddress=127.0.0.1
```

The existing firewall rule (`NotebookLM-CDP-9222`) continues to work as-is.

## Test plan

- [x] Tested `nlm login --wsl` on WSL2 (Ubuntu 24.04) with Chrome 146
- [x] Verified CDP connection works through the port proxy
- [x] Verified `nlm login --check` passes after authentication
- [x] Confirmed no "Profile error occurred" with Windows-native temp dir
- [x] Confirmed temp profile cleanup works

🤖 Generated with [Claude Code](https://claude.com/claude-code)