### PR TITLE
Add cited-only research import

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -161,6 +161,14 @@ research_import(
     source_indices=[0, 2, 5],  # Import only sources at indices 0, 2, and 5
     timeout=600  # Optional: increase for large notebooks (default: 300s)
 )
+
+# Or import only sources cited by the deep research report
+research_import(
+    notebook_id=notebook_id,
+    task_id=status["research"]["task_id"],
+    cited_only=True,  # Overrides source_indices when enabled
+    timeout=600
+)
 ```
 
 **Research Modes:**

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -138,6 +138,7 @@ nlm research start "query" --notebook-id <id> --auto-import # Start, poll, and i
 nlm research status <notebook> --max-wait 300              # Poll until done
 nlm research import <notebook> <task-id>                   # Import sources
 nlm research import <notebook> <task-id> --timeout 600     # Custom timeout (default: 300s)
+nlm research import <notebook> <task-id> --cited-only      # Import cited deep research sources
 ```
 
 ### Studio Status

--- a/docs/MCP_GUIDE.md
+++ b/docs/MCP_GUIDE.md
@@ -118,7 +118,7 @@ source_add(
 |------|-------------|
 | `research_start` | Start web/Drive research |
 | `research_status` | Poll research progress |
-| `research_import` | Import discovered sources (`timeout` param for large notebooks) |
+| `research_import` | Import discovered sources (`timeout` and `cited_only` supported) |
 
 ### Notes (1 unified tool)
 
@@ -215,7 +215,7 @@ tag(action="select", query="ai research")  # Find notebooks by tag match
 ```
 1. research_start(query="AI trends 2026", mode="deep")
 2. research_status(notebook_id, max_wait=300)  # wait for completion
-3. research_import(notebook_id, task_id, timeout=600)  # optional: increase for large notebooks
+3. research_import(notebook_id, task_id, cited_only=True, timeout=600)  # optional cited subset
 4. studio_create(notebook_id, artifact_type="audio", confirm=True)
 5. studio_status(notebook_id)  # poll until complete
 6. download_artifact(notebook_id, artifact_type="audio", output_path="podcast.mp3")

--- a/src/notebooklm_tools/cli/ai_docs.py
+++ b/src/notebooklm_tools/cli/ai_docs.py
@@ -315,6 +315,7 @@ nlm research status <notebook-id> --full             # Full details
 # Import discovered sources
 nlm research import <notebook-id> <task-id>              # Import all
 nlm research import <notebook-id> <task-id> --indices 0,2,5  # Import specific
+nlm research import <notebook-id> <task-id> --cited-only     # Import cited sources
 nlm research import <notebook-id> <task-id> --timeout 600    # Custom timeout (default: 300s)
 ```
 

--- a/src/notebooklm_tools/cli/commands/research.py
+++ b/src/notebooklm_tools/cli/commands/research.py
@@ -325,6 +325,11 @@ def import_research(
         "-t",
         help="Import timeout in seconds (default: 300)",
     ),
+    cited_only: bool = typer.Option(
+        False,
+        "--cited-only",
+        help="Import only sources cited by the research report (overrides --indices)",
+    ),
     profile: str | None = typer.Option(None, "--profile", "-p", help="Profile to use"),
 ) -> None:
     """
@@ -371,6 +376,7 @@ def import_research(
                 task_id,
                 source_indices=source_indices,
                 timeout=timeout,
+                cited_only=cited_only,
             )
 
         console.print(f"[green]✓[/green] {result['message']}")

--- a/src/notebooklm_tools/cli/commands/verbs.py
+++ b/src/notebooklm_tools/cli/commands/verbs.py
@@ -867,11 +867,21 @@ def research_import_verb(
     timeout: float = typer.Option(
         300.0, "--timeout", "-t", help="Import timeout in seconds (default: 300)"
     ),
+    cited_only: bool = typer.Option(
+        False,
+        "--cited-only",
+        help="Import only sources cited by the research report (overrides --indices)",
+    ),
     profile: str | None = typer.Option(None, "--profile", "-p", help="Profile to use"),
 ) -> None:
     """Import discovered sources into notebook."""
     import_research(
-        notebook_id=notebook, task_id=task_id, indices=indices, timeout=timeout, profile=profile
+        notebook_id=notebook,
+        task_id=task_id,
+        indices=indices,
+        timeout=timeout,
+        cited_only=cited_only,
+        profile=profile,
     )
 
 

--- a/src/notebooklm_tools/data/SKILL.md
+++ b/src/notebooklm_tools/data/SKILL.md
@@ -236,6 +236,7 @@ nlm research status <nb-id> --full            # Full details
 # Import discovered sources
 nlm research import <nb-id> <task-id>            # Import all
 nlm research import <nb-id> <task-id> --indices 0,2,5  # Import specific
+nlm research import <nb-id> <task-id> --cited-only      # Import cited sources
 nlm research import <nb-id> <task-id> --timeout 600    # Custom timeout (default: 300s)
 ```
 

--- a/src/notebooklm_tools/data/references/command_reference.md
+++ b/src/notebooklm_tools/data/references/command_reference.md
@@ -384,6 +384,7 @@ nlm research import <notebook-id> <task-id> [OPTIONS]
 | Option | Description |
 |--------|-------------|
 | `--indices` | Comma-separated indices of sources to import (default: all) |
+| `--cited-only` | Import only sources cited by the research report (overrides `--indices`) |
 | `--profile` | Use specific profile |
 
 ---

--- a/src/notebooklm_tools/mcp/tools/research.py
+++ b/src/notebooklm_tools/mcp/tools/research.py
@@ -97,6 +97,7 @@ def research_import(
     task_id: str,
     source_indices: list[int] | None = None,
     timeout: float = 300.0,
+    cited_only: bool = False,
 ) -> ResultDict:
     """Import discovered sources into notebook.
 
