### PR TITLE
fix(download): set Sec-Fetch-Site: cross-site for cross-domain artifa…

### DIFF
--- a/src/notebooklm_tools/core/download.py
+++ b/src/notebooklm_tools/core/download.py
@@ -122,7 +122,19 @@ class DownloadMixin(BaseClient):
             "_PAGE_FETCH_HEADERS",
             {"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"},
         )
-        headers = {**base_headers, "Referer": f"{self._get_base_url()}/"}
+        # Mirror Chrome's window.open() from notebooklm.google.com to a cross-domain
+        # artifact host (lh3.googleusercontent.com / lh3.google.com). The audio CDN
+        # treats "Sec-Fetch-Site: none" as an address-bar navigation and returns 403;
+        # the UI's Download button succeeds because window.open() makes Chrome stamp
+        # the request with "Sec-Fetch-Site: cross-site" + Referer=notebooklm.google.com.
+        headers = {
+            **base_headers,
+            "Referer": f"{self._get_base_url()}/",
+            "Sec-Fetch-Site": "cross-site",
+            "Sec-Fetch-Dest": "document",
+            "Sec-Fetch-Mode": "navigate",
+            "Sec-Fetch-User": "?1",
+        }
 
         # Use httpx.Cookies for proper cross-domain redirect handling
         cookies = self._get_httpx_cookies()


### PR DESCRIPTION
…ct downloads

Audio download has been returning HTTP 403 from lh3.google.com/rd-notebooklm/... because _download_url inherits Sec-Fetch-Site: none from _PAGE_FETCH_HEADERS. Google's audio CDN treats that header value as an unauthorized address-bar navigation and rejects the request, regardless of the authenticated cookies or the OSID strip from PR #180.

The Studio UI's Download button works because it uses window.open() from notebooklm.google.com, which Chrome stamps with Sec-Fetch-Site: cross-site plus Referer: https://notebooklm.google.com/. Same URL, same cookies, different Sec-Fetch-Site, different outcome.

This change mirrors Chrome's window.open() header shape on every cross- domain artifact download. Verified empirically: same notebook that returned 'Download failed for audio.' now produces a 41.7 MB AAC-in-MP4 (byte-for-byte matching the UI Download).

No behavior change for infographic / slide_deck / video — those URLs already accepted the inherited headers; setting cross-site is harmless when the destination is on a different origin from notebooklm.google.com.