### PR TITLE
Add GitHub Copilot setup support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Connect AI assistants (Claude, Gemini, Cursor, etc.) to NotebookLM:
 # Automatic setup — picks the right config for each tool
 nlm setup add claude-code
 nlm setup add gemini
+nlm setup add github-copilot
 nlm setup add cursor
 nlm setup add cline
 nlm setup add antigravity
@@ -317,6 +318,7 @@ Use `nlm setup` to automatically configure the MCP server for your AI tools — 
 nlm setup add claude-code
 nlm setup add claude-desktop
 nlm setup add gemini
+nlm setup add github-copilot
 nlm setup add cursor
 nlm setup add windsurf
 
@@ -400,7 +402,19 @@ gemini mcp add --scope user notebooklm-mcp notebooklm-mcp
 | Cursor | `~/.cursor/mcp.json` |
 | Windsurf | `~/.codeium/windsurf/mcp_config.json` |
 
-**Claude Desktop / VS Code** may not resolve `PATH` — use the full path to the binary:
+**GitHub Copilot (VS Code workspace)** uses `.vscode/mcp.json` with a top-level `servers` key:
+```json
+{
+  "servers": {
+    "notebooklm-mcp": {
+      "command": "notebooklm-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+**Claude Desktop** may not resolve `PATH` — use the full path to the binary:
 ```json
 {
   "mcpServers": {
@@ -416,7 +430,7 @@ Find your path with: `which notebooklm-mcp`
 | Tool | Config Location |
 |------|-----------------|
 | Claude Desktop | `~/Library/Application Support/Claude/claude_desktop_config.json` |
-| VS Code | `~/.vscode/mcp.json` |
+| GitHub Copilot | `.vscode/mcp.json` |
 
 </details>
 

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -278,6 +278,7 @@ Configure the NotebookLM MCP server for AI tools in one command:
 ```bash
 nlm setup add claude-code       # Configure via `claude mcp add`
 nlm setup add gemini            # Write ~/.gemini/settings.json
+nlm setup add github-copilot    # Write .vscode/mcp.json
 nlm setup add cursor            # Write ~/.cursor/mcp.json
 nlm setup add windsurf          # Write mcp_config.json
 nlm setup add json              # Generate JSON config for any tool
@@ -287,7 +288,7 @@ nlm setup remove gemini         # Remove from Gemini CLI
 nlm setup list                  # Show all clients and config status
 ```
 
-**Supported Clients:** `claude-code`, `gemini`, `cursor`, `windsurf`, `cline`, `antigravity`, `codex`, `opencode`
+**Supported Clients:** `claude-code`, `gemini`, `github-copilot`, `cursor`, `windsurf`, `cline`, `antigravity`, `codex`, `opencode`
 
 **For unsupported tools:** Use `nlm setup add json` to interactively generate a JSON config snippet. Choose between uvx or regular mode, full path or command name, and whether to include the `mcpServers` wrapper. The result is printed and can be copied to clipboard.
 

--- a/docs/MCP_GUIDE.md
+++ b/docs/MCP_GUIDE.md
@@ -305,6 +305,7 @@ The easiest way to configure any tool is with `nlm setup`:
 ```bash
 nlm setup add claude-code       # Claude Code
 nlm setup add gemini            # Gemini CLI
+nlm setup add github-copilot    # GitHub Copilot
 nlm setup add cursor            # Cursor
 nlm setup add windsurf          # Windsurf
 nlm setup add json              # Any other tool (interactive JSON generator)
@@ -318,13 +319,26 @@ nlm setup add json              # Any other tool (interactive JSON generator)
 claude mcp add --scope user notebooklm-mcp notebooklm-mcp
 ```
 
-### Cursor / VS Code
-Add to `~/.cursor/mcp.json` or `~/.vscode/mcp.json`:
+### Cursor
+Add to `~/.cursor/mcp.json`:
 ```json
 {
   "mcpServers": {
     "notebooklm-mcp": {
       "command": "/path/to/notebooklm-mcp"
+    }
+  }
+}
+```
+
+### GitHub Copilot / VS Code
+Add to `.vscode/mcp.json`:
+```json
+{
+  "servers": {
+    "notebooklm-mcp": {
+      "command": "notebooklm-mcp",
+      "args": []
     }
   }
 }

--- a/src/notebooklm_tools/cli/commands/setup.py
+++ b/src/notebooklm_tools/cli/commands/setup.py
@@ -75,6 +75,24 @@ def _add_mcp_server(config: dict, key: str = "notebooklm-mcp", extra: dict | Non
     return config
 
 
+def _is_vscode_mcp_configured(config: dict, key: str = "notebooklm-mcp") -> bool:
+    """Check if notebooklm-mcp is already in a VS Code/Copilot ``servers`` config."""
+    servers = config.get("servers", {})
+    return key in servers or "notebooklm" in servers
+
+
+def _add_vscode_mcp_server(
+    config: dict, key: str = "notebooklm-mcp", extra: dict | None = None
+) -> dict:
+    """Add notebooklm-mcp to a VS Code/Copilot ``servers`` config dict."""
+    config.setdefault("servers", {})
+    entry = {"command": MCP_SERVER_CMD, "args": []}
+    if extra:
+        entry.update(extra)
+    config["servers"][key] = entry
+    return config
+
+
 # =============================================================================
 # Client-specific config paths
 # =============================================================================
@@ -135,6 +153,11 @@ def _opencode_config_path() -> Path:
     return Path.home() / ".config" / "opencode" / "opencode.json"
 
 
+def _github_copilot_config_path() -> Path:
+    """Get GitHub Copilot workspace MCP config path."""
+    return Path(".vscode") / "mcp.json"
+
+
 # =============================================================================
 # Client definitions
 # =============================================================================
@@ -153,6 +176,11 @@ CLIENT_REGISTRY = {
     "cursor": {
         "name": "Cursor",
         "description": "Cursor AI editor",
+        "has_auto_setup": True,
+    },
+    "github-copilot": {
+        "name": "GitHub Copilot",
+        "description": "GitHub Copilot in VS Code (workspace)",
         "has_auto_setup": True,
     },
     "windsurf": {
@@ -182,10 +210,14 @@ CLIENT_REGISTRY = {
     },
 }
 
+CLIENT_ALIASES = {
+    "copilot": "github-copilot",
+}
+
 
 def _complete_client(ctx, param, incomplete: str) -> list[str]:
     """Shell completion for client names."""
-    all_clients = list(CLIENT_REGISTRY.keys()) + ["json", "all"]
+    all_clients = list(CLIENT_REGISTRY.keys()) + list(CLIENT_ALIASES.keys()) + ["json", "all"]
     return [name for name in all_clients if name.startswith(incomplete)]
 
 
@@ -249,6 +281,22 @@ def _setup_gemini() -> bool:
     _add_mcp_server(config, key="notebooklm", extra={"trust": True})
     _write_json_config(config_path, config)
     console.print("[green]✓[/green] Added to Gemini CLI")
+    console.print(f"  [dim]{config_path}[/dim]")
+    return True
+
+
+def _setup_github_copilot() -> bool:
+    """Add MCP to GitHub Copilot's workspace MCP config."""
+    config_path = _github_copilot_config_path()
+    config = _read_json_config(config_path)
+
+    if _is_vscode_mcp_configured(config):
+        console.print("[green]✓[/green] Already configured in GitHub Copilot")
+        return True
+
+    _add_vscode_mcp_server(config)
+    _write_json_config(config_path, config)
+    console.print("[green]✓[/green] Added to GitHub Copilot (workspace)")
     console.print(f"  [dim]{config_path}[/dim]")
     return True
 
@@ -434,6 +482,9 @@ def _detect_tool(client_id: str) -> bool:
             shutil.which("gemini") is not None or _gemini_config_path().parent.exists()
         ),
         "cursor": lambda: (Path.home() / ".cursor").exists(),
+        "github-copilot": lambda: (
+            shutil.which("code") is not None or _github_copilot_config_path().parent.exists()
+        ),
         "windsurf": lambda: _windsurf_config_path().parent.exists(),
         "cline": lambda: (Path.home() / ".cline").exists(),
         "antigravity": lambda: _antigravity_config_path().parent.exists(),
@@ -469,6 +520,9 @@ def _is_already_configured(client_id: str) -> bool:
         elif client_id == "gemini":
             config = _read_json_config(_gemini_config_path())
             return _is_configured(config, "notebooklm")
+        elif client_id == "github-copilot":
+            config = _read_json_config(_github_copilot_config_path())
+            return _is_vscode_mcp_configured(config)
         elif client_id == "cursor":
             config = _read_json_config(_cursor_config_path())
             return _is_configured(config)
@@ -739,6 +793,7 @@ def setup_add(
     Examples:
         nlm setup add claude-code
         nlm setup add gemini
+        nlm setup add github-copilot
         nlm setup add cursor
         nlm setup add windsurf
         nlm setup add cline
@@ -747,6 +802,8 @@ def setup_add(
         nlm setup add json
         nlm setup add all         # Interactive — detect and configure all
     """
+    client = CLIENT_ALIASES.get(client, client)
+
     if client == "json":
         _setup_json()
         return
@@ -774,6 +831,7 @@ def setup_add(
     setup_fn = {
         "claude-code": _setup_claude_code,
         "gemini": _setup_gemini,
+        "github-copilot": _setup_github_copilot,
         "cursor": _setup_cursor,
         "windsurf": _setup_windsurf,
         "cline": _setup_cline,
@@ -800,8 +858,11 @@ def setup_remove(
 
     Examples:
         nlm setup remove gemini
+        nlm setup remove github-copilot
         nlm setup remove all
     """
+    client = CLIENT_ALIASES.get(client, client)
+
     if client == "all":
         _remove_all()
         return
@@ -894,6 +955,30 @@ def _remove_single(client: str) -> bool:
         else:
             console.print("[dim]NotebookLM MCP was not configured in OpenCode.[/dim]")
             return False
+
+    # GitHub Copilot uses VS Code's ``servers`` key in .vscode/mcp.json
+    if client == "github-copilot":
+        config_path = _github_copilot_config_path()
+        if not config_path.exists():
+            console.print("[dim]No config file found for GitHub Copilot.[/dim]")
+            return False
+        config = _read_json_config(config_path)
+        servers = config.get("servers", {})
+
+        removed = False
+        for key in ["notebooklm-mcp", "notebooklm"]:
+            if key in servers:
+                del servers[key]
+                removed = True
+
+        if removed:
+            config["servers"] = servers
+            _write_json_config(config_path, config)
+            console.print("[green]✓[/green] Removed from GitHub Copilot")
+            return True
+
+        console.print("[dim]NotebookLM MCP was not configured in GitHub Copilot.[/dim]")
+        return False
 
     # JSON config-based clients
     config_paths = {
@@ -1020,6 +1105,13 @@ def setup_list() -> None:
             if _is_configured(config, "notebooklm"):
                 status = "[green]✓[/green]"
             config_path = str(path).replace(str(Path.home()), "~")
+
+        elif client_id == "github-copilot":
+            path = _github_copilot_config_path()
+            config = _read_json_config(path)
+            if _is_vscode_mcp_configured(config):
+                status = "[green]✓[/green]"
+            config_path = str(path)
 
         elif client_id == "cursor":
             path = _cursor_config_path()

--- a/tests/cli/test_setup_github_copilot.py
+++ b/tests/cli/test_setup_github_copilot.py
@@ -1,0 +1,217 @@
+"""Tests for GitHub Copilot support in ``nlm setup add/remove/list``."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from notebooklm_tools.cli.commands.setup import (
+    CLIENT_REGISTRY,
+    MCP_SERVER_CMD,
+    _detect_tool,
+    _github_copilot_config_path,
+    _is_already_configured,
+    _remove_single,
+    _setup_github_copilot,
+)
+
+
+class TestGitHubCopilotRegistry:
+    """Verify GitHub Copilot is properly registered in CLIENT_REGISTRY."""
+
+    def test_github_copilot_in_registry(self):
+        assert "github-copilot" in CLIENT_REGISTRY
+
+    def test_github_copilot_has_auto_setup(self):
+        assert CLIENT_REGISTRY["github-copilot"]["has_auto_setup"] is True
+
+    def test_github_copilot_name(self):
+        assert CLIENT_REGISTRY["github-copilot"]["name"] == "GitHub Copilot"
+
+
+class TestGitHubCopilotConfigPath:
+    """Verify workspace config path resolution."""
+
+    def test_config_path_is_workspace_vscode_mcp_json(self):
+        path = _github_copilot_config_path()
+        assert path == Path(".vscode") / "mcp.json"
+
+
+class TestSetupGitHubCopilot:
+    """Test ``_setup_github_copilot()`` writes the correct config format."""
+
+    def test_creates_config_from_scratch(self, tmp_path):
+        config_path = tmp_path / ".vscode" / "mcp.json"
+        with patch(
+            "notebooklm_tools.cli.commands.setup._github_copilot_config_path",
+            return_value=config_path,
+        ):
+            result = _setup_github_copilot()
+
+        assert result is True
+        config = json.loads(config_path.read_text())
+        assert "servers" in config
+        assert "notebooklm-mcp" in config["servers"]
+        entry = config["servers"]["notebooklm-mcp"]
+        assert entry["command"] == MCP_SERVER_CMD
+        assert entry["args"] == []
+
+    def test_preserves_existing_config_keys(self, tmp_path):
+        config_path = tmp_path / ".vscode" / "mcp.json"
+        existing = {
+            "inputs": [{"type": "promptString", "id": "token"}],
+            "servers": {"fetch": {"command": "uvx", "args": ["mcp-server-fetch"]}},
+        }
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(existing))
+
+        with patch(
+            "notebooklm_tools.cli.commands.setup._github_copilot_config_path",
+            return_value=config_path,
+        ):
+            _setup_github_copilot()
+
+        config = json.loads(config_path.read_text())
+        assert config["inputs"] == existing["inputs"]
+        assert "fetch" in config["servers"]
+        assert "notebooklm-mcp" in config["servers"]
+
+    def test_skips_if_already_configured(self, tmp_path):
+        config_path = tmp_path / ".vscode" / "mcp.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(
+            json.dumps({"servers": {"notebooklm-mcp": {"command": MCP_SERVER_CMD, "args": []}}})
+        )
+
+        with patch(
+            "notebooklm_tools.cli.commands.setup._github_copilot_config_path",
+            return_value=config_path,
+        ):
+            result = _setup_github_copilot()
+
+        assert result is True
+
+    def test_uses_servers_key_not_mcpservers(self, tmp_path):
+        config_path = tmp_path / ".vscode" / "mcp.json"
+        with patch(
+            "notebooklm_tools.cli.commands.setup._github_copilot_config_path",
+            return_value=config_path,
+        ):
+            _setup_github_copilot()
+
+        config = json.loads(config_path.read_text())
+        assert "servers" in config
+        assert "mcpServers" not in config
+
+
+class TestIsAlreadyConfigured:
+    """Test ``_is_already_configured()`` for GitHub Copilot."""
+
+    def test_detects_notebooklm_key(self, tmp_path):
+        config_path = tmp_path / ".vscode" / "mcp.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps({"servers": {"notebooklm": {"command": MCP_SERVER_CMD}}}))
+        with patch(
+            "notebooklm_tools.cli.commands.setup._github_copilot_config_path",
+            return_value=config_path,
+        ):
+            assert _is_already_configured("github-copilot") is True
+
+    def test_returns_false_when_not_configured(self, tmp_path):
+        config_path = tmp_path / ".vscode" / "mcp.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps({"servers": {}}))
+        with patch(
+            "notebooklm_tools.cli.commands.setup._github_copilot_config_path",
+            return_value=config_path,
+        ):
+            assert _is_already_configured("github-copilot") is False
+
+    def test_returns_false_when_no_config_file(self, tmp_path):
+        config_path = tmp_path / ".vscode" / "mcp.json"
+        with patch(
+            "notebooklm_tools.cli.commands.setup._github_copilot_config_path",
+            return_value=config_path,
+        ):
+            assert _is_already_configured("github-copilot") is False
+
+
+class TestDetectTool:
+    """Test ``_detect_tool()`` for GitHub Copilot."""
+
+    def test_detects_via_which(self):
+        with patch("shutil.which", return_value="/usr/bin/code"):
+            assert _detect_tool("github-copilot") is True
+
+    def test_detects_via_workspace_directory(self, tmp_path):
+        config_path = tmp_path / ".vscode" / "mcp.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        with (
+            patch("shutil.which", return_value=None),
+            patch(
+                "notebooklm_tools.cli.commands.setup._github_copilot_config_path",
+                return_value=config_path,
+            ),
+        ):
+            assert _detect_tool("github-copilot") is True
+
+    def test_not_detected_when_absent(self, tmp_path):
+        config_path = tmp_path / ".vscode" / "mcp.json"
+        with (
+            patch("shutil.which", return_value=None),
+            patch(
+                "notebooklm_tools.cli.commands.setup._github_copilot_config_path",
+                return_value=config_path,
+            ),
+        ):
+            assert _detect_tool("github-copilot") is False
+
+
+class TestRemoveGitHubCopilot:
+    """Test ``_remove_single()`` for GitHub Copilot."""
+
+    def test_removes_notebooklm_entry(self, tmp_path):
+        config_path = tmp_path / ".vscode" / "mcp.json"
+        config = {
+            "inputs": [{"type": "promptString"}],
+            "servers": {
+                "notebooklm-mcp": {"command": MCP_SERVER_CMD, "args": []},
+                "fetch": {"command": "uvx", "args": ["mcp-server-fetch"]},
+            },
+        }
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config))
+
+        with patch(
+            "notebooklm_tools.cli.commands.setup._github_copilot_config_path",
+            return_value=config_path,
+        ):
+            result = _remove_single("github-copilot")
+
+        assert result is True
+        updated = json.loads(config_path.read_text())
+        assert "notebooklm-mcp" not in updated["servers"]
+        assert "fetch" in updated["servers"]
+        assert updated["inputs"] == config["inputs"]
+
+    def test_returns_false_when_not_configured(self, tmp_path):
+        config_path = tmp_path / ".vscode" / "mcp.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps({"servers": {}}))
+
+        with patch(
+            "notebooklm_tools.cli.commands.setup._github_copilot_config_path",
+            return_value=config_path,
+        ):
+            result = _remove_single("github-copilot")
+
+        assert result is False
+
+    def test_returns_false_when_no_config_file(self, tmp_path):
+        config_path = tmp_path / ".vscode" / "mcp.json"
+        with patch(
+            "notebooklm_tools.cli.commands.setup._github_copilot_config_path",
+            return_value=config_path,
+        ):
+            result = _remove_single("github-copilot")
+
+        assert result is False


### PR DESCRIPTION
## Summary
- add GitHub Copilot as a supported `nlm setup` client
- write and remove workspace `.vscode/mcp.json` entries using Copilots `servers` schema
- add setup coverage and docs for the new client

Closes #177