### PR TITLE
fix(cdp): explicitly disable proxies for localhost CDP connections

### DIFF
--- a/src/notebooklm_tools/utils/cdp.py
+++ b/src/notebooklm_tools/utils/cdp.py
@@ -696,13 +696,27 @@ def execute_cdp_command(
             _cached_ws.close()
             _cached_ws = None
 
+        # Explicitly disable proxies for localhost CDP connections (Issue #119)
+        proxy_args = {
+            "http_proxy_host": None,
+            "http_proxy_port": None,
+        }
         # suppress_origin=True is required for some managed Chrome/CDP endpoints
         # (e.g. OpenClaw browser profile) that reject default Origin headers.
         try:
-            ws = websocket.create_connection(ws_url, timeout=30, suppress_origin=True)
+            ws = websocket.create_connection(
+                ws_url,
+                timeout=30,
+                suppress_origin=True,
+                **proxy_args
+            )
         except TypeError:
             # Older websocket-client versions may not support suppress_origin.
-            ws = websocket.create_connection(ws_url, timeout=30)
+            ws = websocket.create_connection(
+                ws_url,
+                timeout=30,
+                **proxy_args
+            )
         _cached_ws = ws
         _cached_ws_url = ws_url
     else:


### PR DESCRIPTION
Hi there!
I’ve been using this tool and am happy to contribute back to it. While using a proxy (like Clash/Surge), I encountered a WebSocketConnectionClosedException during nlm login. After some investigation, I found that the websocket-client library was trying to route local Chrome DevTools traffic (127.0.0.1) through my external proxy, causing the connection to drop.
I've added this fix to help anyone else facing the same problem!
Problem
When system proxy environment variables (like HTTP_PROXY or HTTPS_PROXY) are set, the WebSocket connection used for cookie extraction via CDP fails. This is because the library respects those variables even for localhost connections, which should always be direct.
The Fix
Updated execute_cdp_command in notebooklm_tools/utils/cdp.py to explicitly disable proxies for these connections.
*  Change: Passed http_proxy_host=None and http_proxy_port=None to websocket.create_connection.
*  Impact: This ensures the tool always connects directly to the local browser instance, ignoring any system-wide proxy settings.
Why this is safe:
*  For Proxy Users: Fixes the immediate connection crash.
*  For Non-Proxy Users: No change in behavior. It simply makes the "direct connection" (which they are already using) the explicit default for this specific function.
*  Localhost only: Since CDP traffic is strictly between the CLI and the local browser, there is never a need for an external proxy.
Verification
*  Ran nlm login with active proxy environment variables (Success).
*  Verified via pytest tests/test_auth_browser.py (All 6 tests passed).
---
Tip: If you are submitting this on GitHub, you can mention that this completes the logic started in Issue #119 (which fixed this for HTTP but missed the WebSockets).