@@ -107,6 +108,8 @@ def research_import(
         task_id: Research task ID
         source_indices: Source indices to import (default: all)
         timeout: Import timeout in seconds (default: 300, increase for large notebooks)
+        cited_only: Import only sources cited by the research report.
+            Overrides source_indices when enabled.
     """
     try:
         client = get_client()
@@ -118,6 +121,7 @@ def research_import(
             task_id,
             source_indices=source_indices,
             timeout=timeout,
+            cited_only=cited_only,
         )
         return {"status": "success", **result}
     except ServiceError as e:

--- a/src/notebooklm_tools/services/research.py
+++ b/src/notebooklm_tools/services/research.py
@@ -1,6 +1,8 @@
 """Research service — shared business logic for research start, poll, and import."""
 
+import re
 import time
+from collections import defaultdict
 
 from ..core.client import NotebookLMClient
 from ..core.errors import RPCError
@@ -9,6 +11,11 @@ from .errors import ServiceError, ValidationError
 
 VALID_SOURCES = ("web", "drive")
 VALID_MODES = ("fast", "deep")
+
+_CITATION_MARKER_RE = re.compile(r"\[([0-9][0-9\s,;\-\u2013\u2014]*)\]")
+_BIBLIOGRAPHY_LINE_RE = re.compile(r"^\s*(\d+)\.\s+(.+)$", re.MULTILINE)
+_URL_RE = re.compile(r"https?://[^\s<>\])]+")
+_TRAILING_URL_CHARS = ".,;:!?)]}"
 
 
 class ResearchStartResult(TypedDict):
@@ -29,7 +36,7 @@ class ResearchStatusResult(TypedDict):
     notebook_id: str
     task_id: str | None
     sources_found: int
-    sources: list
+    sources: list[object]
     report: str
     message: str | None
 
@@ -39,8 +46,141 @@ class ResearchImportResult(TypedDict):
 
     notebook_id: str
     imported_count: int
-    imported_sources: list
+    imported_sources: list[dict[str, object]]
     message: str
+
+
+def _normalize_url(value: str) -> str:
+    """Normalize URLs enough for matching report bibliography links to sources."""
+    url = value.strip().strip("<>")
+    while url and url[-1] in _TRAILING_URL_CHARS:
+        url = url[:-1]
+    return url.rstrip("/")
+
+
+def _extract_urls(text: str) -> list[str]:
+    """Extract normalized HTTP(S) URLs while preserving encounter order."""
+    urls: list[str] = []
+    seen: set[str] = set()
+    for match in _URL_RE.finditer(text):
+        url = _normalize_url(match.group(0))
+        if url and url not in seen:
+            urls.append(url)
+            seen.add(url)
+    return urls
+
+
+def _expand_citation_numbers(raw: str) -> set[int]:
+    """Expand citation expressions such as "1, 3-5" into integer IDs."""
+    numbers: set[int] = set()
+    for part in re.split(r"\s*[,;]\s*", raw):
+        part = part.strip()
+        if not part:
+            continue
+
+        range_match = re.fullmatch(r"(\d+)\s*[-\u2013\u2014]\s*(\d+)", part)
+        if range_match:
+            start = int(range_match.group(1))
+            end = int(range_match.group(2))
+            if start <= end and end - start <= 100:
+                numbers.update(range(start, end + 1))
+            continue
+
+        if part.isdigit():
+            numbers.add(int(part))
+    return numbers
+
+
+def _parse_citation_numbers(report: str) -> set[int]:
+    """Return bibliography numbers referenced by inline citation markers."""
+    numbers: set[int] = set()
+    for match in _CITATION_MARKER_RE.finditer(report):
+        numbers.update(_expand_citation_numbers(match.group(1)))
+    return numbers
+
+
+def _parse_bibliography_urls(report: str) -> dict[int, str]:
+    """Parse trailing numbered bibliography lines into citation-number URLs."""
+    bibliography: dict[int, str] = {}
+    for match in _BIBLIOGRAPHY_LINE_RE.finditer(report):
+        urls = _extract_urls(match.group(2))
+        if urls:
+            bibliography[int(match.group(1))] = urls[-1]
+    return bibliography
+
+
+def _source_url(source: object) -> str:
+    if not isinstance(source, dict):
+        return ""
+    return _normalize_url(str(source.get("url") or ""))
+
+
+def _source_title(source: object) -> str:
+    if not isinstance(source, dict):
+        return ""
+    return str(source.get("title") or "").strip()
+
+
+def _source_positions_by_url(sources: list[object]) -> dict[str, list[int]]:
+    positions: defaultdict[str, list[int]] = defaultdict(list)
+    for position, source in enumerate(sources):
+        url = _source_url(source)
+        if url:
+            positions[url].append(position)
+    return dict(positions)
+
+
+def _is_importable_source(source: object) -> bool:
+    """Return whether core import_research_sources can import this source."""
+    if not isinstance(source, dict):
+        return True
+    return bool(source.get("url")) and source.get("result_type") != 5
+
+
+def _derive_cited_source_positions(report: str, sources: list[object]) -> set[int]:
+    """Resolve report citations to source list positions."""
+    if not report or not sources:
+        return set()
+
+    url_to_positions = _source_positions_by_url(sources)
+    strong_positions: set[int] = set()
+    bibliography = _parse_bibliography_urls(report)
+
+    for citation_number in _parse_citation_numbers(report):
+        url = bibliography.get(citation_number)
+        if url:
+            strong_positions.update(url_to_positions.get(url, []))
+
+    for url in _extract_urls(report):
+        strong_positions.update(url_to_positions.get(url, []))
+
+    cited_positions = set(strong_positions)
+    report_lower = report.lower()
+    title_to_positions: defaultdict[str, list[int]] = defaultdict(list)
+    for position, source in enumerate(sources):
+        title = _source_title(source).lower()
+        if len(title) >= 8:
+            title_to_positions[title].append(position)
+
+    for title, positions in title_to_positions.items():
+        if title in report_lower and not any(position in strong_positions for position in positions):
+            cited_positions.update(positions)
+
+    return cited_positions
+
+
+def annotate_cited_sources(sources: list[object], report: str) -> list[object]:
+    """Return sources with a `cited` flag derived from the research report."""
+    cited_positions = _derive_cited_source_positions(report, sources)
+    annotated_sources: list[object] = []
+    for position, source in enumerate(sources):
+        if isinstance(source, dict):
+            annotated_source = dict(source)
+            annotated_source["cited"] = position in cited_positions
+            annotated_sources.append(annotated_source)
+        else:
+            annotated_sources.append(source)
+    return annotated_sources
 
 
 def start_research(
@@ -187,8 +327,8 @@ def poll_research(
             break
         time.sleep(min(poll_interval, remaining))
 
-    sources = result.get("sources", [])
     report = result.get("report", "")
+    sources = annotate_cited_sources(result.get("sources", []), report)
 
     if compact:
         if len(report) > 500:
@@ -217,6 +357,7 @@ def import_research(
     task_id: str,
     source_indices: list[int] | None = None,
     timeout: float = 300.0,
+    cited_only: bool = False,
 ) -> ResearchImportResult:
     """Import discovered sources from a completed research task.
 
@@ -226,6 +367,8 @@ def import_research(
         task_id: Research task ID
         source_indices: Indices of sources to import (default: all)
         timeout: HTTP timeout in seconds (default: 300s)
+        cited_only: Import only sources cited by the research report.
+            Overrides source_indices when enabled.
 
     Returns:
         ResearchImportResult
@@ -254,8 +397,20 @@ def import_research(
             user_message="No sources were found in the research results.",
         )
 
-    # Filter by indices if provided
-    if source_indices is not None:
+    if cited_only:
+        cited_positions = _derive_cited_source_positions(
+            research_result.get("report", ""),
+            all_sources,
+        )
+        cited_sources = [
+            source for position, source in enumerate(all_sources) if position in cited_positions
+        ]
+        sources_to_import = (
+            cited_sources
+            if cited_sources and any(_is_importable_source(source) for source in cited_sources)
+            else all_sources
+        )
+    elif source_indices is not None:
         sources_to_import = [
             all_sources[idx] for idx in source_indices if 0 <= idx < len(all_sources)
         ]

--- a/tests/services/test_research.py
+++ b/tests/services/test_research.py
@@ -7,6 +7,7 @@ import pytest
 from notebooklm_tools.core.errors import RPCError
 from notebooklm_tools.services.errors import ServiceError, ValidationError
 from notebooklm_tools.services.research import (
+    annotate_cited_sources,
     import_research,
     poll_research,
     start_research,
@@ -163,6 +164,26 @@ class TestPollResearch:
         assert len(result["sources"]) == 6  # 5 + note
         assert "more sources" in str(result["sources"][-1])
 
+    def test_completed_status_marks_cited_sources(self, mock_client):
+        report = (
+            "The report relies on the second source [1].\n\n"
+            "1. Cited Paper, [https://example.com/cited](https://example.com/cited)"
+        )
+        mock_client.poll_research.return_value = {
+            "status": "completed",
+            "task_id": "t-1",
+            "sources": [
+                {"index": 0, "title": "Uncited", "url": "https://example.com/uncited"},
+                {"index": 1, "title": "Cited Paper", "url": "https://example.com/cited"},
+            ],
+            "report": report,
+        }
+
+        result = poll_research(mock_client, "nb-1", compact=False)
+
+        assert result["sources"][0]["cited"] is False
+        assert result["sources"][1]["cited"] is True
+
     def test_api_error_raises_service_error(self, mock_client):
         mock_client.poll_research.side_effect = RuntimeError("fail")
         with pytest.raises(ServiceError, match="Failed to poll"):
@@ -311,6 +332,94 @@ class TestImportResearch:
         # Verify the correct source was passed
         call_args = mock_client.import_research_sources.call_args
         assert call_args.kwargs["sources"] == [{"title": "B"}]
+
+    def test_import_cited_only_resolves_bibliography_urls(self, mock_client):
+        sources = [
+            {"index": 0, "title": "Unused", "url": "https://example.com/unused"},
+            {"index": 1, "title": "Also unused", "url": "https://example.com/also-unused"},
+            {"index": 2, "title": "Cited", "url": "https://example.com/cited"},
+        ]
+        mock_client.poll_research.return_value = {
+            "status": "completed",
+            "sources": sources,
+            "report": (
+                "NotebookLM cites bibliography item one [1].\n\n"
+                "1. Cited, [https://example.com/cited](https://example.com/cited)"
+            ),
+        }
+        mock_client.import_research_sources.return_value = [{"title": "Cited"}]
+
+        import_research(mock_client, "nb-1", "task-1", cited_only=True)
+
+        call_args = mock_client.import_research_sources.call_args
+        assert call_args.kwargs["sources"] == [sources[2]]
+
+    def test_import_cited_only_overrides_source_indices(self, mock_client):
+        sources = [
+            {"index": 0, "title": "Manual pick", "url": "https://example.com/manual"},
+            {"index": 1, "title": "Cited", "url": "https://example.com/cited"},
+        ]
+        mock_client.poll_research.return_value = {
+            "status": "completed",
+            "sources": sources,
+            "report": (
+                "The report cites the second source [1].\n\n"
+                "1. Cited, [https://example.com/cited](https://example.com/cited)"
+            ),
+        }
+        mock_client.import_research_sources.return_value = [{"title": "Cited"}]
+
+        import_research(
+            mock_client,
+            "nb-1",
+            "task-1",
+            source_indices=[0],
+            cited_only=True,
+        )
+
+        call_args = mock_client.import_research_sources.call_args
+        assert call_args.kwargs["sources"] == [sources[1]]
+
+    def test_import_cited_only_falls_back_to_all_sources_without_citations(self, mock_client):
+        sources = [
+            {"index": 0, "title": "A", "url": "https://example.com/a"},
+            {"index": 1, "title": "B", "url": "https://example.com/b"},
+        ]
+        mock_client.poll_research.return_value = {
+            "status": "completed",
+            "sources": sources,
+            "report": "The report has no citation markers or bibliography.",
+        }
+        mock_client.import_research_sources.return_value = [{"title": "A"}, {"title": "B"}]
+
+        import_research(mock_client, "nb-1", "task-1", cited_only=True)
+
+        call_args = mock_client.import_research_sources.call_args
+        assert call_args.kwargs["sources"] == sources
+
+    def test_annotate_cited_sources_skips_duplicate_title_false_positive(self):
+        sources = [
+            {
+                "index": 0,
+                "title": "Embedding-Based Context-Aware Reranker",
+                "url": "https://example.com/paper-v1",
+            },
+            {
+                "index": 1,
+                "title": "Embedding-Based Context-Aware Reranker",
+                "url": "https://example.com/paper-v2",
+            },
+        ]
+        report = (
+            "Embedding-Based Context-Aware Reranker improves retrieval [1].\n\n"
+            "1. Embedding-Based Context-Aware Reranker, "
+            "[https://example.com/paper-v2](https://example.com/paper-v2)"
+        )
+
+        annotated = annotate_cited_sources(sources, report)
+
+        assert annotated[0]["cited"] is False
+        assert annotated[1]["cited"] is True
 
     def test_no_research_raises_service_error(self, mock_client):
         mock_client.poll_research.return_value = {"status": "no_research"}


### PR DESCRIPTION
## Summary
- mark research_status sources with a cited flag by resolving report citations through bibliography URLs
- add cited_only support to research_import, MCP, and CLI --cited-only
- fall back to importing all sources when no cited subset can be resolved
- document the new CLI and MCP usage

Fixes #186

## Validation
- .\.venv\Scripts\python.exe -m pytest tests/services/test_research.py -q
- .\.venv\Scripts\python.exe -m ruff check .
- .\.venv\Scripts\python.exe -m mypy src\notebooklm_tools\services\research.py
- .\.venv\Scripts\python.exe -m compileall -q src\notebooklm_tools