### PR TITLE
fix(auth): detect modern Chrome profile cookie database path

### DIFF
--- a/src/notebooklm_tools/utils/cdp.py
+++ b/src/notebooklm_tools/utils/cdp.py
@@ -1319,6 +1319,7 @@ def has_chrome_profile(profile_name: str = "default") -> bool:
 
     Checks both standard and snap-accessible profile directories.
     """
+
     def _profile_has_cookie_db(profile_dir: Path) -> bool:
         cookie_paths = (
             profile_dir / "Default" / "Cookies",

--- a/src/notebooklm_tools/utils/cdp.py
+++ b/src/notebooklm_tools/utils/cdp.py
@@ -1319,10 +1319,16 @@ def has_chrome_profile(profile_name: str = "default") -> bool:
 
     Checks both standard and snap-accessible profile directories.
     """
+    def _profile_has_cookie_db(profile_dir: Path) -> bool:
+        cookie_paths = (
+            profile_dir / "Default" / "Cookies",
+            profile_dir / "Default" / "Network" / "Cookies",
+        )
+        return any(path.exists() for path in cookie_paths)
+
     # Check standard profile directory
     profile_dir = get_chrome_profile_dir(profile_name)
-    cookies_file = profile_dir / "Default" / "Cookies"
-    if cookies_file.exists():
+    if _profile_has_cookie_db(profile_dir):
         return True
 
     # Check snap-accessible profile directory
@@ -1332,8 +1338,7 @@ def has_chrome_profile(profile_name: str = "default") -> bool:
 
         snap_common = get_snap_common_dir(chrome_path)
         snap_profile_dir = get_snap_chrome_profile_dir(profile_name, snap_common)
-        snap_cookies_file = snap_profile_dir / "Default" / "Cookies"
-        if snap_cookies_file.exists():
+        if _profile_has_cookie_db(snap_profile_dir):
             return True
 
     return False


### PR DESCRIPTION
## Summary

- Update `has_chrome_profile()` to detect Chrome cookie databases in both legacy and modern profile locations.
- Treat `Default/Cookies` and `Default/Network/Cookies` as valid profile cookie DB paths.
- Apply the same detection to snap-accessible Chrome profile directories.

## Why

Modern Chrome stores cookies under `Default/Network/Cookies`, so checking only `Default/Cookies` can falsely report that a configured profile does not have a usable cookie database.

## Test plan

- [ ] `Test-Path <profile>\Default\Network\Cookies` returns true for a seeded Chrome profile
- [ ] `has_chrome_profile("pte")` returns true when only `Default\Network\Cookies` exists
- [ ] Existing auth/profile detection behavior remains unchanged for legacy `Default\Cookies`

## Notes for reviewers

This is intentionally scoped to the upstream CLI profile-detection helper only. Dashboard/background-login UX changes belong in the wrapper app repository, not this package.
