### PR TITLE
fix: parse Netscape cookie file format in --manual login

### DIFF
--- a/src/notebooklm_tools/utils/browser.py
+++ b/src/notebooklm_tools/utils/browser.py
@@ -20,6 +20,8 @@ def parse_cookies_from_file(file_path: str | Path) -> dict[str, str]:
     - Raw cookie header string (Cookie: name=value; name2=value2)
     - cURL command (copy as cURL from DevTools)
     - JSON object with cookies
+    - Netscape/Mozilla cookie file format (tab-separated, as exported by
+      browser extensions like "Get cookies.txt LOCALLY")
 
     Args:
         file_path: Path to the file containing cookies.
@@ -56,6 +58,13 @@ def parse_cookies_from_file(file_path: str | Path) -> dict[str, str]:
     except json.JSONDecodeError:
         pass
 
+    # Try Netscape/Mozilla cookie file format
+    # Format: domain  flag  path  secure  expires  name  value  (tab-separated)
+    # Lines starting with '#' are comments
+    netscape_cookies = _try_parse_netscape_cookies(content)
+    if netscape_cookies:
+        return netscape_cookies
+
     # Try to extract from cURL command
     curl_match = re.search(r"-H\s+['\"]Cookie:\s*([^'\"]+)['\"]", content, re.IGNORECASE)
     if curl_match:
@@ -83,6 +92,36 @@ def parse_cookies_from_file(file_path: str | Path) -> dict[str, str]:
         )
 
     return cookies
+
+
+def _try_parse_netscape_cookies(content: str) -> dict[str, str] | None:
+    """
+    Try to parse Netscape/Mozilla cookie file format.
+
+    Format is tab-separated:
+        domain  flag  path  secure  expires  name  value
+
+    Lines starting with '#' are comments. Returns None if
+    the content doesn't appear to be Netscape format.
+    """
+    cookies: dict[str, str] = {}
+    valid_lines = 0
+
+    for line in content.splitlines():
+        line = line.strip()
+        # Skip comments and blank lines
+        if not line or line.startswith("#"):
+            continue
+        # Netscape format: 7 tab-separated fields
+        parts = line.split("\t")
+        if len(parts) >= 7:
+            name = parts[5].strip()
+            value = parts[6].strip()
+            if name and value:
+                cookies[name] = value
+                valid_lines += 1
+
+    return cookies if valid_lines > 0 else None
 
 
 def cookies_to_header(cookies: dict[str, str]) -> str:

