### PR TITLE
fix: parse URL hostname in is_logged_in to avoid post-signin login timeout

### DIFF
--- a/src/notebooklm_tools/utils/cdp.py
+++ b/src/notebooklm_tools/utils/cdp.py
@@ -813,11 +813,18 @@ def _is_notebooklm_url(url: str) -> bool:
 
 
 def is_logged_in(url: str) -> bool:
-    """Check login status by URL.
+    """Check login status by parsed URL hostname.
 
-    If NotebookLM redirects to accounts.google.com, user is not logged in.
+    Inspect the parsed hostname so query strings such as
+    ``?original_referer=https://accounts.google.com#`` (which NotebookLM
+    appends to the redirect target right after Google sign-in) are not
+    mistaken for an accounts.google.com redirect.
     """
-    if "accounts.google.com" in url:
+    try:
+        host = (urlparse(url).hostname or "").lower()
+    except Exception:
+        return False
+    if host == "accounts.google.com" or host.endswith(".accounts.google.com"):
         return False
     return _is_notebooklm_url(url)
 

--- a/tests/test_cdp_url_check.py
+++ b/tests/test_cdp_url_check.py
@@ -1,0 +1,52 @@
+"""Regression tests for ``is_logged_in()`` URL detection.
+
+Background: ``is_logged_in(url)`` previously used a substring match
+(``if "accounts.google.com" in url``) against the full URL string. After
+Google sign-in, NotebookLM appends ``?original_referer=https://accounts.google.com#``
+to the redirect target, which caused the substring check to fire and
+report "not logged in" -- making ``nlm login`` time out after 5 minutes
+even though the browser was fully signed in.
+
+The fix parses the URL hostname instead of substring-matching the full URL.
+"""
+
+import pytest
+
+from notebooklm_tools.utils.cdp import is_logged_in
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        # Plain logged-in URLs.
+        ("https://notebooklm.google.com/", True),
+        ("https://notebooklm.google.com/some/notebook/abc", True),
+        # Regression: NotebookLM appends ?original_referer=... right after
+        # Google sign-in. The substring `accounts.google.com` IS present in
+        # the URL (inside the query string), but the user is signed in.
+        (
+            "https://notebooklm.google.com/?original_referer=https%3A%2F%2Faccounts.google.com%23",
+            True,
+        ),
+        # Defensive: an unrelated query string mentioning accounts.google.com
+        # must not be confused with a sign-in redirect.
+        ("https://notebooklm.google.com/?ref=https://accounts.google.com", True),
+        # Enterprise NotebookLM host.
+        ("https://notebooklm.cloud.google.com/", True),
+        ("https://notebooklm.cloud.google.com/notebook/abc", True),
+        # Standard Google sign-in redirect: not logged in.
+        ("https://accounts.google.com/v3/signin/identifier?continue=...", False),
+        ("https://accounts.google.com/", False),
+        # Hostname spoofing on the accounts.google.com side must not be treated
+        # as a sign-in redirect (the regression this PR fixes was the inverse:
+        # treating a query-string mention of accounts.google.com as a redirect).
+        ("https://evil.accounts.google.com.example.com/", False),
+        # Unrelated domains.
+        ("https://example.com/", False),
+        # Edge cases: empty / malformed URLs must default to "not logged in".
+        ("", False),
+        ("not a url at all", False),
+    ],
+)
+def test_is_logged_in(url: str, expected: bool) -> None:
+    assert is_logged_in(url) is expected


### PR DESCRIPTION
## Summary

`nlm login` (builtin CDP mode) consistently fails with `Error: Login timeout`
after 5 minutes, even when the user has completed Google sign-in successfully
in the browser window. The fix parses the URL's hostname instead of doing a
substring match against the full URL string.

## Root cause

`is_logged_in(url)` (in `src/notebooklm_tools/utils/cdp.py`) decides whether
the current browser tab is on the Google sign-in page using:

```python
if "accounts.google.com" in url:
    return False
return _is_notebooklm_url(url)
```

After sign-in, NotebookLM redirects the browser to:

```
https://notebooklm.google.com/?original_referer=https%3A%2F%2Faccounts.google.com%23
```

The substring `accounts.google.com` is present in this URL (inside the
`original_referer` query parameter), so `is_logged_in()` returns `False`.
The poll loop in `extract_cookies_from_page()` (and `run_headless_auth()`)
never recognizes the post-signin state and times out after `login_timeout`
seconds.

This affects `nlm login` and `nlm login --provider openclaw` whenever the
browser lands on the post-signin URL with the `original_referer` query, which
is the default Google flow as of late April 2026.

`nlm login --check` is **not** affected because `--check` doesn't go through
`is_logged_in`.

## Reproduction

1. Run `nlm login` from a fresh terminal (no cached session).
2. Complete Google sign-in in the launched browser window.
3. Watch `is_logged_in()` return `False` repeatedly because the post-signin
   URL contains `original_referer=...accounts.google.com...`.
4. After 300 seconds: `Error: Login timeout`.

## Fix

Parse the hostname instead of substring-matching the full URL:

```python
def is_logged_in(url: str) -> bool:
    """..."""
    try:
        host = (urlparse(url).hostname or "").lower()
    except Exception:
        return False
    if host == "accounts.google.com" or host.endswith(".accounts.google.com"):
        return False
    return _is_notebooklm_url(url)
```

Hostname-based matching is robust against query strings that mention
`accounts.google.com` (the regression case here) or any other domain.

`urlparse` is already imported at the top of `cdp.py` (line 20:
`from urllib.parse import quote, urlparse`), so no new dependency.

The existing `_is_notebooklm_url(url)` helper is reused for the positive
case, so personal NotebookLM (`notebooklm.google.com`) and enterprise
NotebookLM (`notebooklm.cloud.google.com`) keep working without
duplicated logic.

## Tests

Adds `tests/test_cdp_url_check.py` with `@pytest.mark.parametrize`-driven
cases:

- Plain logged-in URL → True
- The regression case: `?original_referer=https://accounts.google.com#` → True
- Enterprise host `notebooklm.cloud.google.com` → True
- Logged-in URL with unrelated `?ref=https://accounts.google.com` query → True
- Standard sign-in redirect `accounts.google.com/v3/signin/identifier` → False
- Hostname spoofing `evil.accounts.google.com.example.com` → False
- Empty string / malformed URL → False

Run: `uv run pytest tests/test_cdp_url_check.py -v`

## Live verification (CLI)

Tested locally against the real NotebookLM API. Before the fix, sign-in
times out:

```
$ nlm login
Authenticating profile: default (...)
Launching Brave Browser for authentication...
Using Chrome DevTools Protocol
Starting Brave Browser...
[user signs in via Google]
Error: Login timeout
Hint: Please log in to NotebookLM in the connected browser window.
```

After the fix, `nlm login` completes immediately on landing the post-signin URL:

```
$ nlm login
Authenticating profile: default (...)
Launching Brave Browser for authentication...
Using Chrome DevTools Protocol
Starting Brave Browser...
[user signs in via Google]
✓ Successfully authenticated!
  Profile: default
  Cookies: 45 extracted
  CSRF Token: Yes
  Account: ...

$ nlm login --check
✓ Authentication valid!
  Profile: default
  Notebooks found: 18
  Account: ...
```

## Live verification (MCP)

`notebooklm-mcp --transport stdio` exercised with `initialize` + `tools/list`
over JSON-RPC stdio against the real API on the patched cookies:

```
initialize → server=notebooklm v3.2.4
tools/list → 39 tools (refresh_auth, save_auth_tokens, batch, notebook_query, chat_configure, ...)
```

Both rely on the same auth pipeline that goes through `is_logged_in`
(during cookie extraction in `nlm login`), confirming the fix doesn't
regress MCP behavior.

## Tests run

- `uv run pytest tests/test_cdp_url_check.py -v` — 12 passed
- `uv run pytest` (full) — 789 passed, 37 skipped, 0 failed
- `uv run ruff check src/notebooklm_tools/utils/cdp.py tests/test_cdp_url_check.py` — clean
- `uv run ruff format --check src/notebooklm_tools/utils/cdp.py tests/test_cdp_url_check.py` — clean

## Out of scope

`_is_notebooklm_url` itself uses substring matching and could be
hostname-spoofed by a URL like `notebooklm.google.com.attacker.example`.
That's a separate (lower-impact) hardening — happy to follow up in a
separate PR if you'd like.

## Notes

- One-line behavior change. Function signature and return type unchanged.
- No new dependencies. `urlparse` already imported.
- `_is_notebooklm_url` already covers personal + enterprise hosts.
- Backward compatible for every URL the previous version handled correctly.
```
