### PR TITLE
ci: pin all GitHub Actions to full 40-char commit SHAs

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9  # v7
 
       - name: Run ruff linting
         run: uv run --dev ruff check . --output-format=github
@@ -30,10 +30,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9  # v7
 
       - name: Run tests with pytest
         run: uv run --dev --with pytest-github-actions-annotate-failures --with pytest-asyncio pytest -v --tb=short -m "not e2e"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,10 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f  # v4
         with:
           version: "latest"
       
@@ -28,12 +28,12 @@ jobs:
         run: uv build
       
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
 
       - name: Build MCPB extension
         run: python3 scripts/build_mcpb.py
 
       - name: Upload MCPB to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
         with:
           files: notebooklm-mcp-*.mcpb

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9  # v7
 
       - name: Run ruff linting
         run: uv run --dev ruff check . --output-format=github
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9  # v7
 
       - name: Run tests
         run: uv run --dev --with pytest-github-actions-annotate-failures --with pytest-asyncio pytest -v --tb=short -m "not e2e"
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Check all version strings match
         run: |

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Extract and compare versions
         run: |


### PR DESCRIPTION
## Summary

Pin every third-party GitHub Action to its full 40-character commit SHA to prevent tag-drift supply chain attacks. The original tag is preserved in a trailing comment for readability.

**Pinned actions:**
| Action | Tag | Full SHA |
|--------|-----|----------|
| actions/checkout | v6 | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| actions/checkout | v4 | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| astral-sh/setup-uv | v7 | `94527f2e458b27549849d47d273a16bec83a01e9` |
| astral-sh/setup-uv | v4 | `e4db8464a088ece1b920f60402e813ea4de65b8f` |
| pypa/gh-action-pypi-publish | release/v1 | `cef221092ed1bacb1cc03d23a2d87d1d172e277b` |
| softprops/action-gh-release | v2 | `3bb12739c298aeb8a4eeaf626c5b8d85266b0e65` |

All SHAs verified against their respective tags via `gh api repos/<owner>/<repo>/git/refs/tags/<tag>`.

Split from #200 per review feedback.

## Test plan

- [ ] Verify CI workflows still pass on this PR
- [ ] Spot-check SHA→tag mapping for 2-3 actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)