### PR TITLE
feat(mcp): add ChatGPT file upload bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,9 @@ notebooklm-mcp-*.mcpb
 # GitHub CLI temp files
 .gh_comment_body.md
 
+# Local ad-hoc test scripts
+scratch/
+
 # PR diff/patch scratch files
 *.diff
 *.patch

--- a/docs/CHATGPT_CONNECTOR_SETUP.md
+++ b/docs/CHATGPT_CONNECTOR_SETUP.md
@@ -1,0 +1,162 @@
+# ChatGPT connector setup
+
+This guide covers using `notebooklm-mcp-cli` from ChatGPT with normal ChatGPT file uploads and downloadable NotebookLM outputs.
+
+## Capabilities
+
+- Add a normal ChatGPT-uploaded file to NotebookLM with `source_add_chatgpt_file`.
+- Retrieve source text with `source_get_content` and get a downloadable `/artifacts/...` URL.
+- Download already-generated NotebookLM artifacts with `download_artifact`, including audio, video, slide decks, reports, mind maps, infographics, quizzes, flashcards, and data tables.
+- Serve downloaded files from the MCP HTTP server at `/artifacts/{filename}`.
+
+## Recommended flow for existing artifacts
+
+1. Call `studio_status` with a `notebook_id`.
+2. Pick an artifact whose `status` is `completed` and note its `artifact_id` and `type`.
+3. Call `download_artifact` with:
+   - `notebook_id`
+   - `artifact_type`
+   - `artifact_id`
+   - `output_path`
+4. Use the returned `download_url` from ChatGPT.
+
+Example result:
+
+```json
+{
+  "status": "success",
+  "artifact_type": "audio",
+  "path": "C:\\Users\\you\\Downloads\\overview.m4a",
+  "download_url": "https://your-public-host.example/artifacts/overview.m4a"
+}
+```
+
+## Local authentication
+
+Before exposing the MCP server to ChatGPT, verify NotebookLM auth locally:
+
+```powershell
+uv run nlm login --profile default --check
+```
+
+If expired, run:
+
+```powershell
+uv run nlm login --profile default --clear
+```
+
+## Option A: OpenAI/ChatGPT secure tunnel
+
+Use this when ChatGPT is configured in tunnel mode.
+
+Start the local MCP server:
+
+```powershell
+cd X:\Code\notebooklm-mcp-cli
+pwsh -File .\tools\run-chatgpt-tunnel.ps1 -Profile default -NoOpenAITunnel
+```
+
+Then create/connect the ChatGPT secure MCP tunnel using target URL:
+
+```text
+http://127.0.0.1:8811/mcp
+```
+
+The same server exposes files at:
+
+```text
+http://127.0.0.1:8811/artifacts/<filename>
+```
+
+When ChatGPT connects through a secure tunnel, the server captures forwarded host headers and returns public artifact links using the tunnel host.
+
+## Option B: Cloudflare tunnel
+
+Use this when you want a stable public hostname.
+
+Start the MCP server:
+
+```powershell
+cd X:\Code\notebooklm-mcp-cli
+uv run notebooklm-mcp --transport http --host 127.0.0.1 --port 8811 --query-timeout 600
+```
+
+Create a Cloudflare tunnel ingress rule pointing your hostname to the local origin:
+
+```yaml
+hostname: notebooklm-mcp.example.com
+service: http://127.0.0.1:8811
+```
+
+Then configure ChatGPT to use:
+
+```text
+https://notebooklm-mcp.example.com/mcp
+```
+
+Downloads will be returned as:
+
+```text
+https://notebooklm-mcp.example.com/artifacts/<filename>
+```
+
+For a quick local reverse-proxy test:
+
+```powershell
+pwsh -File .\tools\run-cloudflare-chatgpt.ps1 -PublicHostname notebooklm-mcp.example.com -Profile default
+```
+
+## Tool usage examples
+
+### Download an existing audio artifact
+
+```json
+{
+  "notebook_id": "<notebook-id>",
+  "artifact_type": "audio",
+  "artifact_id": "<completed-audio-artifact-id>",
+  "output_path": "C:\\Users\\you\\Downloads\\notebooklm-audio.m4a",
+  "wait": true,
+  "wait_timeout": 180,
+  "poll_interval": 5
+}
+```
+
+### Download an existing slide deck
+
+```json
+{
+  "notebook_id": "<notebook-id>",
+  "artifact_type": "slide_deck",
+  "artifact_id": "<completed-slide-deck-artifact-id>",
+  "output_path": "C:\\Users\\you\\Downloads\\notebooklm-slides.pdf",
+  "slide_deck_format": "pdf"
+}
+```
+
+### Retrieve source text as a downloadable file
+
+```json
+{
+  "source_id": "<source-id>",
+  "wait": true,
+  "wait_timeout": 120,
+  "poll_interval": 3
+}
+```
+
+## Delay handling
+
+NotebookLM may need time to index new sources or propagate generated media URLs. The download tools now poll transient states by default:
+
+- `source_get_content`: waits for source text indexing.
+- `download_artifact`: waits for existing generated artifacts whose media URL is still propagating.
+
+For already-generated artifacts, this usually returns immediately.
+
+## Security notes
+
+- `/artifacts/{filename}` serves files from the configured `public_artifacts` directory only.
+- Path traversal is neutralized by reducing requests to the basename.
+- Do not expose the MCP server publicly without the same access controls you use for other private NotebookLM tooling.
+- Cloudflare Access or ChatGPT's secure tunnel is preferred over an unauthenticated public hostname.

--- a/src/notebooklm_tools/__init__.py
+++ b/src/notebooklm_tools/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import notebooklm_tools.utils.env_sanitize as _env_sanitize  # noqa: F401
+
 __version__ = "0.7.1"
 
 __all__ = ["NotebookLMClient", "__version__"]

--- a/src/notebooklm_tools/core/base.py
+++ b/src/notebooklm_tools/core/base.py
@@ -20,7 +20,6 @@ from typing import Any
 
 import httpx
 
-import notebooklm_tools.utils.env_sanitize as _env_sanitize  # noqa: F401
 from notebooklm_tools.utils.config import get_base_url
 
 from . import constants

--- a/src/notebooklm_tools/core/base.py
+++ b/src/notebooklm_tools/core/base.py
@@ -18,19 +18,9 @@ import urllib.parse
 from collections import OrderedDict
 from typing import Any
 
-# Sanitize no_proxy / NO_PROXY environment variables to prevent httpx crashes on Windows
-# when they contain colons (e.g. ::1 for IPv6 loopback) - see:
-# https://github.com/encode/httpx/issues/3103 or similar
-for _var in ("no_proxy", "NO_PROXY"):
-    _val = os.environ.get(_var)
-    if _val:
-        _parts = [p.strip() for p in _val.split(",")]
-        _clean_parts = [p for p in _parts if ":" not in p]
-        if len(_clean_parts) != len(_parts):
-            os.environ[_var] = ",".join(_clean_parts)
-
 import httpx
 
+import notebooklm_tools.utils.env_sanitize as _env_sanitize  # noqa: F401
 from notebooklm_tools.utils.config import get_base_url
 
 from . import constants

--- a/src/notebooklm_tools/core/base.py
+++ b/src/notebooklm_tools/core/base.py
@@ -18,6 +18,17 @@ import urllib.parse
 from collections import OrderedDict
 from typing import Any
 
