### PR TITLE
fix(wsl): handle non-UTF-8 output from PowerShell in firewall check

### DIFF
--- a/src/notebooklm_tools/utils/wsl.py
+++ b/src/notebooklm_tools/utils/wsl.py
@@ -425,6 +425,7 @@ def check_firewall_rule(port: int = DEFAULT_WSL_CDP_PORT) -> bool:
             [str(ps_path), "-Command", check_cmd],
             capture_output=True,
             text=True,
+            errors="replace",
         )
         exists = result.returncode == 0 and result.stdout.strip()
         logger.debug(f"Firewall rule check for port {port}: {exists}")


### PR DESCRIPTION
## Problem

`check_firewall_rule()` calls PowerShell via `subprocess.run(text=True)` without
specifying an encoding. Python defaults to UTF-8, but PowerShell on Windows commonly
returns output in UTF-16-LE, which causes a decode error:

```
Failed to check firewall rule: 'utf-8' codec can't decode byte 0x88 in position 667: invalid start byte
```

The exception is caught and the function returns `False`, so `nlm login --wsl` shows
the firewall setup warning and aborts — even when the rule already exists.

## Fix

Add `errors="replace"` to the `subprocess.run` call. This tolerates the encoding
mismatch by substituting undecodable bytes with `?` instead of raising an exception.

`encoding="utf-16"` was not used because PowerShell output encoding can vary across
Windows versions and configurations. Since `check_firewall_rule` only checks
`returncode == 0 and stdout.strip()`, the exact text content doesn't matter — it just
needs to not crash.

## Tested on

- WSL2 / Ubuntu 24.04 on Windows 11
- notebooklm-mcp-cli v0.5.28