### PR TITLE
fix(download): strip OSID cookies before cross-domain artifact downloads

### DIFF
--- a/src/notebooklm_tools/core/download.py
+++ b/src/notebooklm_tools/core/download.py
@@ -127,6 +127,14 @@ class DownloadMixin(BaseClient):
         # Use httpx.Cookies for proper cross-domain redirect handling
         cookies = self._get_httpx_cookies()
 
+        # Drop OSID cookies before issuing the download request.
+        # OSID is scoped to notebooklm.google.com; when it leaks onto download
+        # hosts (e.g. lh3.googleusercontent.com) Google treats the request as
+        # an invalid session and redirects to ServiceLogin, breaking downloads.
+        for domain in (".google.com", ".googleusercontent.com"):
+            cookies.delete("OSID", domain=domain)
+            cookies.delete("__Secure-OSID", domain=domain)
+
         # Per-chunk timeouts: 10s connect, 30s per chunk read/write
         # This allows large files to download without timeout while detecting stalls
         timeout = httpx.Timeout(connect=10.0, read=30.0, write=30.0, pool=30.0)

--- a/tests/core/test_download.py
+++ b/tests/core/test_download.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Tests for DownloadMixin."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -171,3 +171,79 @@ class TestDownloadMixinMethods:
             "/tmp/audio.m4a",
             None,
         )
+
+
+class TestDownloadUrlCookies:
+    """Cookie handling for cross-domain artifact downloads."""
+
+    @pytest.mark.asyncio
+    async def test_download_url_strips_osid_cookies(self, tmp_path):
+        """OSID cookies must be removed before issuing the download request.
+
+        OSID is scoped to notebooklm.google.com. If it leaks onto a download
+        host such as lh3.googleusercontent.com, Google treats the request as
+        an invalid session and redirects to ServiceLogin.
+        """
+        mixin = DownloadMixin(
+            cookies=[
+                {"name": "SID", "value": "sid-value", "domain": ".google.com", "path": "/"},
+                {"name": "OSID", "value": "osid-value", "domain": ".google.com", "path": "/"},
+                {
+                    "name": "__Secure-OSID",
+                    "value": "secure-osid-value",
+                    "domain": ".google.com",
+                    "path": "/",
+                },
+            ],
+            csrf_token="token",
+        )
+
+        captured = {}
+
+        class MockStreamResponse:
+            headers = {
+                "content-length": "4",
+                "content-type": "application/octet-stream",
+            }
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return None
+
+            def raise_for_status(self):
+                return None
+
+            async def aiter_bytes(self, chunk_size=8192):
+                yield b"data"
+
+        class MockAsyncClient:
+            def __init__(self, *, cookies, headers, follow_redirects, timeout):
+                captured["cookies"] = cookies
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return None
+
+            def stream(self, method, url):
+                return MockStreamResponse()
+
+        output = tmp_path / "out.bin"
+
+        with patch("notebooklm_tools.core.download.httpx.AsyncClient", MockAsyncClient):
+            result = await mixin._download_url(
+                "https://lh3.googleusercontent.com/file", str(output)
+            )
+
+        assert result == str(output)
+        assert output.read_bytes() == b"data"
+
+        cookies = captured["cookies"]
+        assert cookies.get("SID", domain=".google.com") == "sid-value"
+        assert cookies.get("SID", domain=".googleusercontent.com") == "sid-value"
+        for domain in (".google.com", ".googleusercontent.com"):
+            assert cookies.get("OSID", domain=domain) is None
+            assert cookies.get("__Secure-OSID", domain=domain) is None


### PR DESCRIPTION
## Summary

Strip `OSID` and `__Secure-OSID` from the cookie jar used by artifact download requests. Other auth cookies are preserved so successful downloads continue to work.

## Why

Artifact downloads can redirect from `notebooklm.google.com` to a Google-hosted download host such as `lh3.googleusercontent.com`. `_get_httpx_cookies()` duplicates `.google.com` cookies onto `.googleusercontent.com` so authentication survives the redirect, but that also forwards `OSID` cookies, which are scoped to NotebookLM only.

When those cookies arrive at a different Google host, the session is treated as invalid and the request is bounced to `ServiceLogin`, so the download returns an HTML login page instead of the file. This is most visible in isolated environments (Docker, fresh profiles) where the surrounding cookies happen to expose the mismatch.

## Change

In `_download_url()`, after building the cookie jar, delete `OSID` and `__Secure-OSID` for both `.google.com` and `.googleusercontent.com` before passing the jar to `httpx.AsyncClient`. The change is scoped to the download path; RPC calls are untouched.

## Test plan

- new unit test `tests/core/test_download.py::TestDownloadUrlCookies::test_download_url_strips_osid_cookies` patches `httpx.AsyncClient` and asserts that `OSID` / `__Secure-OSID` are absent from the cookie jar passed to the client, while `SID` is still present on both domains
- verified the test fails on `main` and passes with the fix applied
- `uv run pytest tests/core/` — 221 passed