### PR TITLE
fix(auth,studio): fail loudly on stale auth instead of silent false-success

### DIFF
--- a/src/notebooklm_tools/mcp/tools/auth.py
+++ b/src/notebooklm_tools/mcp/tools/auth.py
@@ -44,9 +44,24 @@ def refresh_auth() -> ResultDict:
             # Reset client to force re-initialization with fresh tokens
             reset_client()
             get_client()  # This will use the cached tokens
+
+            # Honesty check: reloading tokens from disk is NOT a successful
+            # re-auth if those tokens are already dead. Validate live before
+            # claiming success, otherwise agents loop on doomed studio calls.
+            from notebooklm_tools.core.auth import check_auth
+
+            check = check_auth(live=True)
+            if not check.valid:
+                return error_result(
+                    "Auth tokens were reloaded from disk but are no longer valid "
+                    f"(reason: {check.reason}). A disk reload cannot revive expired "
+                    "credentials — run `nlm login` in a terminal to re-authenticate.",
+                    status="expired",
+                    reason=check.reason,
+                )
             return {
                 "status": "success",
-                "message": "Auth tokens reloaded from disk cache.",
+                "message": "Auth tokens reloaded from disk cache and validated.",
             }
 
         # Try headless auth if Chrome profile exists

--- a/src/notebooklm_tools/mcp/tools/studio.py
+++ b/src/notebooklm_tools/mcp/tools/studio.py
@@ -15,6 +15,17 @@ def _normalize_studio_validation_error(message: str) -> str:
     return message
 
 
