### PR TITLE
fix(security): harden credential storage with TOCTOU-safe file creation

### DIFF
--- a/src/notebooklm_tools/core/auth.py
+++ b/src/notebooklm_tools/core/auth.py
@@ -142,10 +142,14 @@ def save_tokens_to_cache(tokens: AuthTokens, silent: bool = False) -> None:
         silent: If True, don't print confirmation message (for auto-updates)
     """
     cache_path = get_cache_path()
-    with open(cache_path, "w", encoding="utf-8") as f:
+    fd = os.open(str(cache_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        f = os.fdopen(fd, "w", encoding="utf-8")
+    except BaseException:
+        os.close(fd)
+        raise
+    with f:
         json.dump(tokens.to_dict(), f, indent=2)
-    with contextlib.suppress(OSError):
-        os.chmod(cache_path, 0o600)
 
     # Also update the default profile so load_cached_tokens() (which
     # checks profiles first) picks up the same tokens.
@@ -436,13 +440,17 @@ class AuthManager:
         # Set restrictive permissions on the directory
         self.profile_dir.chmod(0o700)
 
-        # Save cookies
-        self.cookies_file.write_text(
-            json.dumps(cookies, indent=2, ensure_ascii=False), encoding="utf-8"
-        )
-        self.cookies_file.chmod(0o600)
+        # Save cookies with restrictive permissions from creation
+        fd = os.open(str(self.cookies_file), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            f = os.fdopen(fd, "w", encoding="utf-8")
+        except BaseException:
+            os.close(fd)
+            raise
+        with f:
+            json.dump(cookies, f, indent=2, ensure_ascii=False)
 
-        # Save metadata
+        # Save metadata with restrictive permissions from creation
         metadata = {
             "csrf_token": csrf_token,
             "session_id": session_id,
@@ -450,10 +458,14 @@ class AuthManager:
             "build_label": build_label,
             "last_validated": datetime.now().isoformat(),
         }
-        self.metadata_file.write_text(
-            json.dumps(metadata, indent=2, ensure_ascii=False), encoding="utf-8"
-        )
-        self.metadata_file.chmod(0o600)
+        fd = os.open(str(self.metadata_file), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            f = os.fdopen(fd, "w", encoding="utf-8")
+        except BaseException:
+            os.close(fd)
+            raise
+        with f:
+            json.dump(metadata, f, indent=2, ensure_ascii=False)
 
         self._profile = Profile(
             name=self.profile_name,

--- a/src/notebooklm_tools/mcp/tools/auth.py
+++ b/src/notebooklm_tools/mcp/tools/auth.py
@@ -101,7 +101,7 @@ def save_auth_tokens(
         for part in cookies.split("; "):
             if "=" in part:
                 key, value = part.split("=", 1)
-                all_cookies[key] = value
+                all_cookies[key.strip()] = value
 
         # Validate required cookies
         required = ["SID", "HSID", "SSID", "APISID", "SAPISID"]

--- a/src/notebooklm_tools/utils/cdp.py
+++ b/src/notebooklm_tools/utils/cdp.py
@@ -156,11 +156,19 @@ def _read_port_map() -> dict[str, dict]:
 
 
 def _save_port_map(data: dict[str, dict]) -> None:
-    """Write port map to disk."""
+    """Write port map to disk with restrictive permissions from creation."""
+    import os as _os
+
     map_file = _get_port_map_file()
-    try:  # noqa: SIM105
-        map_file.write_text(json.dumps(data, indent=2), encoding="utf-8")
-        map_file.chmod(0o600)
+    try:
+        fd = _os.open(str(map_file), _os.O_WRONLY | _os.O_CREAT | _os.O_TRUNC, 0o600)
+        try:
+            f = _os.fdopen(fd, "w", encoding="utf-8")
+        except BaseException:
+            _os.close(fd)
+            raise
+        with f:
+            json.dump(data, f, indent=2)
     except OSError:
         pass  # Best-effort
 
@@ -684,12 +692,13 @@ def terminate_chrome(process: subprocess.Popen | None = None, port: int | None =
         return False
 
     # Attempt graceful shutdown via CDP to prevent "Restore Pages" warnings on next launch
+    ws_to_close = _cached_ws
     try:
         if port or _cached_ws_url:
             execute_cdp_command(_cached_ws_url or get_debugger_url(_chrome_port), "Browser.close")
-            _cached_ws.close()
+            if ws_to_close:
+                ws_to_close.close()
         else:
-            # No fast path, use slow path
             process.terminate()
     except Exception:
         pass  # Ignore connection drops or failures during close


### PR DESCRIPTION
## Summary

- Fix TOCTOU race in credential file creation: use `os.open()` with `0o600` mode at creation instead of write-then-chmod pattern that leaves a brief window where credentials are world-readable
- Use the correct `os.fdopen()` pattern so `os.close(fd)` is only called before the file object takes ownership (fixes the double-close bug from #200)
- Add null-safety check for `_cached_ws` in `terminate_chrome()` to prevent `AttributeError` on double-call
- Add `.strip()` to cookie key parsing for whitespace robustness

**Locations fixed:** `save_tokens_to_cache()`, `AuthManager.save_profile()` (cookies.json + metadata.json), `_save_port_map()`

Split from #200 per review feedback.

## Test plan

- [ ] Verify `save_tokens_to_cache()` creates files with 0600 permissions (no brief world-readable window)
- [ ] Verify `save_profile()` creates cookies.json and metadata.json with 0600 permissions
- [ ] Verify `terminate_chrome()` handles None `_cached_ws` without error
- [ ] Run existing test suite: `uv run pytest -v --tb=short -m "not e2e"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)