--- a/tests/test_cookie_parsing.py
+++ b/tests/test_cookie_parsing.py
@@ -1,0 +1,139 @@
+"""Tests for cookie parsing from files (Netscape format support)."""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from notebooklm_tools.core.exceptions import AuthenticationError
+from notebooklm_tools.utils.browser import parse_cookies_from_file
+
+# --- JSON format ---
+
+
+def test_parse_json_dict():
+    """JSON dict format: {"name": "value"}."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump({"SID": "abc123", "HSID": "def456"}, f)
+        path = f.name
+    try:
+        result = parse_cookies_from_file(path)
+        assert result == {"SID": "abc123", "HSID": "def456"}
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+# --- Netscape format ---
+
+SAMPLE_NETSCAPE = """# Netscape HTTP Cookie File
+# https://curl.haxx.se/rfc/cookie_spec.html
+# This is a generated file! Do not edit.
+
+.google.com\tTRUE\t/\tFALSE\t1788094158\tSEARCH_SAMESITE\tCgQIo6AB
+.google.com\tTRUE\t/\tTRUE\t1788094158\t__Secure-BUCKET\tCMID
+.google.com\tTRUE\t/\tFALSE\t1812953356\tSID\tsid-value-123
+.google.com\tTRUE\t/\tTRUE\t1812953356\tHSID\tA1SAks--UQ
+.google.com\tTRUE\t/\tTRUE\t1812953356\tSSID\tAYOTqrMe
+.google.com\tTRUE\t/\tFALSE\t1812953356\tAPISID\tapi-value-789
+.google.com\tTRUE\t/\tTRUE\t1812953356\tSAPISID\tsapi-value-000
+notebooklm.google.com\tFALSE\t/\tTRUE\t1814162423\tOSID\tosid-value-111
+"""
+
+
+def test_parse_netscape_format():
+    """Netscape cookie file with tab-separated fields."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write(SAMPLE_NETSCAPE)
+        path = f.name
+    try:
+        result = parse_cookies_from_file(path)
+        assert result["SID"] == "sid-value-123"
+        assert result["HSID"] == "A1SAks--UQ"
+        assert result["SSID"] == "AYOTqrMe"
+        assert result["APISID"] == "api-value-789"
+        assert result["SAPISID"] == "sapi-value-000"
+        assert result["OSID"] == "osid-value-111"
+        assert result["SEARCH_SAMESITE"] == "CgQIo6AB"
+        assert result["__Secure-BUCKET"] == "CMID"
+        assert len(result) == 8
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_netscape_passes_validation():
+    """Netscape cookies should pass validate_notebooklm_cookies."""
+    from notebooklm_tools.utils.browser import validate_notebooklm_cookies
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write(SAMPLE_NETSCAPE)
+        path = f.name
+    try:
+        result = parse_cookies_from_file(path)
+        assert validate_notebooklm_cookies(result) is True
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_netscape_skips_blank_and_comments():
+    """Blank lines and comments starting with # are skipped."""
+    content = """# Header comment
+# Another comment
+
+.google.com\tTRUE\t/\tTRUE\t1\tMYCOOKIE\tmyvalue
+
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write(content)
+        path = f.name
+    try:
+        result = parse_cookies_from_file(path)
+        assert result == {"MYCOOKIE": "myvalue"}
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_non_netscape_tab_content_ignored():
+    """Content with tabs but not 7+ fields per line falls through."""
+    content = "just\ta\tfew\tfields\nnot\tenough"
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write(content)
+        path = f.name
+    try:
+        with pytest.raises(AuthenticationError, match="Could not parse cookies"):
+            parse_cookies_from_file(path)
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+# --- Cookie header format (existing, ensure not broken) ---
+
+
+def test_parse_cookie_header():
+    """Standard Cookie header format."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write("Cookie: SID=abc; HSID=def; SSID=ghi")
+        path = f.name
+    try:
+        result = parse_cookies_from_file(path)
+        assert result == {"SID": "abc", "HSID": "def", "SSID": "ghi"}
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_parse_name_value_pairs():
+    """Plain name=value pairs separated by semicolons."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write("SID=abc; HSID=def; SSID=ghi")
+        path = f.name
+    try:
+        result = parse_cookies_from_file(path)
+        assert result == {"SID": "abc", "HSID": "def", "SSID": "ghi"}
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_file_not_found():
+    """Missing file raises AuthenticationError."""
+    with pytest.raises(AuthenticationError, match="Cookie file not found"):
+        parse_cookies_from_file("/tmp/nonexistent_cookie_file_xyz.txt")


### PR DESCRIPTION
Fixes #198

## Problem

The `nlm login --manual --file` command only supported JSON, cURL, and raw Cookie header formats. Browser extensions like "Get cookies.txt LOCALLY" export cookies in Netscape/Mozilla format (tab-separated with domain, path, expires columns), which was stored as a raw JSON key instead of parsed name→value pairs, causing `LocalProtocolError: Illegal header value` on subsequent API calls.

## Fix

Add `_try_parse_netscape_cookies()` that:
- Detects tab-separated format with 7+ fields per line
- Extracts name/value from columns 5/6 (Netscape format: domain, flag, path, secure, expires, name, value)
- Skips comment lines (starting with `#`) and blank lines
- Returns `None` if the content doesn not appear to be Netscape format, falling through to existing parsers

The new parser is inserted after JSON parsing but before cURL/header parsing, so no existing format is affected.

## Tests

8 new tests in `tests/test_cookie_parsing.py` covering:
- Full Netscape file parsing (8 cookies extracted)
- Validation pass-through to `validate_notebooklm_cookies`
- Comment and blank line skipping
- Graceful fallback for non-Netscape tab content
- Existing JSON and header formats unaffected

Full test suite: **871 passed, 0 failed.**