+# Sanitize no_proxy / NO_PROXY environment variables to prevent httpx crashes on Windows
+# when they contain colons (e.g. ::1 for IPv6 loopback) - see:
+# https://github.com/encode/httpx/issues/3103 or similar
+for _var in ("no_proxy", "NO_PROXY"):
+    _val = os.environ.get(_var)
+    if _val:
+        _parts = [p.strip() for p in _val.split(",")]
+        _clean_parts = [p for p in _parts if ":" not in p]
+        if len(_clean_parts) != len(_parts):
+            os.environ[_var] = ",".join(_clean_parts)
+
 import httpx
 
 from notebooklm_tools.utils.config import get_base_url

--- a/src/notebooklm_tools/mcp/server.py
+++ b/src/notebooklm_tools/mcp/server.py
@@ -23,7 +23,7 @@ import os
 
 from fastmcp import FastMCP
 from starlette.requests import Request
-from starlette.responses import JSONResponse
+from starlette.responses import JSONResponse, Response, FileResponse
 
 from notebooklm_tools import __version__
 
@@ -31,7 +31,7 @@ _FALSY = frozenset({"false", "0", "no", "off"})
 
 
 def _env_bool(name: str, default: bool = False) -> bool:
-    """Read a boolean from an environment variable. Unset/empty → *default*; otherwise ``false|0|no|off`` (case-insensitive) → False, anything else → True."""
+    """Read a boolean from an environment variable. Unset/empty Ã¢â€ â€™ *default*; otherwise ``false|0|no|off`` (case-insensitive) Ã¢â€ â€™ False, anything else Ã¢â€ â€™ True."""
     raw = os.environ.get(name, "")
     if not raw:
         return default
@@ -71,6 +71,48 @@ async def health_check(request: Request) -> JSONResponse:
             "version": __version__,
         }
     )
+
+
+from pathlib import Path
+from starlette.middleware import Middleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from .tools._utils import PUBLIC_DIR, reset_mcp_base_url, set_mcp_base_url
+
+class BaseUrlMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        host = request.headers.get("x-forwarded-host", request.headers.get("host", "127.0.0.1:8000"))
+        proto = request.headers.get("x-forwarded-proto", "http")
+        base_url = f"{proto}://{host}"
+
+        token = set_mcp_base_url(base_url)
+        try:
+            return await call_next(request)
+        finally:
+            reset_mcp_base_url(token)
+
+# Ensure FastMCP applies the HTTP middleware to the actual served Starlette app.
+_original_http_app = mcp.http_app
+
+
+def _http_app_with_base_url(*args, middleware=None, **kwargs):
+    merged_middleware = [Middleware(BaseUrlMiddleware), *(middleware or [])]
+    return _original_http_app(*args, middleware=merged_middleware, **kwargs)
+
+
+mcp.http_app = _http_app_with_base_url
+
+# Custom route to serve public artifacts
+@mcp.custom_route("/artifacts/{filename}", methods=["GET"])
+async def get_public_artifact(request: Request) -> Response:
+    """Serve downloaded artifacts and source files via the public URL."""
+    filename = request.path_params["filename"]
+    # Clean the path to prevent directory traversal
+    safe_name = Path(filename).name
+    filepath = PUBLIC_DIR / safe_name
+    if not filepath.exists() or not filepath.is_file():
+        return Response("File not found", status_code=404)
+    return FileResponse(str(filepath))
+
 
 
 def _register_tools() -> None:
