### PR TITLE
fix(auth): use configured profile for headless refresh

### DIFF
--- a/src/notebooklm_tools/core/base.py
+++ b/src/notebooklm_tools/core/base.py
@@ -932,11 +932,13 @@ class BaseClient:
                 self._session_id = ""  # Force re-extraction of session ID
             return True
 
-        # Try headless auth if Chrome profile exists
+        # Try headless auth if the configured default Chrome profile exists.
         try:
-            from notebooklm_tools.utils.cdp import run_headless_auth
+            from notebooklm_tools.utils.auth_browser import run_headless_auth
+            from notebooklm_tools.utils.config import get_config
 
-            tokens = run_headless_auth()
+            profile_name = get_config().auth.default_profile
+            tokens = run_headless_auth(profile_name=profile_name)
             if tokens:
                 with self._state_lock:
                     self.cookies = tokens.cookies

--- a/src/notebooklm_tools/mcp/tools/auth.py
+++ b/src/notebooklm_tools/mcp/tools/auth.py
@@ -63,11 +63,13 @@ def refresh_auth() -> ResultDict:
                 "message": "Auth tokens reloaded from disk cache and validated.",
             }
 
-        # Try headless auth if Chrome profile exists
+        # Try headless auth if the configured default Chrome profile exists
         try:
-            from notebooklm_tools.utils.cdp import run_headless_auth
+            from notebooklm_tools.utils.auth_browser import run_headless_auth
+            from notebooklm_tools.utils.config import get_config
 
-            tokens = run_headless_auth()
+            profile_name = get_config().auth.default_profile
+            tokens = run_headless_auth(profile_name=profile_name)
             if tokens:
                 reset_client()
                 get_client()

--- a/tests/test_profile_aware_headless_auth.py
+++ b/tests/test_profile_aware_headless_auth.py
@@ -1,0 +1,84 @@
+"""Regression tests for profile-aware headless auth refresh."""
+
+from types import SimpleNamespace
+
+
+def test_mcp_refresh_auth_uses_configured_default_profile(monkeypatch):
+    """refresh_auth() must run headless auth against the configured default profile."""
+    import notebooklm_tools.mcp.tools.auth as auth_tools
+    from notebooklm_tools.core.auth import AuthTokens
+
+    calls: list[str] = []
+
+    monkeypatch.delenv("NOTEBOOKLM_COOKIES", raising=False)
+    monkeypatch.setattr(
+        "notebooklm_tools.services.auth.load_cached_tokens",
+        lambda: None,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "notebooklm_tools.utils.config.get_config",
+        lambda: SimpleNamespace(auth=SimpleNamespace(default_profile="pte")),
+        raising=True,
+    )
+
+    def fake_headless_auth(*, profile_name, timeout=30):
+        calls.append(profile_name)
+        return AuthTokens(cookies={"SID": "x"}, extracted_at=1.0)
+
+    monkeypatch.setattr(
+        "notebooklm_tools.utils.auth_browser.run_headless_auth",
+        fake_headless_auth,
+        raising=True,
+    )
+    monkeypatch.setattr(auth_tools, "reset_client", lambda: None, raising=True)
+    monkeypatch.setattr(auth_tools, "get_client", lambda: object(), raising=True)
+
+    result = auth_tools.refresh_auth()
+
+    assert result["status"] == "success"
+    assert calls == ["pte"]
+
+
+def test_core_recovery_uses_configured_default_profile(monkeypatch):
+    """NotebookLMClient auth recovery must also use the configured default profile."""
+    from notebooklm_tools.core.auth import AuthTokens
+    from notebooklm_tools.core.base import BaseClient
+
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        "notebooklm_tools.core.auth.load_cached_tokens",
+        lambda: None,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "notebooklm_tools.utils.config.get_config",
+        lambda: SimpleNamespace(auth=SimpleNamespace(default_profile="pte")),
+        raising=True,
+    )
+
+    def fake_headless_auth(*, profile_name, timeout=30):
+        calls.append(profile_name)
+        return AuthTokens(
+            cookies={"SID": "x"},
+            csrf_token="csrf",
+            session_id="sid",
+            extracted_at=1.0,
+        )
+
+    monkeypatch.setattr(
+        "notebooklm_tools.utils.auth_browser.run_headless_auth",
+        fake_headless_auth,
+        raising=True,
+    )
+
+    monkeypatch.setattr(BaseClient, "_refresh_auth_tokens", lambda self: None)
+
+    client = BaseClient(cookies={"SID": "old"})
+    assert client._try_reload_or_headless_auth() is True
+
+    assert calls == ["pte"]
+    assert client.cookies == {"SID": "x"}
+    assert client.csrf_token == "csrf"
+    assert client._session_id == "sid"


### PR DESCRIPTION
## Summary

- Use the configured default profile for MCP `refresh_auth()` headless refresh.
- Use the configured default profile for core client auth recovery when cached tokens cannot be reloaded.
- Import the profile-aware auth-browser wrapper instead of calling the lower-level CDP helper with its implicit `default` profile.
- Add regression tests proving headless refresh receives `auth.default_profile` rather than falling back to `default`.

## Why

Lower-level headless auth already supports `profile_name`, but the MCP refresh path and core auto-recovery path called `run_headless_auth()` without passing it. For users who switch the default profile, such as `pte`, headless refresh could inspect the wrong Chrome profile.

## Test plan

- [x] `uv run pytest tests/test_profile_aware_headless_auth.py tests/test_mcp_auth_studio_failures.py -q`

## Notes for reviewers

This does not change the interactive login flow. It only wires the already-supported configured default profile into the existing headless refresh call sites.
