### PR TITLE
docs: add Google AI Ultra to tested tiers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 **Programmatic access to Google NotebookLM** — via command-line interface (CLI) or Model Context Protocol (MCP) server.
 
-> **Note:** Tested with Pro/free tier accounts. May work with NotebookLM Enterprise accounts but has not been tested.
+> **Note:** Tested with Pro/free and Google AI Ultra ($249/mo) tier accounts. May work with NotebookLM Enterprise accounts but has not been tested.
 
 📺 **Watch the Demos**
 


### PR DESCRIPTION
Small positive data point: `nlm` v0.6.5 works on Google AI Ultra ($249/mo) for `notebook list/create`, `source add`, `video create --format cinematic`, and `studio status` — verified 2026-05-06 from a NotebookLM-based content production pipeline.

Updates the README "tested tiers" note accordingly. No code changes.

Related: #183 (mentions Ultra in the Environment block as a side data point).
