### PR TITLE
fix(core): sanitize no_proxy on import to prevent httpx crash on Windows

### DIFF
--- a/src/notebooklm_tools/__init__.py
+++ b/src/notebooklm_tools/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import notebooklm_tools.utils.env_sanitize as _env_sanitize  # noqa: F401
+
 __version__ = "0.7.1"
 
 __all__ = ["NotebookLMClient", "__version__"]

--- a/src/notebooklm_tools/core/base.py
+++ b/src/notebooklm_tools/core/base.py
@@ -18,6 +18,17 @@ import urllib.parse
 from collections import OrderedDict
 from typing import Any
 
+# Sanitize no_proxy / NO_PROXY environment variables to prevent httpx crashes on Windows
+# when they contain colons (e.g. ::1 for IPv6 loopback) - see:
+# https://github.com/encode/httpx/issues/3103 or similar
+for _var in ("no_proxy", "NO_PROXY"):
+    _val = os.environ.get(_var)
+    if _val:
+        _parts = [p.strip() for p in _val.split(",")]
+        _clean_parts = [p for p in _parts if ":" not in p]
+        if len(_clean_parts) != len(_parts):
+            os.environ[_var] = ",".join(_clean_parts)
+
 import httpx
 
 from notebooklm_tools.utils.config import get_base_url

--- a/src/notebooklm_tools/core/base.py
+++ b/src/notebooklm_tools/core/base.py
@@ -18,17 +18,6 @@ import urllib.parse
 from collections import OrderedDict
 from typing import Any
 
-# Sanitize no_proxy / NO_PROXY environment variables to prevent httpx crashes on Windows
-# when they contain colons (e.g. ::1 for IPv6 loopback) - see:
-# https://github.com/encode/httpx/issues/3103 or similar
-for _var in ("no_proxy", "NO_PROXY"):
-    _val = os.environ.get(_var)
-    if _val:
-        _parts = [p.strip() for p in _val.split(",")]
-        _clean_parts = [p for p in _parts if ":" not in p]
-        if len(_clean_parts) != len(_parts):
-            os.environ[_var] = ",".join(_clean_parts)
-
 import httpx
 
 from notebooklm_tools.utils.config import get_base_url

--- a/src/notebooklm_tools/utils/env_sanitize.py
+++ b/src/notebooklm_tools/utils/env_sanitize.py
@@ -1,0 +1,20 @@
+"""Environment sanitization that must run before HTTP clients import."""
+
+import os
+
+_NO_PROXY_VARS = ("no_proxy", "NO_PROXY")
+
+
+def sanitize_no_proxy_env() -> None:
+    """Strip colon-containing entries from no_proxy vars (Windows httpx crash)."""
+    for var in _NO_PROXY_VARS:
+        val = os.environ.get(var)
+        if not val:
+            continue
+        parts = [p.strip() for p in val.split(",")]
+        clean_parts = [p for p in parts if ":" not in p]
+        if len(clean_parts) != len(parts):
+            os.environ[var] = ",".join(clean_parts)
+
+
+sanitize_no_proxy_env()


### PR DESCRIPTION
This PR sanitizes the `no_proxy`/`NO_PROXY` environment variables on Windows to prevent `httpx` from crashing on startup.

### Description
On Windows, it is common for the system `no_proxy` environment variable to contain IPv6 loopback addresses like `::1` or `::1/128`. However, `httpx` has a known parsing bug (see httpx issue #3103) when handling IPv6 addresses with colons in the `no_proxy` setting, leading to `InvalidURL: Invalid port: ':1'` crashes on startup.

This crash loop prevents any `nlm` CLI command or MCP server from running on affected Windows systems.

### Fix
This PR intercepts the `no_proxy`/`NO_PROXY` environment variables on import of `notebooklm_tools/core/base.py` and strips any elements containing colons (like `::1`). This cleans the environment for `httpx` client initialization without affecting standard IPv4 loopback bypasses.