+def _check_studio_auth():
+    """Live auth validity check used as a pre-flight gate for generation.
+
+    Returns an AuthCheckResult. Isolated in its own function so it is an easy
+    seam to mock in tests and so the import stays lazy (no network at import).
+    """
+    from notebooklm_tools.core.auth import check_auth
+
+    return check_auth(live=True)
+
+
 @logged_tool()
 def studio_create(
     notebook_id: str,
@@ -143,6 +154,20 @@ def studio_create(
             "settings": settings,
             "note": "Set confirm=True after user approves these settings.",
         }
+
+    # Pre-flight auth gate: fail loudly NOW rather than returning a fake
+    # success with an artifact_id that silently fails seconds later (the bug
+    # that sent agents into pointless polling loops). See bug report 2026-06-01.
+    auth = _check_studio_auth()
+    if not auth.valid:
+        return error_result(
+            f"Cannot create {artifact_type}: NotebookLM auth is not valid "
+            f"(reason: {auth.reason}). Run `nlm login` in a terminal to "
+            "re-authenticate, then retry. `refresh_auth()` will NOT help if the "
+            "tokens are expired — it only reloads them from disk.",
+            hint="nlm login",
+            reason=auth.reason,
+        )
 
     try:
         client = get_client()

--- a/src/notebooklm_tools/services/studio.py
+++ b/src/notebooklm_tools/services/studio.py
@@ -78,6 +78,7 @@ class ArtifactInfo(TypedDict, total=False):
     type: str
     title: str
     status: str
+    error_reason: str | None
     created_at: str | None
     url: str | None
     custom_instructions: str | None
@@ -566,6 +567,31 @@ def _create_mind_map(
 # ---------- Status ----------
 
 
+def _derive_error_reason(raw_artifact: dict[str, Any]) -> str | None:
+    """Best-effort failure reason for a studio artifact.
+
+    The raw NotebookLM gRPC payload does not include an error string, so:
+    1. Prefer a real key if a future API version provides one.
+    2. Otherwise, synthesize a reason for genuinely failed artifacts so callers
+       get a non-null signal instead of silence (the bug: failed artifacts
+       returned every field null, leaving agents to poll forever).
+    Non-failed artifacts return None.
+    """
+    for key in ("error_reason", "failure_reason", "failure_code", "error"):
+        value = raw_artifact.get(key)
+        if isinstance(value, str) and value:
+            return value
+
+    if raw_artifact.get("status") == "failed":
+        return (
+            "generation_failed: NotebookLM rejected or aborted this artifact "
+            "(no media produced). Common causes: expired auth, capacity/"
+            "rate-limit, or an unsupported prompt. Re-check auth (nlm login) "
+            "and retry."
+        )
+    return None
+
+
 def get_studio_status(
     client: NotebookLMClient,
     notebook_id: str,
@@ -598,6 +624,11 @@ def get_studio_status(
             "status": raw_artifact.get("status")
             if isinstance(raw_artifact.get("status"), str)
             else "unknown",
+            # Surface a failure signal so callers stop polling and act. The raw
+            # gRPC payload carries no error string, so prefer any real key if a
+            # future API exposes one, else synthesize a reason for failed
+            # artifacts (status 4 with no media URL = backend rejected the job).
+            "error_reason": _derive_error_reason(raw_artifact),
             "created_at": raw_artifact.get("created_at")
             if isinstance(raw_artifact.get("created_at"), str)
             or raw_artifact.get("created_at") is None

--- a/tests/test_mcp_auth_studio_failures.py
+++ b/tests/test_mcp_auth_studio_failures.py
@@ -42,24 +42,24 @@ def test_refresh_auth_does_not_claim_success_when_tokens_are_expired(monkeypatch
     non-success status that tells the user to run `nlm login`.
     """
     # Tokens DO load from disk (file exists)...
-    monkeypatch.setattr(
-        auth_tools, "get_client", lambda: _FakeClient(), raising=True
-    )
+    monkeypatch.setattr(auth_tools, "get_client", lambda: _FakeClient(), raising=True)
     monkeypatch.setattr(auth_tools, "reset_client", lambda: None, raising=True)
     monkeypatch.setattr(
-        core_auth, "load_cached_tokens",
+        core_auth,
+        "load_cached_tokens",
         lambda: core_auth.AuthTokens(cookies={"SID": "x"}, extracted_at=0.0),
         raising=True,
     )
     # ...but a live check reports them expired.
-    monkeypatch.setattr(core_auth, "check_auth", lambda **kw: _auth_result(False, "expired"), raising=True)
+    monkeypatch.setattr(
+        core_auth, "check_auth", lambda **kw: _auth_result(False, "expired"), raising=True
+    )
     monkeypatch.delenv("NOTEBOOKLM_COOKIES", raising=False)
 
     result = auth_tools.refresh_auth()
 
     assert result.get("status") != "success", (
-        "refresh_auth lied: returned success while tokens are expired. "
-        f"Got: {result}"
+        f"refresh_auth lied: returned success while tokens are expired. Got: {result}"
     )
     # And it should point the user at the real fix.
     blob = (str(result.get("error", "")) + str(result.get("message", ""))).lower()
@@ -71,7 +71,8 @@ def test_refresh_auth_reports_success_when_tokens_are_valid(monkeypatch):
     monkeypatch.setattr(auth_tools, "get_client", lambda: _FakeClient(), raising=True)
     monkeypatch.setattr(auth_tools, "reset_client", lambda: None, raising=True)
     monkeypatch.setattr(
-        core_auth, "load_cached_tokens",
+        core_auth,
+        "load_cached_tokens",
         lambda: core_auth.AuthTokens(cookies={"SID": "x"}, extracted_at=0.0),
         raising=True,
     )
@@ -89,10 +90,14 @@ def test_studio_create_fails_loudly_on_stale_auth(monkeypatch):
     """When auth is stale/expired, studio_create() must return status:"error" BEFORE firing a doomed generation request
     — not status:"success" with an artifact_id that immediately fails.
     """
-    monkeypatch.setattr(studio_tools, "_check_studio_auth", lambda: _auth_result(False, "expired"), raising=False)
+    monkeypatch.setattr(
+        studio_tools, "_check_studio_auth", lambda: _auth_result(False, "expired"), raising=False
+    )
+
     # If the code wrongly proceeds, make the client call explode so the test can't pass by luck.
     def _boom():
         raise AssertionError("studio_create proceeded to get_client() despite stale auth")
+
     monkeypatch.setattr(studio_tools, "get_client", _boom, raising=True)
 
     result = studio_tools.studio_create(
@@ -112,10 +117,13 @@ def test_studio_create_fails_loudly_on_stale_auth(monkeypatch):
 
 def test_studio_create_proceeds_when_auth_valid(monkeypatch):
     """With valid auth, studio_create() must still create the artifact normally."""
-    monkeypatch.setattr(studio_tools, "_check_studio_auth", lambda: _auth_result(True), raising=False)
+    monkeypatch.setattr(
+        studio_tools, "_check_studio_auth", lambda: _auth_result(True), raising=False
+    )
     monkeypatch.setattr(studio_tools, "get_client", lambda: _FakeClient(), raising=True)
     monkeypatch.setattr(
-        studio_tools.studio_service, "create_artifact",
+        studio_tools.studio_service,
+        "create_artifact",
         lambda *a, **k: {"artifact_id": "art-1", "status": "in_progress"},
         raising=True,
     )
@@ -196,7 +204,9 @@ def test_studio_status_no_reason_for_healthy_artifact(monkeypatch):
         studio_tools, "get_client", lambda: _client_returning([ok_artifact]), raising=True
     )
     art = studio_tools.studio_status(notebook_id="nb-123")["artifacts"][0]
-    assert art.get("error_reason") is None, f"Healthy artifact must have no error_reason, got: {art}"
+    assert art.get("error_reason") is None, (
+        f"Healthy artifact must have no error_reason, got: {art}"
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -215,10 +225,13 @@ def test_studio_create_e2e_per_auth_state(monkeypatch, auth_state, valid, reason
     """Each auth state must yield a deterministic, actionable outcome: valid → success; any invalid state →
     status:"error" (never a fake success).
     """
-    monkeypatch.setattr(studio_tools, "_check_studio_auth", lambda: _auth_result(valid, reason), raising=False)
+    monkeypatch.setattr(
+        studio_tools, "_check_studio_auth", lambda: _auth_result(valid, reason), raising=False
+    )
     monkeypatch.setattr(studio_tools, "get_client", lambda: _FakeClient(), raising=True)
     monkeypatch.setattr(
-        studio_tools.studio_service, "create_artifact",
+        studio_tools.studio_service,
+        "create_artifact",
         lambda *a, **k: {"artifact_id": "art-e2e", "status": "in_progress"},
         raising=True,
     )

--- a/tests/test_mcp_auth_studio_failures.py
+++ b/tests/test_mcp_auth_studio_failures.py
@@ -1,0 +1,237 @@
+"""Regression tests for the P1 auth/studio silent-failure bug (Netter bug report 2026-06-01).
+
+Bug: under stale/expired auth, `refresh_auth()` returns status:"success" (it only
+reloads dead tokens from disk), and `studio_create()` returns status:"success" with an
+artifact_id that immediately fails — sending agents into pointless polling loops, with
+`studio_status()` exposing `status:"failed"` and no error reason.
+
+These tests pin the *desired* contract. They are RED against notebooklm-mcp-cli 0.6.13
+and GREEN after the fix. All auth states are mocked — no network, no real credentials.
+"""
+
+import importlib
+
+import pytest
+
+# MCP tool modules under test
+auth_tools = importlib.import_module("notebooklm_tools.mcp.tools.auth")
+studio_tools = importlib.import_module("notebooklm_tools.mcp.tools.studio")
+core_auth = importlib.import_module("notebooklm_tools.core.auth")
+
+
+# --------------------------------------------------------------------------- #
+# Helpers / fakes
+# --------------------------------------------------------------------------- #
+def _auth_result(valid, reason=None):
+    """Build a real AuthCheckResult so we exercise the production type."""
+    return core_auth.AuthCheckResult(valid=valid, reason=reason, live=True, profile="default")
+
+
+class _FakeClient:
+    """Stand-in for NotebookLMClient; never touches the network."""
+
+
+# --------------------------------------------------------------------------- #
+# Test 1 — refresh_auth honesty
+# --------------------------------------------------------------------------- #
+def test_refresh_auth_does_not_claim_success_when_tokens_are_expired(monkeypatch):
+    """refresh_auth() must NOT return status:"success" while the reloaded tokens are actually unusable. A disk reload of
+    dead tokens is not a successful re-auth.
+
+    Desired: when tokens load from disk but a live validity check says they're expired, refresh_auth() returns a
+    non-success status that tells the user to run `nlm login`.
+    """
+    # Tokens DO load from disk (file exists)...
+    monkeypatch.setattr(
+        auth_tools, "get_client", lambda: _FakeClient(), raising=True
+    )
+    monkeypatch.setattr(auth_tools, "reset_client", lambda: None, raising=True)
+    monkeypatch.setattr(
+        core_auth, "load_cached_tokens",
+        lambda: core_auth.AuthTokens(cookies={"SID": "x"}, extracted_at=0.0),
+        raising=True,
+    )
+    # ...but a live check reports them expired.
+    monkeypatch.setattr(core_auth, "check_auth", lambda **kw: _auth_result(False, "expired"), raising=True)
+    monkeypatch.delenv("NOTEBOOKLM_COOKIES", raising=False)
+
+    result = auth_tools.refresh_auth()
+
+    assert result.get("status") != "success", (
+        "refresh_auth lied: returned success while tokens are expired. "
+        f"Got: {result}"
+    )
+    # And it should point the user at the real fix.
+    blob = (str(result.get("error", "")) + str(result.get("message", ""))).lower()
+    assert "nlm login" in blob, f"Expected actionable 'nlm login' guidance, got: {result}"
+
+
+def test_refresh_auth_reports_success_when_tokens_are_valid(monkeypatch):
+    """The happy path must still work: valid tokens on disk → success."""
+    monkeypatch.setattr(auth_tools, "get_client", lambda: _FakeClient(), raising=True)
+    monkeypatch.setattr(auth_tools, "reset_client", lambda: None, raising=True)
+    monkeypatch.setattr(
+        core_auth, "load_cached_tokens",
+        lambda: core_auth.AuthTokens(cookies={"SID": "x"}, extracted_at=0.0),
+        raising=True,
+    )
+    monkeypatch.setattr(core_auth, "check_auth", lambda **kw: _auth_result(True), raising=True)
+    monkeypatch.delenv("NOTEBOOKLM_COOKIES", raising=False)
+
+    result = auth_tools.refresh_auth()
+    assert result.get("status") == "success", f"Valid tokens should refresh OK, got: {result}"
+
+
+# --------------------------------------------------------------------------- #
+# Test 2 — studio_create pre-flight auth check
+# --------------------------------------------------------------------------- #
+def test_studio_create_fails_loudly_on_stale_auth(monkeypatch):
+    """When auth is stale/expired, studio_create() must return status:"error" BEFORE firing a doomed generation request
+    — not status:"success" with an artifact_id that immediately fails.
+    """
+    monkeypatch.setattr(studio_tools, "_check_studio_auth", lambda: _auth_result(False, "expired"), raising=False)
+    # If the code wrongly proceeds, make the client call explode so the test can't pass by luck.
+    def _boom():
+        raise AssertionError("studio_create proceeded to get_client() despite stale auth")
+    monkeypatch.setattr(studio_tools, "get_client", _boom, raising=True)
+
+    result = studio_tools.studio_create(
+        notebook_id="nb-123",
+        artifact_type="infographic",
+        confirm=True,
+    )
+
+    assert result.get("status") == "error", (
+        f"studio_create should error loudly on stale auth, got: {result}"
+    )
+    blob = (str(result.get("error", "")) + str(result.get("hint", ""))).lower()
+    assert "nlm login" in blob or "auth" in blob, (
+        f"Error should explain the auth problem, got: {result}"
+    )
+
+
+def test_studio_create_proceeds_when_auth_valid(monkeypatch):
+    """With valid auth, studio_create() must still create the artifact normally."""
+    monkeypatch.setattr(studio_tools, "_check_studio_auth", lambda: _auth_result(True), raising=False)
+    monkeypatch.setattr(studio_tools, "get_client", lambda: _FakeClient(), raising=True)
+    monkeypatch.setattr(
+        studio_tools.studio_service, "create_artifact",
+        lambda *a, **k: {"artifact_id": "art-1", "status": "in_progress"},
+        raising=True,
+    )
+
+    result = studio_tools.studio_create(
+        notebook_id="nb-123",
+        artifact_type="infographic",
+        confirm=True,
+    )
+    assert result.get("status") == "success", f"Valid auth should create artifact, got: {result}"
+    assert result.get("artifact_id") == "art-1"
+
+
+# --------------------------------------------------------------------------- #
+# Test 3 — studio_status failure surface
+# --------------------------------------------------------------------------- #
+def _client_returning(artifacts):
+    class _Client:
+        def poll_studio_status(self, notebook_id):
+            return list(artifacts)
+
+        def list_mind_maps(self, notebook_id):
+            return []
+
+    return _Client()
+
+
+def test_studio_status_synthesizes_reason_for_failed_artifact_without_raw_error(monkeypatch):
+    """The real gRPC payload gives failed artifacts NO error string. The service must still surface a non-null
+    error_reason so an agent stops polling and acts (instead of looping on an all-null failed artifact — the
+    reported bug).
+    """
+    failed_artifact = {
+        "artifact_id": "art-fail",
+        "type": "infographic",
+        "title": "NMJ",
+        "status": "failed",
+        # NOTE: deliberately NO error_reason/failure_* key — matches real API.
+    }
+    monkeypatch.setattr(
+        studio_tools, "get_client", lambda: _client_returning([failed_artifact]), raising=True
+    )
+
+    art = studio_tools.studio_status(notebook_id="nb-123")["artifacts"][0]
+    assert art["status"] == "failed"
+    assert isinstance(art.get("error_reason"), str) and art["error_reason"], (
+        f"Failed artifact must carry a synthesized error_reason, got: {art}"
+    )
+    assert "nlm login" in art["error_reason"].lower(), (
+        f"Reason should hint at the likely auth fix, got: {art['error_reason']}"
+    )
+
+
+def test_studio_status_prefers_real_error_key_when_present(monkeypatch):
+    """If a future API version DOES provide an error key, surface it verbatim."""
+    failed_artifact = {
+        "artifact_id": "art-fail2",
+        "type": "infographic",
+        "status": "failed",
+        "error_reason": "RESOURCE_EXHAUSTED",
+    }
+    monkeypatch.setattr(
+        studio_tools, "get_client", lambda: _client_returning([failed_artifact]), raising=True
+    )
+    art = studio_tools.studio_status(notebook_id="nb-123")["artifacts"][0]
+    assert art.get("error_reason") == "RESOURCE_EXHAUSTED"
+
+
+def test_studio_status_no_reason_for_healthy_artifact(monkeypatch):
+    """A completed/in-progress artifact must NOT get a spurious error_reason."""
+    ok_artifact = {
+        "artifact_id": "art-ok",
+        "type": "infographic",
+        "status": "completed",
+        "infographic_url": "https://example/x.png",
+    }
+    monkeypatch.setattr(
+        studio_tools, "get_client", lambda: _client_returning([ok_artifact]), raising=True
+    )
+    art = studio_tools.studio_status(notebook_id="nb-123")["artifacts"][0]
+    assert art.get("error_reason") is None, f"Healthy artifact must have no error_reason, got: {art}"
+
+
+# --------------------------------------------------------------------------- #
+# Test 4 — end-to-end studio_create per mocked auth state
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "auth_state,valid,reason",
+    [
+        ("fresh", True, None),
+        ("stale_recoverable", False, "stale_heuristic"),
+        ("expired", False, "expired"),
+        ("missing", False, "no_tokens"),
+    ],
+)
+def test_studio_create_e2e_per_auth_state(monkeypatch, auth_state, valid, reason):
+    """Each auth state must yield a deterministic, actionable outcome: valid → success; any invalid state →
+    status:"error" (never a fake success).
+    """
+    monkeypatch.setattr(studio_tools, "_check_studio_auth", lambda: _auth_result(valid, reason), raising=False)
+    monkeypatch.setattr(studio_tools, "get_client", lambda: _FakeClient(), raising=True)
+    monkeypatch.setattr(
+        studio_tools.studio_service, "create_artifact",
+        lambda *a, **k: {"artifact_id": "art-e2e", "status": "in_progress"},
+        raising=True,
+    )
+
+    result = studio_tools.studio_create(
+        notebook_id="nb-123",
+        artifact_type="infographic",
+        confirm=True,
+    )
+
+    if valid:
+        assert result.get("status") == "success", f"[{auth_state}] expected success, got: {result}"
+    else:
+        assert result.get("status") == "error", (
+            f"[{auth_state}] expected a loud error, not a fake success. Got: {result}"
+        )


### PR DESCRIPTION
## Problem

Under stale/expired auth, the MCP **silently misleads callers** instead of failing loudly:

1. **`refresh_auth()` false-success from disk tokens.** It returns `status:"success"` after reloading **dead** tokens from `auth.json`. `load_cached_tokens()` deliberately does not validate, so the message ("Auth tokens reloaded from disk cache") hides that the credentials are unusable. Issue #170 fixed this **only** for the `NOTEBOOKLM_COOKIES` env-var path — the disk-token path is still affected.
2. **`studio_create()` has no pre-flight auth check.** It returns `status:"success"` with an `artifact_id` that fails seconds later. Agents/automations then poll a doomed artifact in a long loop. (The CLI infographic path got a fix in #47, but the MCP `studio_create` tool still returns a fake success.)
3. **A failed artifact surfaces no reason.** `_normalize_studio_status` already maps code `4 → "failed"`, but every other field is `null` and there is no error string, so callers can't tell *why* it failed or what to do.

### Repro (the scenario that triggered this)
```
server_info()      # auth_status: "stale"
refresh_auth()     # status: "success"  ← but tokens are dead
studio_create(notebook_id=..., artifact_type="infographic", confirm=True)
                   # status: "success", artifact_status: "in_progress"
studio_status(...) # artifacts[0].status == "failed", every field null, no reason
```

## Fix

All three hook into the unified `check_auth()` / `AuthCheckResult` seam added in #203.

1. **`refresh_auth()`** — after the disk reload, run `check_auth(live=True)`. If invalid, return `status:"expired"` with an actionable *"run `nlm login`"* message instead of `"success"`.
2. **`studio_create()`** — new `_check_studio_auth()` runs `check_auth(live=True)` **after** the network-free confirmation-preview and artifact-type validation, **before** `get_client()`. Invalid auth → `status:"error"` + `hint:"nlm login"`. The `confirm=False` preview path and the bad-`artifact_type` path stay network-free (covered by tests).
3. **`studio_status()`** — `_derive_error_reason()` prefers any real raw error key (future-proof if the API adds one), else **synthesizes** a reason for `status=="failed"` artifacts (auth / capacity / prompt, with an `nlm login` hint). Healthy artifacts return `None`. Adds `error_reason` to `ArtifactInfo`.

## Tests

`tests/test_mcp_auth_studio_failures.py` — 11 cases, all auth states mocked, no network, no credentials:
- `refresh_auth` honesty (expired → not success + guidance; valid → success)
- `studio_create` pre-flight (stale → loud error; valid → creates)
- `studio_status` failure surface (synthesized reason when raw has none; prefers real key; `None` for healthy)
- parametrized e2e per auth state: `fresh|stale_recoverable|expired|missing`

Full suite after the change: **901 passed, 37 skipped**.

## Notes / trade-offs

- The `studio_create` pre-flight adds **one** homepage fetch (same mechanism as `server_info` / `nlm login --check`) on the `confirm=True` path only. A ~1s validity check beats a silent failure plus minutes of polling.
- NotebookLM has no official API, so a "success" from `studio_create` is inherently unverifiable at create time; this change makes the auth precondition explicit and gives `studio_status` a usable failure signal.

Refs #170, #210.
