### PR TITLE
Fix nlm login crash on expired auth

### DIFF
--- a/src/notebooklm_tools/cli/main.py
+++ b/src/notebooklm_tools/cli/main.py
@@ -184,6 +184,7 @@ def login_callback(
     To switch active accounts, run `nlm login switch <profile>`.
     """
     from notebooklm_tools.core.auth import AuthManager
+    from notebooklm_tools.core.errors import ClientAuthenticationError
     from notebooklm_tools.core.exceptions import AccountMismatchError, NLMError
     from notebooklm_tools.utils.config import get_config
 
@@ -248,7 +249,7 @@ def login_callback(
             p, notebook_count = _validate_saved_profile(auth)
             _print_auth_valid(p, notebook_count)
             return
-        except NLMError:
+        except (NLMError, ClientAuthenticationError):
             pass
 
     try:


### PR DESCRIPTION
This PR fixes a bug where running `nlm login` in the terminal crashes with an unhandled exception when cached credentials are fully expired.

### Root Cause
1. In `src/notebooklm_tools/cli/main.py`, the validation check on startup catches `NLMError` and continues to interactive login if the check fails:
   ```python
   try:
       p, notebook_count = _validate_saved_profile(auth)
       _print_auth_valid(p, notebook_count)
       return
   except NLMError:
       pass
   ```
2. However, when the stored Google session/cookies are fully expired, `_validate_saved_profile()` throws **`ClientAuthenticationError`** (aliased as `AuthenticationError` in `base.py`).
3. Unlike other exception classes in the codebase (which inherit from `NLMError`), `ClientAuthenticationError` inherits directly from the standard Python `Exception` class.
4. Because of this, the `except NLMError:` block missed it entirely. The error bubbled all the way up to `cli_main()`, printing the `✗ Authentication Error` block and exiting the program before ever launching Chrome for interactive sign-in.

### Changes
* Imported `ClientAuthenticationError` in `login_callback` in `src/notebooklm_tools/cli/main.py`.
* Updated the `except` block to catch `(NLMError, ClientAuthenticationError)`:
  ```python
  except (NLMError, ClientAuthenticationError):
      pass
  ```
  This allows the CLI to gracefully proceed to launch the interactive sign-in browser when validation fails due to expired sessions.