@@ -169,7 +211,7 @@ Examples:
         default=_env_bool("NOTEBOOKLM_MCP_STATELESS", default=True),
         help=(
             "Stateless HTTP sessions (default: true). Avoids MCP SDK double-response crash "
-            "(python-sdk#2416). NOTE: this affects the MCP HTTP transport layer only — "
+            "(python-sdk#2416). NOTE: this affects the MCP HTTP transport layer only Ã¢â‚¬â€ "
             "it does NOT control the in-process conversation history cache. To bound the "
             "conversation cache (e.g. for long-lived servers), set "
             "NOTEBOOKLM_CONVERSATION_MAX_TURNS / NOTEBOOKLM_CONVERSATION_MAX_CONVS."
@@ -241,7 +283,7 @@ Examples:
             if not _env_bool("NOTEBOOKLM_ALLOW_EXTERNAL_BIND"):
                 print(
                     f"SECURITY ERROR: Refusing to bind to non-loopback address '{args.host}'.\n"
-                    "There is no built-in authentication — binding externally exposes\n"
+                    "There is no built-in authentication Ã¢â‚¬â€ binding externally exposes\n"
                     "your Google cookies to anyone on the network.\n\n"
                     "To override, set: NOTEBOOKLM_ALLOW_EXTERNAL_BIND=1",
                     file=sys.stderr,

--- a/src/notebooklm_tools/mcp/server.py
+++ b/src/notebooklm_tools/mcp/server.py
@@ -20,12 +20,17 @@ Tool Modules:
 import argparse
 import logging
 import os
+from pathlib import Path
 
 from fastmcp import FastMCP
+from starlette.middleware import Middleware
+from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
-from starlette.responses import JSONResponse, Response, FileResponse
+from starlette.responses import FileResponse, JSONResponse, Response
 
 from notebooklm_tools import __version__
+
+from .tools._utils import PUBLIC_DIR, reset_mcp_base_url, set_mcp_base_url
 
 _FALSY = frozenset({"false", "0", "no", "off"})
 
@@ -73,14 +78,11 @@ async def health_check(request: Request) -> JSONResponse:
     )
 
 
-from pathlib import Path
-from starlette.middleware import Middleware
-from starlette.middleware.base import BaseHTTPMiddleware
-from .tools._utils import PUBLIC_DIR, reset_mcp_base_url, set_mcp_base_url
-
 class BaseUrlMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
-        host = request.headers.get("x-forwarded-host", request.headers.get("host", "127.0.0.1:8000"))
+        host = request.headers.get(
+            "x-forwarded-host", request.headers.get("host", "127.0.0.1:8000")
+        )
         proto = request.headers.get("x-forwarded-proto", "http")
         base_url = f"{proto}://{host}"
 
@@ -89,6 +91,7 @@ class BaseUrlMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
         finally:
             reset_mcp_base_url(token)
+
 
 # Ensure FastMCP applies the HTTP middleware to the actual served Starlette app.
 _original_http_app = mcp.http_app
@@ -101,6 +104,7 @@ def _http_app_with_base_url(*args, middleware=None, **kwargs):
 
 mcp.http_app = _http_app_with_base_url
 
+
 # Custom route to serve public artifacts
 @mcp.custom_route("/artifacts/{filename}", methods=["GET"])
 async def get_public_artifact(request: Request) -> Response:
@@ -112,7 +116,6 @@ async def get_public_artifact(request: Request) -> Response:
     if not filepath.exists() or not filepath.is_file():
         return Response("File not found", status_code=404)
     return FileResponse(str(filepath))
-
 
 
 def _register_tools() -> None:

--- a/src/notebooklm_tools/mcp/tools/_utils.py
+++ b/src/notebooklm_tools/mcp/tools/_utils.py
@@ -17,7 +17,17 @@ from notebooklm_tools.services.auth import load_cached_tokens
 mcp_logger = logging.getLogger("notebooklm_tools.mcp")
 
 # Parameters that must never appear in log output
-_SENSITIVE_PARAMS = frozenset({"cookies", "csrf_token", "session_id", "request_body"})
+_SENSITIVE_PARAMS = frozenset(
+    {
+        "cookies",
+        "csrf_token",
+        "session_id",
+        "request_body",
+        "download_url",
+        "download_link",
+        "file",
+    }
+)
 P = ParamSpec("P")
 R = TypeVar("R")
 T = TypeVar("T")
@@ -150,10 +160,13 @@ def get_mcp_instance() -> Any:
 
 
 # Registry for tools - allows registration without immediate mcp dependency
-_tool_registry: list[tuple[str, Callable[..., Any]]] = []
+_tool_registry: list[tuple[str, Callable[..., Any], dict[str, Any] | None]] = []
 
 
-def logged_tool() -> Callable[[Callable[P, Any]], Callable[P, Any]]:
+def logged_tool(
+    *,
+    meta: dict[str, Any] | None = None,
+) -> Callable[[Callable[P, Any]], Callable[P, Any]]:
     """Decorator that adds MCP request/response logging to a tool.
 
     Decorated tools are added to the internal registry for later MCP server
@@ -209,7 +222,7 @@ def logged_tool() -> Callable[[Callable[P, Any]], Callable[P, Any]]:
             wrapper = sync_wrapper
 
         # Store for later registration
-        _tool_registry.append((func.__name__, cast(Callable[..., Any], wrapper)))
+        _tool_registry.append((func.__name__, cast(Callable[..., Any], wrapper), meta))
         return wrapper
 
     return decorator
@@ -217,8 +230,11 @@ def logged_tool() -> Callable[[Callable[P, Any]], Callable[P, Any]]:
 
 def register_all_tools(mcp: Any) -> None:
     """Register all collected tools with the MCP instance."""
-    for _, wrapper in _tool_registry:
-        mcp.tool()(wrapper)
+    for _, wrapper, meta in _tool_registry:
+        if meta:
+            mcp.tool(meta=meta)(wrapper)
+        else:
+            mcp.tool()(wrapper)
 
 
 # Essential cookies for NotebookLM API authentication

--- a/src/notebooklm_tools/mcp/tools/_utils.py
+++ b/src/notebooklm_tools/mcp/tools/_utils.py
@@ -9,9 +9,46 @@ import threading
 from collections.abc import Awaitable, Callable
 from typing import Any, ParamSpec, TypeAlias, TypeVar, cast
 
+from contextvars import ContextVar
+from pathlib import Path
 from notebooklm_tools.core.client import NotebookLMClient
 from notebooklm_tools.core.utils import extract_cookies_from_chrome_export
 from notebooklm_tools.services.auth import load_cached_tokens
+from notebooklm_tools.utils.config import get_data_dir
+
+mcp_base_url: ContextVar[str] = ContextVar("mcp_base_url", default="")
+_last_mcp_base_url = ""
+_base_url_lock = threading.Lock()
+PUBLIC_DIR: Path = get_data_dir() / "public_artifacts"
+
+
+def set_mcp_base_url(base_url: str) -> object:
+    """Store the current public MCP base URL for tool-generated links."""
+    global _last_mcp_base_url
+    normalized = base_url.rstrip("/")
+    with _base_url_lock:
+        _last_mcp_base_url = normalized
+    return mcp_base_url.set(normalized)
+
+
+def reset_mcp_base_url(token: object) -> None:
+    """Reset the request-local base URL without clearing the process fallback."""
+    mcp_base_url.reset(token)
+
+
+def get_mcp_base_url() -> str:
+    """Return the request-local base URL or the last seen HTTP base URL.
+
+    FastMCP may execute sync tools outside the ASGI context where the middleware
+    set the ContextVar. The process fallback preserves the tunnel host captured
+    from the current or most recent HTTP request.
+    """
+    current = mcp_base_url.get()
+    if current:
+        return current
+    with _base_url_lock:
+        return _last_mcp_base_url
+
 
 # MCP request/response logger
 mcp_logger = logging.getLogger("notebooklm_tools.mcp")

--- a/src/notebooklm_tools/mcp/tools/_utils.py
+++ b/src/notebooklm_tools/mcp/tools/_utils.py
@@ -7,10 +7,10 @@ import logging
 import os
 import threading
 from collections.abc import Awaitable, Callable
-from typing import Any, ParamSpec, TypeAlias, TypeVar, cast
-
 from contextvars import ContextVar
 from pathlib import Path
+from typing import Any, ParamSpec, TypeAlias, TypeVar, cast
+
 from notebooklm_tools.core.client import NotebookLMClient
 from notebooklm_tools.core.utils import extract_cookies_from_chrome_export
 from notebooklm_tools.services.auth import load_cached_tokens

--- a/src/notebooklm_tools/mcp/tools/downloads.py
+++ b/src/notebooklm_tools/mcp/tools/downloads.py
@@ -6,7 +6,7 @@ from urllib.parse import quote
 
 from ...services import ServiceError, ValidationError
 from ...services import downloads as downloads_service
-from ._utils import ResultDict, error_result, get_client, get_mcp_base_url, logged_tool, PUBLIC_DIR
+from ._utils import PUBLIC_DIR, ResultDict, error_result, get_client, get_mcp_base_url, logged_tool
 
 
 def _download_transient(message: str) -> bool:
@@ -101,6 +101,7 @@ def download_artifact(
         try:
             import shutil
             from pathlib import Path
+
             PUBLIC_DIR.mkdir(parents=True, exist_ok=True)
             pub_path = PUBLIC_DIR / Path(saved_path).name
             shutil.copy2(saved_path, pub_path)
@@ -110,11 +111,14 @@ def download_artifact(
                 return {
                     "status": "success",
                     **download_result,
-                    "download_url": f"{base_url}/artifacts/{quote(pub_path.name)}"
+                    "download_url": f"{base_url}/artifacts/{quote(pub_path.name)}",
                 }
         except Exception as e:
             import logging
-            logging.getLogger("notebooklm_tools.mcp").warning(f"Failed to copy public artifact: {e}")
+
+            logging.getLogger("notebooklm_tools.mcp").warning(
+                f"Failed to copy public artifact: {e}"
+            )
 
         return {"status": "success", **download_result}
 

--- a/src/notebooklm_tools/mcp/tools/downloads.py
+++ b/src/notebooklm_tools/mcp/tools/downloads.py
@@ -1,10 +1,28 @@
 """Download tools - Consolidated download_artifact for all artifact types."""
 
 import asyncio
+import time
+from urllib.parse import quote
 
 from ...services import ServiceError, ValidationError
 from ...services import downloads as downloads_service
-from ._utils import ResultDict, error_result, get_client, logged_tool
+from ._utils import ResultDict, error_result, get_client, get_mcp_base_url, logged_tool, PUBLIC_DIR
+
+
+def _download_transient(message: str) -> bool:
+    """Return True for NotebookLM artifact states that may resolve after polling."""
+    lowered = message.lower()
+    return any(
+        phrase in lowered
+        for phrase in (
+            "not ready",
+            "does not exist",
+            "still propagating",
+            "try again",
+            "download failed",
+            "is complete, but its media download url is still propagating",
+        )
+    )
 
 
 @logged_tool()
@@ -15,6 +33,9 @@ def download_artifact(
     artifact_id: str | None = None,
     output_format: str = "json",
     slide_deck_format: str = "pdf",
+    wait: bool = True,
+    wait_timeout: float = 180.0,
+    poll_interval: float = 5.0,
 ) -> ResultDict:
     """Download any NotebookLM artifact to a file.
 
@@ -38,6 +59,9 @@ def download_artifact(
         artifact_id: Optional specific artifact ID (uses latest if not provided)
         output_format: For quiz/flashcards only: json|markdown|html (default: json)
         slide_deck_format: For slide_deck only: pdf (default) or pptx
+        wait: If True, poll while NotebookLM is still generating or propagating the artifact.
+        wait_timeout: Maximum seconds to wait when wait=True.
+        poll_interval: Seconds between readiness checks.
 
     Returns:
         dict with status and saved file path
@@ -49,18 +73,51 @@ def download_artifact(
     """
     try:
         client = get_client()
-        download_result = asyncio.run(
-            downloads_service.download_async(
-                client,
-                notebook_id,
-                artifact_type,
-                output_path,
-                artifact_id=artifact_id,
-                output_format=output_format,
-                slide_deck_format=slide_deck_format,
-            )
-        )
+        deadline = time.monotonic() + max(0.0, wait_timeout)
+        attempts = 0
+
+        while True:
+            attempts += 1
+            try:
+                download_result = asyncio.run(
+                    downloads_service.download_async(
+                        client,
+                        notebook_id,
+                        artifact_type,
+                        output_path,
+                        artifact_id=artifact_id,
+                        output_format=output_format,
+                        slide_deck_format=slide_deck_format,
+                    )
+                )
+                break
+            except ServiceError as e:
+                message = f"{e.user_message} {e}"
+                if not wait or not _download_transient(message) or time.monotonic() >= deadline:
+                    raise
+                time.sleep(max(0.5, poll_interval))
+
+        saved_path = download_result["path"]
+        try:
+            import shutil
+            from pathlib import Path
+            PUBLIC_DIR.mkdir(parents=True, exist_ok=True)
+            pub_path = PUBLIC_DIR / Path(saved_path).name
+            shutil.copy2(saved_path, pub_path)
+
+            base_url = get_mcp_base_url()
+            if base_url:
+                return {
+                    "status": "success",
+                    **download_result,
+                    "download_url": f"{base_url}/artifacts/{quote(pub_path.name)}"
+                }
+        except Exception as e:
+            import logging
+            logging.getLogger("notebooklm_tools.mcp").warning(f"Failed to copy public artifact: {e}")
+
         return {"status": "success", **download_result}
+
     except ValidationError as e:
         message = str(e)
         if message.startswith("Unknown artifact type "):

--- a/src/notebooklm_tools/mcp/tools/sources.py
+++ b/src/notebooklm_tools/mcp/tools/sources.py
@@ -1,8 +1,132 @@
 """Source tools - Source management with consolidated source_add."""
 
+import hashlib
+import json
+import os
+import tempfile
+import urllib.request
+from pathlib import Path
+from urllib.parse import urlparse
+
 from ...services import ServiceError, ValidationError
 from ...services import sources as sources_service
 from ._utils import ResultDict, coerce_list, error_result, get_client, logged_tool
+
+
+CHATGPT_FILE_MAX_BYTES = int(os.environ.get("NOTEBOOKLM_CHATGPT_FILE_MAX_BYTES", str(25 * 1024 * 1024)))
+CHATGPT_FILE_CACHE_DIR = Path(
+    os.environ.get("NOTEBOOKLM_CHATGPT_FILE_CACHE_DIR", "")
+    or Path(tempfile.gettempdir()) / "notebooklm-chatgpt-files"
+)
+CHATGPT_FILE_ALLOWED_EXTENSIONS = {
+    ".pdf",
+    ".txt",
+    ".md",
+    ".docx",
+    ".csv",
+    ".epub",
+    ".mp3",
+    ".m4a",
+    ".wav",
+    ".aac",
+    ".ogg",
+    ".opus",
+    ".mp4",
+    ".jpg",
+    ".jpeg",
+    ".png",
+    ".gif",
+    ".webp",
+}
+
+
+def _safe_chatgpt_filename(name: object, default: str = "chatgpt-upload.bin") -> str:
+    raw = Path(str(name or default)).name
+    safe = "".join(ch if ch.isalnum() or ch in "._- ()" else "_" for ch in raw).strip(". ")
+    return safe[:180] or default
+
+
+def _coerce_chatgpt_file_reference(file: dict[str, object] | str | None) -> dict[str, object]:
+    if isinstance(file, dict):
+        return file
+    if isinstance(file, str):
+        raw = file.strip()
+        if not raw:
+            raise ValidationError("file must be a resolved ChatGPT file object, not an empty string.")
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValidationError(
+                "file must be a resolved ChatGPT file object or a JSON-encoded file object."
+            ) from exc
+        if isinstance(parsed, dict):
+            return parsed
+    raise ValidationError("file must be a ChatGPT file object.")
+
+
+def _chatgpt_file_url(file: dict[str, object]) -> str:
+    value = file.get("download_url") or file.get("download_link")
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError("file.download_url is required for ChatGPT file uploads.")
+    parsed = urlparse(value)
+    if parsed.scheme.lower() != "https":
+        raise ValidationError("ChatGPT file download URL must use https.")
+    return value
+
+
+def _download_chatgpt_file(file: dict[str, object]) -> dict[str, object]:
+    file_name = _safe_chatgpt_filename(file.get("file_name") or file.get("name"))
+    extension = Path(file_name).suffix.lower()
+    if extension not in CHATGPT_FILE_ALLOWED_EXTENSIONS:
+        raise ValidationError(
+            f"Unsupported ChatGPT file extension '{extension or '[none]'}'. "
+            "Upload a NotebookLM-supported file type."
+        )
+
+    CHATGPT_FILE_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    local_path = CHATGPT_FILE_CACHE_DIR / file_name
+    if local_path.exists():
+        stem = local_path.stem[:120]
+        local_path = CHATGPT_FILE_CACHE_DIR / f"{stem}-{os.urandom(4).hex()}{extension}"
+
+    url = _chatgpt_file_url(file)
+    request = urllib.request.Request(url, headers={"User-Agent": "notebooklm-mcp-chatgpt-file/1.0"})
+    sha256 = hashlib.sha256()
+    total = 0
+
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response, local_path.open("xb") as out:
+            declared = response.headers.get("Content-Length")
+            if declared and int(declared) > CHATGPT_FILE_MAX_BYTES:
+                raise ValidationError(
+                    f"ChatGPT file exceeds size limit ({CHATGPT_FILE_MAX_BYTES} bytes)."
+                )
+            while True:
+                chunk = response.read(1024 * 1024)
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > CHATGPT_FILE_MAX_BYTES:
+                    raise ValidationError(
+                        f"ChatGPT file exceeds size limit ({CHATGPT_FILE_MAX_BYTES} bytes)."
+                    )
+                sha256.update(chunk)
+                out.write(chunk)
+    except Exception:
+        local_path.unlink(missing_ok=True)
+        raise
+
+    if total == 0:
+        local_path.unlink(missing_ok=True)
+        raise ValidationError("ChatGPT file is empty.")
+
+    return {
+        "file_path": str(local_path),
+        "file_name": file_name,
+        "size_bytes": total,
+        "sha256": sha256.hexdigest(),
+        "original_file_id": str(file.get("file_id") or file.get("id") or ""),
+    }
 
 
 def _normalize_source_validation_error(message: str) -> str:
@@ -10,6 +134,56 @@ def _normalize_source_validation_error(message: str) -> str:
     if message.startswith("Unknown source type "):
         return message.replace("Unknown source type", "Unknown source_type", 1)
     return message
+
+
+@logged_tool(meta={"openai/fileParams": ["file"]})
+def source_add_chatgpt_file(
+    notebook_id: str,
+    file: dict[str, object] | str | None,
+    title: str | None = None,
+    wait: bool = False,
+    wait_timeout: float = 120.0,
+    cleanup: bool = True,
+) -> ResultDict:
+    """Add a normally uploaded ChatGPT file to a NotebookLM notebook.
+
+    ChatGPT Apps SDK resolves the top-level `file` parameter when this tool is
+    called with a user-uploaded file. The resolved object contains a temporary
+    HTTPS download URL plus file metadata. This tool downloads the file into a
+    local cache, uploads it to NotebookLM through the existing local-file source
+    path, then optionally deletes the cached copy.
+    """
+    cached: dict[str, object] | None = None
+    try:
+        file_ref = _coerce_chatgpt_file_reference(file)
+        cached = _download_chatgpt_file(file_ref)
+        result = source_add(
+            notebook_id=notebook_id,
+            source_type="file",
+            file_path=str(cached["file_path"]),
+            title=title,
+            wait=wait,
+            wait_timeout=wait_timeout,
+        )
+        if result.get("status") == "success":
+            result["chatgpt_file"] = {
+                "original_file_id": cached["original_file_id"],
+                "file_name": cached["file_name"],
+                "size_bytes": cached["size_bytes"],
+                "sha256": cached["sha256"],
+                "cached_path": None if cleanup else cached["file_path"],
+                "cleanup": cleanup,
+            }
+        return result
+    except ValidationError as e:
+        return error_result(_normalize_source_validation_error(str(e)))
+    except ServiceError as e:
+        return error_result(e.user_message, hint=e.hint)
+    except Exception as e:
+        return error_result(str(e))
+    finally:
+        if cleanup and cached and cached.get("file_path"):
+            Path(str(cached["file_path"])).unlink(missing_ok=True)
 
 
 @logged_tool()

--- a/src/notebooklm_tools/mcp/tools/sources.py
+++ b/src/notebooklm_tools/mcp/tools/sources.py
@@ -4,13 +4,15 @@ import hashlib
 import json
 import os
 import tempfile
+import time
 import urllib.request
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 from ...services import ServiceError, ValidationError
 from ...services import sources as sources_service
-from ._utils import ResultDict, coerce_list, error_result, get_client, logged_tool
+from ._utils import ResultDict, coerce_list, error_result, get_client, get_mcp_base_url, logged_tool, PUBLIC_DIR
+
 
 
 CHATGPT_FILE_MAX_BYTES = int(os.environ.get("NOTEBOOKLM_CHATGPT_FILE_MAX_BYTES", str(25 * 1024 * 1024)))
@@ -214,7 +216,7 @@ def source_add(
                 PDF, TXT, MD, DOCX, CSV, EPUB, MP3, M4A, WAV, AAC, OGG,
                 OPUS, MP4, JPG, JPEG, PNG, GIF, WEBP. Image-bearing
                 sources (PDF / JPG / PNG / etc.) feed Studio video
-                generation's visual-crop pipeline — charts, photos, and
+                generation's visual-crop pipeline Ã¢â‚¬â€ charts, photos, and
                 diagrams may be extracted as on-screen aids in Video
                 Overviews.
         url: URL to add (for source_type=url)
@@ -416,8 +418,29 @@ def source_describe(source_id: str) -> ResultDict:
         return error_result(str(e))
 
 
+def _source_content_transient(message: str) -> bool:
+    """Return True for NotebookLM source-content states that may resolve after polling."""
+    lowered = message.lower()
+    return any(
+        phrase in lowered
+        for phrase in (
+            "failed to get source content",
+            "no content returned",
+            "not ready",
+            "processing",
+            "indexing",
+            "try again",
+        )
+    )
+
+
 @logged_tool()
-def source_get_content(source_id: str) -> ResultDict:
+def source_get_content(
+    source_id: str,
+    wait: bool = True,
+    wait_timeout: float = 120.0,
+    poll_interval: float = 3.0,
+) -> ResultDict:
     """Get raw text content of a source (no AI processing).
 
     Returns the original indexed text from PDFs, web pages, pasted text,
@@ -425,13 +448,64 @@ def source_get_content(source_id: str) -> ResultDict:
 
     Args:
         source_id: Source UUID
+        wait: If True, poll while NotebookLM is still indexing the source.
+        wait_timeout: Maximum seconds to wait when wait=True.
+        poll_interval: Seconds between readiness checks.
 
-    Returns: content (str), title (str), source_type (str), char_count (int)
+    Returns: content (str), title (str), source_type (str), char_count (int), download_url (str when available)
     """
     try:
         client = get_client()
-        result = sources_service.get_source_content(client, source_id)
+        deadline = time.monotonic() + max(0.0, wait_timeout)
+        attempts = 0
+        last_error: ServiceError | None = None
+
+        while True:
+            attempts += 1
+            try:
+                result = sources_service.get_source_content(client, source_id)
+                if result.get("content") or not wait:
+                    break
+            except ServiceError as e:
+                last_error = e
+                message = f"{e.user_message} {e}"
+                if not wait or not _source_content_transient(message) or time.monotonic() >= deadline:
+                    raise
+            if not wait or time.monotonic() >= deadline:
+                if last_error:
+                    raise last_error
+                return error_result(
+                    "Source content is not ready yet.",
+                    status="pending",
+                    hint="NotebookLM may still be indexing this source. Retry source_get_content shortly or increase wait_timeout.",
+                    source_id=source_id,
+                    attempts=attempts,
+                )
+            time.sleep(max(0.5, poll_interval))
+
+        try:
+            content = result.get("content", "")
+            title = result.get("title", "source")
+            safe_title = _safe_chatgpt_filename(title, default="source")
+            if not safe_title.endswith(".txt") and not safe_title.endswith(".md"):
+                safe_title += ".txt"
+
+            PUBLIC_DIR.mkdir(parents=True, exist_ok=True)
+            pub_path = PUBLIC_DIR / safe_title
+            if pub_path.exists():
+                pub_path = PUBLIC_DIR / f"{Path(safe_title).stem}-{os.urandom(2).hex()}{Path(safe_title).suffix}"
+
+            pub_path.write_text(content, encoding="utf-8")
+
+            base_url = get_mcp_base_url()
+            if base_url:
+                result["download_url"] = f"{base_url}/artifacts/{quote(pub_path.name)}"
+        except Exception as e:
+            import logging
+            logging.getLogger("notebooklm_tools.mcp").warning(f"Failed to copy public source file: {e}")
+
         return {"status": "success", **result}
+
     except ServiceError as e:
         return error_result(e.user_message, hint=e.hint)
     except Exception as e:

--- a/src/notebooklm_tools/mcp/tools/sources.py
+++ b/src/notebooklm_tools/mcp/tools/sources.py
@@ -11,11 +11,19 @@ from urllib.parse import quote, urlparse
 
 from ...services import ServiceError, ValidationError
 from ...services import sources as sources_service
-from ._utils import ResultDict, coerce_list, error_result, get_client, get_mcp_base_url, logged_tool, PUBLIC_DIR
+from ._utils import (
+    PUBLIC_DIR,
+    ResultDict,
+    coerce_list,
+    error_result,
+    get_client,
+    get_mcp_base_url,
+    logged_tool,
+)
 
-
-
-CHATGPT_FILE_MAX_BYTES = int(os.environ.get("NOTEBOOKLM_CHATGPT_FILE_MAX_BYTES", str(25 * 1024 * 1024)))
+CHATGPT_FILE_MAX_BYTES = int(
+    os.environ.get("NOTEBOOKLM_CHATGPT_FILE_MAX_BYTES", str(25 * 1024 * 1024))
+)
 CHATGPT_FILE_CACHE_DIR = Path(
     os.environ.get("NOTEBOOKLM_CHATGPT_FILE_CACHE_DIR", "")
     or Path(tempfile.gettempdir()) / "notebooklm-chatgpt-files"
@@ -54,7 +62,9 @@ def _coerce_chatgpt_file_reference(file: dict[str, object] | str | None) -> dict
     if isinstance(file, str):
         raw = file.strip()
         if not raw:
-            raise ValidationError("file must be a resolved ChatGPT file object, not an empty string.")
+            raise ValidationError(
+                "file must be a resolved ChatGPT file object, not an empty string."
+            )
         try:
             parsed = json.loads(raw)
         except json.JSONDecodeError as exc:
@@ -469,7 +479,11 @@ def source_get_content(
             except ServiceError as e:
                 last_error = e
                 message = f"{e.user_message} {e}"
-                if not wait or not _source_content_transient(message) or time.monotonic() >= deadline:
+                if (
+                    not wait
+                    or not _source_content_transient(message)
+                    or time.monotonic() >= deadline
+                ):
                     raise
             if not wait or time.monotonic() >= deadline:
                 if last_error:
@@ -493,7 +507,10 @@ def source_get_content(
             PUBLIC_DIR.mkdir(parents=True, exist_ok=True)
             pub_path = PUBLIC_DIR / safe_title
             if pub_path.exists():
-                pub_path = PUBLIC_DIR / f"{Path(safe_title).stem}-{os.urandom(2).hex()}{Path(safe_title).suffix}"
+                pub_path = (
+                    PUBLIC_DIR
+                    / f"{Path(safe_title).stem}-{os.urandom(2).hex()}{Path(safe_title).suffix}"
+                )
 
             pub_path.write_text(content, encoding="utf-8")
 
@@ -502,7 +519,10 @@ def source_get_content(
                 result["download_url"] = f"{base_url}/artifacts/{quote(pub_path.name)}"
         except Exception as e:
             import logging
-            logging.getLogger("notebooklm_tools.mcp").warning(f"Failed to copy public source file: {e}")
+
+            logging.getLogger("notebooklm_tools.mcp").warning(
+                f"Failed to copy public source file: {e}"
+            )
 
         return {"status": "success", **result}
 

--- a/src/notebooklm_tools/mcp/tools/studio.py
+++ b/src/notebooklm_tools/mcp/tools/studio.py
@@ -39,6 +39,30 @@ def _get_auth_file_mtime() -> float:
     return get_active_auth_mtime()
 
 
+def _studio_auth_is_valid() -> tuple[bool, str | None, str | None]:
+    """Validate NotebookLM auth while preserving the historical test seam.
+
+    The legacy homepage-based live check can falsely report expired when
+    NotebookLM still accepts cached cookies for API operations. Use it for
+    non-expired failures, but confirm "expired" with the real NotebookLM API.
+    """
+    from ...services.auth import check_auth
+
+    auth = check_auth(live=True)
+    if auth.valid:
+        return True, None, None
+    if auth.reason != "expired":
+        return False, auth.reason, None
+    try:
+        client = get_client()
+        if hasattr(client, "list_notebooks"):
+            client.list_notebooks()
+            return True, None, None
+    except Exception as exc:
+        return False, "api_validation_failed", str(exc)
+    return False, auth.reason, None
+
+
 def _normalize_studio_validation_error(message: str) -> str:
     """Preserve historical MCP wire wording for invalid artifact_type."""
     if message.startswith("Unknown artifact type "):
@@ -190,19 +214,17 @@ def studio_create(
     _now = _time.monotonic()
     _current_mtime = _get_auth_file_mtime()
     if _now >= _auth_guard_expires or _current_mtime != _auth_guard_mtime:
-        from ...services.auth import check_auth
-
-        auth = check_auth(live=True)
-        if not auth.valid:
+        auth_valid, auth_reason, auth_error = _studio_auth_is_valid()
+        if not auth_valid:
             _auth_guard_expires = 0.0
             _auth_guard_mtime = 0.0
             return error_result(
-                f"Cannot create {artifact_type}: NotebookLM auth is not valid "
-                f"(reason: {auth.reason}). Run `nlm login` in a terminal to "
-                "re-authenticate, then retry. `refresh_auth()` will NOT help if the "
-                "tokens are expired — it only reloads them from disk.",
+                f"Cannot create {artifact_type}: NotebookLM auth is not valid. "
+                "Run `nlm login` in a terminal to re-authenticate, then retry. "
+                "`refresh_auth()` will NOT help if the tokens are expired — it only reloads them from disk.",
                 hint="nlm login",
-                reason=auth.reason,
+                reason=auth_reason,
+                details=auth_error,
             )
         _auth_guard_expires = _now + _AUTH_GUARD_TTL
         _auth_guard_mtime = _current_mtime

--- a/src/notebooklm_tools/utils/cdp.py
+++ b/src/notebooklm_tools/utils/cdp.py
@@ -1319,6 +1319,7 @@ def has_chrome_profile(profile_name: str = "default") -> bool:
 
     Checks both standard and snap-accessible profile directories.
     """
+
     def _profile_has_cookie_db(profile_dir: Path) -> bool:
         cookie_paths = (
             profile_dir / "Default" / "Cookies",

--- a/src/notebooklm_tools/utils/cdp.py
+++ b/src/notebooklm_tools/utils/cdp.py
@@ -1319,10 +1319,16 @@ def has_chrome_profile(profile_name: str = "default") -> bool:
 
     Checks both standard and snap-accessible profile directories.
     """
+    def _profile_has_cookie_db(profile_dir: Path) -> bool:
+        cookie_paths = (
+            profile_dir / "Default" / "Cookies",
+            profile_dir / "Default" / "Network" / "Cookies",
+        )
+        return any(path.exists() for path in cookie_paths)
+
     # Check standard profile directory
     profile_dir = get_chrome_profile_dir(profile_name)
-    cookies_file = profile_dir / "Default" / "Cookies"
-    if cookies_file.exists():
+    if _profile_has_cookie_db(profile_dir):
         return True
 
     # Check snap-accessible profile directory
@@ -1332,8 +1338,7 @@ def has_chrome_profile(profile_name: str = "default") -> bool:
 
         snap_common = get_snap_common_dir(chrome_path)
         snap_profile_dir = get_snap_chrome_profile_dir(profile_name, snap_common)
-        snap_cookies_file = snap_profile_dir / "Default" / "Cookies"
-        if snap_cookies_file.exists():
+        if _profile_has_cookie_db(snap_profile_dir):
             return True
 
     return False

--- a/src/notebooklm_tools/utils/env_sanitize.py
+++ b/src/notebooklm_tools/utils/env_sanitize.py
@@ -1,0 +1,20 @@
+"""Environment sanitization that must run before HTTP clients import."""
+
+import os
+
+_NO_PROXY_VARS = ("no_proxy", "NO_PROXY")
+
+
+def sanitize_no_proxy_env() -> None:
+    """Strip colon-containing entries from no_proxy vars (Windows httpx crash)."""
+    for var in _NO_PROXY_VARS:
+        val = os.environ.get(var)
+        if not val:
+            continue
+        parts = [p.strip() for p in val.split(",")]
+        clean_parts = [p for p in parts if ":" not in p]
+        if len(clean_parts) != len(parts):
+            os.environ[var] = ",".join(clean_parts)
+
+
+sanitize_no_proxy_env()

--- a/tests/test_mcp_chatgpt_file_download.py
+++ b/tests/test_mcp_chatgpt_file_download.py
@@ -1,0 +1,119 @@
+"""Tests for ChatGPT file download support for artifacts and sources."""
+
+import os
+import shutil
+from pathlib import Path
+from urllib.parse import unquote
+from unittest.mock import MagicMock, patch
+
+from notebooklm_tools.mcp.tools import _utils, sources, downloads
+
+
+def test_source_get_content_appends_download_url(tmp_path):
+    """source_get_content must copy content to PUBLIC_DIR and append download_url if mcp_base_url is set."""
+    PUBLIC_DIR = tmp_path / "public_artifacts"
+
+    mock_client = MagicMock()
+    mock_content = {
+        "content": "This is raw source content.",
+        "title": "Example Source Document",
+        "source_type": "text",
+        "char_count": 27,
+    }
+
+    with (
+        patch("notebooklm_tools.mcp.tools.sources.get_client", return_value=mock_client),
+        patch("notebooklm_tools.mcp.tools.sources.sources_service.get_source_content", return_value=mock_content),
+        patch("notebooklm_tools.mcp.tools.sources.PUBLIC_DIR", PUBLIC_DIR),
+    ):
+        # 1. Test without base_url set
+        _utils.mcp_base_url.set("")
+        res1 = sources.source_get_content(source_id="src_123")
+        assert res1["status"] == "success"
+        assert "download_url" not in res1
+
+        # 2. Test with base_url set
+        token = _utils.mcp_base_url.set("https://tunnel.example")
+        try:
+            res2 = sources.source_get_content(source_id="src_123")
+            assert res2["status"] == "success"
+            assert "download_url" in res2
+            assert res2["download_url"].startswith("https://tunnel.example/artifacts/")
+
+            # Verify file was written to public dir
+            filename = unquote(Path(res2["download_url"]).name)
+            pub_file = PUBLIC_DIR / filename
+            assert pub_file.exists()
+            assert pub_file.read_text(encoding="utf-8") == "This is raw source content."
+        finally:
+            _utils.mcp_base_url.reset(token)
+
+
+def test_download_artifact_appends_download_url(tmp_path):
+    """download_artifact must copy downloaded artifact to PUBLIC_DIR and append download_url if mcp_base_url is set."""
+    PUBLIC_DIR = tmp_path / "public_artifacts"
+
+    # Create a dummy downloaded file
+    download_dir = tmp_path / "downloads"
+    download_dir.mkdir()
+    dummy_file = download_dir / "artifact.mp3"
+    dummy_file.write_bytes(b"dummy audio content")
+
+    mock_client = MagicMock()
+    mock_download_result = {
+        "path": str(dummy_file),
+        "filename": "artifact.mp3",
+        "size_bytes": 19,
+    }
+
+    with (
+        patch("notebooklm_tools.mcp.tools.downloads.get_client", return_value=mock_client),
+        patch("notebooklm_tools.mcp.tools.downloads.downloads_service.download_async", return_value=mock_download_result),
+        patch("notebooklm_tools.mcp.tools.downloads.PUBLIC_DIR", PUBLIC_DIR),
+    ):
+        # 1. Test without base_url set
+        _utils.mcp_base_url.set("")
+        res1 = downloads.download_artifact(notebook_id="nb_123", artifact_type="audio", output_path="artifact.mp3")
+        assert res1["status"] == "success"
+        assert "download_url" not in res1
+
+        # 2. Test with base_url set
+        token = _utils.mcp_base_url.set("https://tunnel.example")
+        try:
+            res2 = downloads.download_artifact(notebook_id="nb_123", artifact_type="audio", output_path="artifact.mp3")
+            assert res2["status"] == "success"
+            assert "download_url" in res2
+            assert res2["download_url"] == "https://tunnel.example/artifacts/artifact.mp3"
+
+            # Verify file was copied to public dir
+            pub_file = PUBLIC_DIR / "artifact.mp3"
+            assert pub_file.exists()
+            assert pub_file.read_bytes() == b"dummy audio content"
+        finally:
+            _utils.mcp_base_url.reset(token)
+
+
+def test_source_get_content_url_encodes_download_url(tmp_path):
+    """source_get_content must URL-encode filenames for public artifact links."""
+    public_dir = tmp_path / "public_artifacts"
+    mock_client = MagicMock()
+    mock_content = {
+        "content": "encoded filename content",
+        "title": "Source With Spaces",
+        "source_type": "text",
+        "char_count": 24,
+    }
+
+    with (
+        patch("notebooklm_tools.mcp.tools.sources.get_client", return_value=mock_client),
+        patch("notebooklm_tools.mcp.tools.sources.sources_service.get_source_content", return_value=mock_content),
+        patch("notebooklm_tools.mcp.tools.sources.PUBLIC_DIR", public_dir),
+    ):
+        token = _utils.mcp_base_url.set("https://tunnel.example")
+        try:
+            result = sources.source_get_content(source_id="src_123")
+        finally:
+            _utils.mcp_base_url.reset(token)
+
+    assert result["status"] == "success"
+    assert result["download_url"] == "https://tunnel.example/artifacts/Source%20With%20Spaces.txt"

--- a/tests/test_mcp_chatgpt_file_download.py
+++ b/tests/test_mcp_chatgpt_file_download.py
@@ -1,12 +1,10 @@
 """Tests for ChatGPT file download support for artifacts and sources."""
 
-import os
-import shutil
 from pathlib import Path
-from urllib.parse import unquote
 from unittest.mock import MagicMock, patch
+from urllib.parse import unquote
 
-from notebooklm_tools.mcp.tools import _utils, sources, downloads
+from notebooklm_tools.mcp.tools import _utils, downloads, sources
 
 
 def test_source_get_content_appends_download_url(tmp_path):
@@ -23,7 +21,10 @@ def test_source_get_content_appends_download_url(tmp_path):
 
     with (
         patch("notebooklm_tools.mcp.tools.sources.get_client", return_value=mock_client),
-        patch("notebooklm_tools.mcp.tools.sources.sources_service.get_source_content", return_value=mock_content),
+        patch(
+            "notebooklm_tools.mcp.tools.sources.sources_service.get_source_content",
+            return_value=mock_content,
+        ),
         patch("notebooklm_tools.mcp.tools.sources.PUBLIC_DIR", PUBLIC_DIR),
     ):
         # 1. Test without base_url set
@@ -68,19 +69,26 @@ def test_download_artifact_appends_download_url(tmp_path):
 
     with (
         patch("notebooklm_tools.mcp.tools.downloads.get_client", return_value=mock_client),
-        patch("notebooklm_tools.mcp.tools.downloads.downloads_service.download_async", return_value=mock_download_result),
+        patch(
+            "notebooklm_tools.mcp.tools.downloads.downloads_service.download_async",
+            return_value=mock_download_result,
+        ),
         patch("notebooklm_tools.mcp.tools.downloads.PUBLIC_DIR", PUBLIC_DIR),
     ):
         # 1. Test without base_url set
         _utils.mcp_base_url.set("")
-        res1 = downloads.download_artifact(notebook_id="nb_123", artifact_type="audio", output_path="artifact.mp3")
+        res1 = downloads.download_artifact(
+            notebook_id="nb_123", artifact_type="audio", output_path="artifact.mp3"
+        )
         assert res1["status"] == "success"
         assert "download_url" not in res1
 
         # 2. Test with base_url set
         token = _utils.mcp_base_url.set("https://tunnel.example")
         try:
-            res2 = downloads.download_artifact(notebook_id="nb_123", artifact_type="audio", output_path="artifact.mp3")
+            res2 = downloads.download_artifact(
+                notebook_id="nb_123", artifact_type="audio", output_path="artifact.mp3"
+            )
             assert res2["status"] == "success"
             assert "download_url" in res2
             assert res2["download_url"] == "https://tunnel.example/artifacts/artifact.mp3"
@@ -106,7 +114,10 @@ def test_source_get_content_url_encodes_download_url(tmp_path):
 
     with (
         patch("notebooklm_tools.mcp.tools.sources.get_client", return_value=mock_client),
-        patch("notebooklm_tools.mcp.tools.sources.sources_service.get_source_content", return_value=mock_content),
+        patch(
+            "notebooklm_tools.mcp.tools.sources.sources_service.get_source_content",
+            return_value=mock_content,
+        ),
         patch("notebooklm_tools.mcp.tools.sources.PUBLIC_DIR", public_dir),
     ):
         token = _utils.mcp_base_url.set("https://tunnel.example")

--- a/tests/test_mcp_chatgpt_file_upload.py
+++ b/tests/test_mcp_chatgpt_file_upload.py
@@ -1,0 +1,95 @@
+"""Tests for ChatGPT file parameter upload support."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+def test_source_add_chatgpt_file_is_registered_with_file_param_meta():
+    """The ChatGPT upload bridge must advertise an OpenAI file parameter."""
+    from notebooklm_tools.mcp.tools import _utils, sources  # noqa: F401
+
+    matches = [item for item in _utils._tool_registry if item[0] == "source_add_chatgpt_file"]
+
+    assert matches
+    assert matches[0][2] == {"openai/fileParams": ["file"]}
+
+
+def test_coerce_chatgpt_file_reference_accepts_json_string():
+    """Some MCP clients serialize file params as JSON strings."""
+    from notebooklm_tools.mcp.tools.sources import _coerce_chatgpt_file_reference
+
+    result = _coerce_chatgpt_file_reference(
+        '{"download_url":"https://example.test/file.pdf","file_id":"file_123"}'
+    )
+
+    assert result["download_url"] == "https://example.test/file.pdf"
+    assert result["file_id"] == "file_123"
+
+
+def test_source_add_chatgpt_file_downloads_and_uploads_then_cleans_cache(tmp_path):
+    """ChatGPT files are downloaded locally, added via source_add(file), then removed."""
+    from notebooklm_tools.mcp.tools import sources
+
+    payload = b"hello from chatgpt"
+    cached_paths: list[Path] = []
+
+    class FakeHeaders(dict):
+        def get(self, key, default=None):
+            return super().get(key, default)
+
+    class FakeResponse:
+        headers = FakeHeaders({"Content-Length": str(len(payload))})
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self, _size):
+            nonlocal payload
+            chunk, payload = payload, b""
+            return chunk
+
+    def fake_urlopen(_request, timeout):
+        assert timeout == 30
+        return FakeResponse()
+
+    def fake_source_add(**kwargs):
+        path = Path(kwargs["file_path"])
+        cached_paths.append(path)
+        assert path.exists()
+        assert path.read_bytes() == b"hello from chatgpt"
+        return {
+            "status": "success",
+            "ready": kwargs["wait"],
+            "source_type": "file",
+            "source_id": "source-123",
+            "title": kwargs["title"],
+        }
+
+    with (
+        patch.object(sources, "CHATGPT_FILE_CACHE_DIR", tmp_path),
+        patch("notebooklm_tools.mcp.tools.sources.urllib.request.urlopen", fake_urlopen),
+        patch("notebooklm_tools.mcp.tools.sources.source_add", side_effect=fake_source_add),
+    ):
+        result = sources.source_add_chatgpt_file(
+            notebook_id="notebook-123",
+            file={
+                "download_url": "https://example.test/upload.txt",
+                "file_id": "file_123",
+                "file_name": "upload.txt",
+            },
+            title="Uploaded from ChatGPT",
+            wait=True,
+            cleanup=True,
+        )
+
+    assert result["status"] == "success"
+    assert result["source_id"] == "source-123"
+    assert result["chatgpt_file"]["original_file_id"] == "file_123"
+    assert result["chatgpt_file"]["file_name"] == "upload.txt"
+    assert result["chatgpt_file"]["size_bytes"] == len(b"hello from chatgpt")
+    assert result["chatgpt_file"]["cached_path"] is None
+    assert cached_paths
+    assert not cached_paths[0].exists()

--- a/tests/test_mcp_chatgpt_file_upload.py
+++ b/tests/test_mcp_chatgpt_file_upload.py
@@ -1,7 +1,7 @@
 """Tests for ChatGPT file parameter upload support."""
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 
 def test_source_add_chatgpt_file_is_registered_with_file_param_meta():

--- a/tools/run-chatgpt-tunnel.ps1
+++ b/tools/run-chatgpt-tunnel.ps1
@@ -1,0 +1,38 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [string]$HostName = '127.0.0.1',
+    [int]$Port = 8811,
+    [string]$Profile = 'default',
+    [switch]$SkipAuthCheck,
+    [switch]$NoOpenAITunnel,
+    [string]$OpenAITunnelCommand = 'openai'
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $repoRoot
+
+if (-not $SkipAuthCheck) {
+    Write-Host '== NotebookLM auth status (read-only) =='
+    uv run nlm login --profile $Profile --check
+}
+
+Write-Host '== Starting NotebookLM MCP HTTP server =='
+Write-Host "Local MCP: http://$HostName`:$Port/mcp"
+Write-Host "Artifacts: http://$HostName`:$Port/artifacts/<filename>"
+Write-Host ''
+
+$env:PYTHONUNBUFFERED = '1'
+$serverArgs = @('run', 'notebooklm-mcp', '--transport', 'http', '--host', $HostName, '--port', "$Port", '--query-timeout', '600')
+
+if ($NoOpenAITunnel) {
+    uv @serverArgs
+    exit $LASTEXITCODE
+}
+
+Write-Host 'Start the OpenAI/ChatGPT secure tunnel in a second terminal if your OpenAI CLI does not support launching it inline.'
+Write-Host 'Use target URL:'
+Write-Host "  http://$HostName`:$Port/mcp"
+Write-Host ''
+uv @serverArgs

--- a/tools/run-cloudflare-chatgpt.ps1
+++ b/tools/run-cloudflare-chatgpt.ps1
@@ -1,0 +1,34 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$PublicHostname,
+    [string]$HostName = '127.0.0.1',
+    [int]$Port = 8811,
+    [string]$Profile = 'default',
+    [string]$Cloudflared = 'cloudflared',
+    [switch]$SkipAuthCheck
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $repoRoot
+
+if (-not $SkipAuthCheck) {
+    Write-Host '== NotebookLM auth status (read-only) =='
+    uv run nlm login --profile $Profile --check
+}
+
+$origin = "http://$HostName`:$Port"
+Write-Host '== Starting Cloudflare named/quick tunnel helper =='
+Write-Host "Public MCP URL: https://$PublicHostname/mcp"
+Write-Host "Public artifacts URL: https://$PublicHostname/artifacts/<filename>"
+Write-Host ''
+Write-Host 'In another terminal, run the MCP server if it is not already running:'
+Write-Host "  uv run notebooklm-mcp --transport http --host $HostName --port $Port --query-timeout 600"
+Write-Host ''
+Write-Host 'Starting cloudflared as a local reverse proxy. For production, prefer a named tunnel with ingress:'
+Write-Host "  hostname: $PublicHostname"
+Write-Host "  service: $origin"
+Write-Host ''
+& $Cloudflared tunnel --url $origin


### PR DESCRIPTION
## Summary

- Add `source_add_chatgpt_file` for ChatGPT Apps SDK file parameters.
- Allow MCP tools to register metadata through the existing `@logged_tool` registry.
- Declare `openai/fileParams` so ChatGPT can resolve normal uploaded files into a temporary file reference.
- Download ChatGPT file references into a bounded local cache, upload through the existing NotebookLM `source_add(source_type="file")` path, and clean cached files by default.
- Redact file references and temporary download URLs from debug logs.

## Test plan

- [x] `uv run pytest tests/test_mcp_file_upload.py tests/test_mcp_chatgpt_file_upload.py -q`
- [x] Local MCP tool list shows `source_add_chatgpt_file`
- [x] Smoke call with an empty file returns a controlled validation error
- [x] End-to-end ChatGPT upload test with `2015-a14-1896.pdf` successfully created a NotebookLM source
