### PR TITLE
feat: support EPUB file uploads

### DIFF
--- a/src/notebooklm_tools/cli/ai_docs.py
+++ b/src/notebooklm_tools/cli/ai_docs.py
@@ -232,7 +232,7 @@ nlm source add <notebook-id> --file doc.pdf --wait          # Upload and wait un
 nlm source add <notebook-id> --drive <doc-id>              # Add Drive doc
 nlm source add <notebook-id> --drive <doc-id> --type slides  # Add Drive slides
 # Types: doc, slides, sheets, pdf
-# Supported file types: PDF, TXT, MD, DOCX, CSV, MP3, M4A, WAV, AAC, OGG, OPUS, MP4, JPG, JPEG, PNG, GIF, WEBP
+# Supported file types: PDF, TXT, MD, DOCX, CSV, EPUB, MP3, M4A, WAV, AAC, OGG, OPUS, MP4, JPG, JPEG, PNG, GIF, WEBP
 
 nlm source get <source-id>             # Get source metadata
 nlm source get <source-id> --json      # JSON output

--- a/src/notebooklm_tools/core/sources.py
+++ b/src/notebooklm_tools/core/sources.py
@@ -845,7 +845,7 @@ class SourceMixin(BaseClient):
         2. Start upload session with SOURCE_ID → get upload URL
         3. Stream upload file content (memory-efficient for large files)
 
-        Supported file types: PDF, TXT, MD, DOCX, CSV, MP3, M4A, WAV, AAC, OGG, OPUS, MP4, JPG, PNG, GIF, WEBP
+        Supported file types: PDF, TXT, MD, DOCX, CSV, EPUB, MP3, M4A, WAV, AAC, OGG, OPUS, MP4, JPG, PNG, GIF, WEBP
 
         Args:
             notebook_id: The notebook ID to add the source to
@@ -883,6 +883,7 @@ class SourceMixin(BaseClient):
             ".md",
             ".docx",
             ".csv",  # Documents
+            ".epub",  # Ebooks
             ".mp3",
             ".m4a",
             ".wav",

--- a/tests/test_file_upload.py
+++ b/tests/test_file_upload.py
@@ -273,6 +273,41 @@ class TestAddFileIntegration:
         finally:
             temp_path.unlink()
 
+    def test_add_file_accepts_epub(self):
+        """Test that EPUB files pass validation and use the upload protocol."""
+        from notebooklm_tools.core.sources import SourceMixin
+
+        client = SourceMixin.__new__(SourceMixin)
+        client.cookies = {"test": "cookie"}
+        client.csrf_token = "test-csrf"
+        client._session_id = "test-session"
+        client._client = None
+
+        with tempfile.NamedTemporaryFile(mode="wb", suffix=".epub", delete=False) as f:
+            f.write(b"PK\x03\x04fake epub content")
+            temp_path = Path(f.name)
+
+        try:
+            with (
+                patch.object(
+                    client, "_register_file_source", return_value="source-id-epub"
+                ) as mock_register,
+                patch.object(
+                    client, "_start_resumable_upload", return_value="https://upload.url/session"
+                ) as mock_start,
+                patch.object(client, "_upload_file_streaming") as mock_upload,
+            ):
+                result = client.add_file("notebook-123", temp_path)
+
+            mock_register.assert_called_once_with("notebook-123", temp_path.name)
+            mock_start.assert_called_once()
+            mock_upload.assert_called_once_with("https://upload.url/session", temp_path)
+
+            assert result["id"] == "source-id-epub"
+            assert result["title"] == temp_path.name
+        finally:
+            temp_path.unlink()
+
 
 @pytest.mark.e2e
 class TestFileUploadE2E:


### PR DESCRIPTION
## Summary
- allow `.epub` files through local file upload validation
- update AI-facing file upload docs to list EPUB as supported
- add unit coverage that EPUB files pass validation and use the existing upload protocol

## Verification
- `uv run pytest tests/test_file_upload.py tests/cli/test_source_add.py -q` -> 22 passed
- `uv run ruff check src/notebooklm_tools/core/sources.py src/notebooklm_tools/cli/ai_docs.py tests/test_file_upload.py` -> passed
- `uv run ruff format --check src/notebooklm_tools/core/sources.py src/notebooklm_tools/cli/ai_docs.py tests/test_file_upload.py` -> passed
- Manual API check with `nlm source add <notebook-id> --file The\ Art\ of\ Gathering.epub --wait --wait-timeout 300` after enabling `.epub`: source reached `ready`; `nlm notebook query` answered with citations from that EPUB source.

## Notes
- I also tried `.azw3` and `.mobi` during manual validation; both still failed, so this PR only enables `.epub`.
- `uv run pytest -q` reached 842 passed / 37 skipped, with one unrelated CDP auth migration failure: `tests/test_auth_migration.py::TestBrowserErrorMessages::test_cannot_connect_error_is_generic`.
