### PR TITLE
fix(security): redact sensitive cookie values from debug logs

### DIFF
--- a/src/notebooklm_tools/core/base.py
+++ b/src/notebooklm_tools/core/base.py
@@ -670,10 +670,9 @@ class BaseClient:
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug("-" * 70)
                 logger.debug(f"Response Status: {response.status_code}")
-                logger.debug(
-                    "Raw response (first 2000 chars): %s",
-                    response.text[:2000] if response.text else "(empty)",
-                )
+                _raw = response.text[:2000] if response.text else "(empty)"
+                _raw = re.sub(r'"(SID|HSID|SSID|APISID|SAPISID|NID|__Secure-\w+)":\s*"[^"]*"', r'"\1":"[REDACTED]"', _raw)
+                logger.debug("Raw response (first 2000 chars): %s", _raw)
                 logger.debug("=" * 70)
 
             response.raise_for_status()

--- a/src/notebooklm_tools/core/conversation.py
+++ b/src/notebooklm_tools/core/conversation.py
@@ -333,7 +333,7 @@ class ConversationMixin(BaseClient):
             "references": citation_data.get("references", []),
             "turn_number": turn_number,
             "is_follow_up": not is_new_conversation,
-            "raw_response": response.text[:1000] if response.text else "",
+            "raw_response": "",
         }
 
     def _extract_source_ids_from_notebook(self, notebook_data: Any) -> list[str]:


### PR DESCRIPTION
## Summary

- Redact known sensitive cookie names (SID, HSID, SSID, APISID, SAPISID, NID, __Secure-*) from raw response debug log output to prevent accidental credential exposure
- Stop returning raw API response text in conversation query results, as it may contain session data

Split from #200 per review feedback.

## Test plan

- [ ] Enable DEBUG logging and verify cookie values are replaced with `[REDACTED]` in log output
- [ ] Verify `notebook_query` results have empty `raw_response` field
- [ ] Run existing test suite: `uv run pytest -v --tb=short -m "not e2e"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)