### PR TITLE
docs(readme): fix outdated 'nlm skill install codex' -> 'nlm skill install agents'

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ Install the NotebookLM expert guide for your AI assistant to help it use the too
 # Install skill files
 nlm skill install cline
 nlm skill install openclaw
-nlm skill install codex
+nlm skill install agents    # covers Codex and any tool reading .agents/skills/
 nlm skill install antigravity
 
 # Update skills


### PR DESCRIPTION
## Summary

Per #163, the README's Install block still tells users to run \`nlm skill install codex\`. The current CLI rejects that with:

\`\`\`
Error: Unknown tool 'codex'
Valid tools: claude-code, cursor, agents, opencode, antigravity, cline, openclaw, alef-agent, other
\`\`\`

The project's own CHANGELOG (line 249) already documents that \`nlm skill install codex\` was replaced by \`nlm skill install agents\`, which installs to \`~/.agents/skills/nlm-skill/\` — covering Codex and any other tool that reads \`.agents/skills/\`. Updated the Install block to reflect that.

Closes #163

## Testing

Single-line README change. Kept the \`cline\`, \`openclaw\`, \`antigravity\` installs since those are still valid target names per the error output.