### PR TITLE
docs(mcp/source_add): document the full supported file-type list

### DIFF
--- a/src/notebooklm_tools/mcp/tools/sources.py
+++ b/src/notebooklm_tools/mcp/tools/sources.py
@@ -36,7 +36,13 @@ def source_add(
             - url: Web page or YouTube URL
             - text: Pasted text content
             - drive: Google Drive document
-            - file: Local file upload (PDF, text, audio)
+            - file: Local file upload. Supported extensions:
+                PDF, TXT, MD, DOCX, CSV, EPUB, MP3, M4A, WAV, AAC, OGG,
+                OPUS, MP4, JPG, JPEG, PNG, GIF, WEBP. Image-bearing
+                sources (PDF / JPG / PNG / etc.) feed Studio video
+                generation's visual-crop pipeline — charts, photos, and
+                diagrams may be extracted as on-screen aids in Video
+                Overviews.
         url: URL to add (for source_type=url)
         urls: List of URLs to add in bulk (for source_type=url, alternative to url)
         text: Text content to add (for source_type=text)
@@ -52,6 +58,7 @@ def source_add(
         source_add(notebook_id="abc", source_type="url", urls=["https://a.com", "https://b.com"])
         source_add(notebook_id="abc", source_type="url", url="https://example.com", wait=True)
         source_add(notebook_id="abc", source_type="file", file_path="/path/to/doc.pdf", wait=True)
+        source_add(notebook_id="abc", source_type="file", file_path="/path/to/screenshot.png", wait=True)
     """
     try:
         client = get_client()


### PR DESCRIPTION
## Summary

The `source_add` MCP tool's docstring currently says `- file: Local file upload (PDF, text, audio)` — which is misleading. The `core/sources.py:add_file` function and the CLI's `ai_docs.py` already document the broader supported set: `PDF, TXT, MD, DOCX, CSV, EPUB, MP3, M4A, WAV, AAC, OGG, OPUS, MP4, JPG, JPEG, PNG, GIF, WEBP` (recently confirmed by #191's EPUB addition).

This narrow PR aligns the MCP tool docstring with the canonical list, so AI agents reading the MCP tool description don't assume image / video / docx uploads are unsupported when they actually work.

## Why this matters

I hit this empirically today: NotebookLM's web UI ingests image uploads and Gemini's Studio video generation crops visual segments from those sources to use as on-screen aids in Video Overviews. An agent reading the MCP docstring would conclude images aren't supported and either (a) skip uploading screenshots to NotebookLM, or (b) bundle them into a PDF unnecessarily. Empirically, `source_add(source_type="file", file_path="...screenshot.png")` succeeds and the resulting Studio video can use the image visually.

## Change

- `src/notebooklm_tools/mcp/tools/sources.py`:
  - Replace the `(PDF, text, audio)` shorthand with the same extension list `core/sources.py:add_file` already documents
  - Add a one-sentence note about image-bearing sources feeding Studio video generation's visual-crop pipeline (referenced behavior is documented in Google's NotebookLM materials; surfacing it in the MCP tool docstring helps AI clients choose the right source shape)
  - Add a PNG path to the example block so agents see image upload as a first-class example

## What this is NOT

- Not a code change — pure docstring update
- Not a file-type allowlist change — the actual allowlist already accepts all these extensions (validated in `core/sources.py:add_file`'s `valid_extensions` set, recently extended via #191)
- Not a behavioral change — `source_add(source_type="file", file_path="...png")` already worked; only the description was misleading

## Test plan

- [x] Verified `source_add type=file` with a PNG against a real NotebookLM notebook — succeeds, source is ready and queryable
- [x] Verified the resulting Studio video generation can use the image source for visual crops
- [x] No production code path changes (docstring-only); existing tests cover the behavioral surface unchanged

Filed against v0.6.11.