### PR TITLE
fix: set content type for notebook query requests

### DIFF
--- a/src/notebooklm_tools/core/conversation.py
+++ b/src/notebooklm_tools/core/conversation.py
@@ -292,7 +292,10 @@ class ConversationMixin(BaseClient):
         url = f"{self._get_base_url()}{self.QUERY_ENDPOINT}?{query_string}"
 
         cookies = self._get_httpx_cookies()
-        with _httpx.Client(timeout=timeout, cookies=cookies) as client:
+        # The streamed query endpoint is stricter than batchexecute and rejects
+        # form-encoded payloads without an explicit Content-Type header.
+        headers = {"Content-Type": "application/x-www-form-urlencoded;charset=UTF-8"}
+        with _httpx.Client(timeout=timeout, cookies=cookies, headers=headers) as client:
             response = client.post(url, content=body)
             response.raise_for_status()
 

--- a/tests/core/test_conversation.py
+++ b/tests/core/test_conversation.py
@@ -2,7 +2,7 @@
 """Tests for ConversationMixin."""
 
 import json
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 
@@ -169,6 +169,11 @@ class TestQueryUsesServerConversationId:
 
             result = mixin.query("nb-123", "Hello?", source_ids=["src-1"])
 
+        mock_client_class.assert_called_once_with(
+            timeout=120.0,
+            cookies=ANY,
+            headers={"Content-Type": "application/x-www-form-urlencoded;charset=UTF-8"},
+        )
         assert result["conversation_id"] == "server-conv-id"
 
     def test_falls_back_to_uuid_when_no_server_id(self):


### PR DESCRIPTION
## Summary

Fixes streamed notebook query requests by sending an explicit form content type header:

```http
Content-Type: application/x-www-form-urlencoded;charset=UTF-8
```

The `GenerateFreeFormStreamed` endpoint rejects the form-encoded `f.req` body without this header and returns `400 Bad Request` with an XSRF-looking error payload, even when cookies and CSRF token are valid.

## Context

While testing `nlm notebook query` against NotebookLM with a valid authenticated profile, these operations worked:

- `nlm login --check`
- `nlm notebook list`
- `nlm notebook create`
- `nlm source add`
- `nlm source get`
- `nlm source describe`
- `nlm notebook describe`

But `nlm notebook query` failed with `400 Bad Request` from:

```text
/_/LabsTailwindUi/data/google.internal.labs.tailwind.orchestration.v1.LabsTailwindOrchestrationService/GenerateFreeFormStreamed
```

Manual isolation showed that the same payload succeeds when the explicit `Content-Type` header is present.

## Changes

- Add `Content-Type: application/x-www-form-urlencoded;charset=UTF-8` to the standalone httpx client used by `ConversationMixin.query()`.
- Add a regression assertion that the query client is constructed with the header.

## Validation

```bash
/tmp/notebooklm-mcp-pr-venv/bin/python -m pytest tests/core/test_conversation.py -q
```

Result:

```text
61 passed in 0.29s
```

Also validated manually against a live NotebookLM test notebook: after this patch, `nlm notebook query --profile fabi` returned an answer with `conversation_id`, `sources_used`, citations, and references.
