### PR TITLE
fix(auth): pass full cookie list in AuthHealthChecker API fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`AuthHealthChecker` API fallback falsely reported `stale` for valid multi-domain cookie profiles** — the homepage probe could correctly redirect to `accounts.google.com` (semi-stale cookies) while the RPC API still accepted the session, but the API fallback flattened `profile.cookies` to a dict before calling `NotebookLMClient`, dropping domain-specific duplicates (e.g. the same cookie name on `.google.com` and another host). `nlm login --check` passed the full cookie list and succeeded, so the two checks disagreed. The API probe now passes `profile.cookies` unchanged and includes `session_id` / `build_label`, matching `login --check`.
+
 ## [0.7.1] - 2026-06-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **`AuthHealthChecker` API fallback falsely reported `stale` for valid multi-domain cookie profiles** — the homepage probe could correctly redirect to `accounts.google.com` (semi-stale cookies) while the RPC API still accepted the session, but the API fallback flattened `profile.cookies` to a dict before calling `NotebookLMClient`, dropping domain-specific duplicates (e.g. the same cookie name on `.google.com` and another host). `nlm login --check` passed the full cookie list and succeeded, so the two checks disagreed. The API probe now passes `profile.cookies` unchanged and includes `session_id` / `build_label`, matching `login --check`.
+- **`server_info` / `refresh_auth` / `studio_create` disagreed on semi-stale auth (Issue #224)** — `server_info` used the broken `AuthHealthChecker` API fallback, while `refresh_auth` and `studio_create` relied on homepage-only `check_auth` (no API confirmation on `stale`/`unverified`). CLI and `notebook_list` could work while `server_info` reported `stale`, `refresh_auth` refused to reload tokens, and agents looped on `nlm login`. MCP paths now share `credentials_are_usable()` (`AuthHealthChecker` + live API confirmation). `load_cached_tokens()` also forwards `build_label` to the MCP client.
 
 ## [0.7.1] - 2026-06-06
 

--- a/src/notebooklm_tools/core/auth.py
+++ b/src/notebooklm_tools/core/auth.py
@@ -95,6 +95,7 @@ def load_cached_tokens() -> AuthTokens | None:
                 cookies=profile.cookies,
                 csrf_token=profile.csrf_token or "",
                 session_id=profile.session_id or "",
+                build_label=profile.build_label or "",
                 extracted_at=(
                     profile.last_validated.timestamp() if profile.last_validated else time.time()
                 ),

--- a/src/notebooklm_tools/mcp/tools/auth.py
+++ b/src/notebooklm_tools/mcp/tools/auth.py
@@ -45,16 +45,17 @@ def refresh_auth() -> ResultDict:
             # re-auth if those tokens are already dead. Validate live before
             # creating any client, otherwise agents loop on doomed studio calls
             # (and we leave a client object initialized with bad tokens behind).
-            from notebooklm_tools.services.auth import check_auth
+            from notebooklm_tools.services.auth import credentials_are_usable
 
-            check = check_auth(live=True)
-            if not check.valid:
+            usable, status, detail = credentials_are_usable(force=True)
+            if not usable:
                 return error_result(
                     "Auth tokens were reloaded from disk but are no longer valid "
-                    f"(reason: {check.reason}). A disk reload cannot revive expired "
+                    f"(reason: {status}). A disk reload cannot revive expired "
                     "credentials — run `nlm login` in a terminal to re-authenticate.",
                     status="expired",
-                    reason=check.reason,
+                    reason=status,
+                    details=detail,
                 )
             reset_client()
             get_client()

--- a/src/notebooklm_tools/mcp/tools/studio.py
+++ b/src/notebooklm_tools/mcp/tools/studio.py
@@ -40,27 +40,18 @@ def _get_auth_file_mtime() -> float:
 
 
 def _studio_auth_is_valid() -> tuple[bool, str | None, str | None]:
-    """Validate NotebookLM auth while preserving the historical test seam.
+    """Validate NotebookLM auth for studio_create pre-flight checks.
 
-    The legacy homepage-based live check can falsely report expired when
-    NotebookLM still accepts cached cookies for API operations. Use it for
-    non-expired failures, but confirm "expired" with the real NotebookLM API.
+    Uses ``AuthHealthChecker`` (homepage + API fallback) and, when probes
+    are inconclusive or falsely negative, confirms with the same live API
+    path as ``nlm login --check``.
     """
-    from ...services.auth import check_auth
+    from ...services.auth import credentials_are_usable
 
-    auth = check_auth(live=True)
-    if auth.valid:
+    usable, status, detail = credentials_are_usable()
+    if usable:
         return True, None, None
-    if auth.reason != "expired":
-        return False, auth.reason, None
-    try:
-        client = get_client()
-        if hasattr(client, "list_notebooks"):
-            client.list_notebooks()
-            return True, None, None
-    except Exception as exc:
-        return False, "api_validation_failed", str(exc)
-    return False, auth.reason, None
+    return False, status, detail
 
 
 def _normalize_studio_validation_error(message: str) -> str:

--- a/src/notebooklm_tools/services/auth.py
+++ b/src/notebooklm_tools/services/auth.py
@@ -346,7 +346,13 @@ class AuthHealthChecker:
         # to login or rejects auth, which is the most common false-positive scenario)
         if hp_reason in ("expired", "http_401", "http_403"):
             api_start = time.perf_counter()
-            api_valid, api_error = self._probe_api(cookie_dict, profile.csrf_token, timeout=timeout)
+            api_valid, api_error = self._probe_api(
+                profile.cookies,
+                profile.csrf_token,
+                timeout=timeout,
+                session_id=getattr(profile, "session_id", None),
+                build_label=getattr(profile, "build_label", None),
+            )
             api_latency = (time.perf_counter() - api_start) * 1000
 
             if api_valid:
@@ -418,7 +424,13 @@ class AuthHealthChecker:
             return False, f"network_error: {type(e).__name__}", str(e), None
 
     def _probe_api(
-        self, cookie_dict: dict[str, str], csrf_token: str | None, *, timeout: float
+        self,
+        cookies: dict[str, str] | list[dict[str, str]],
+        csrf_token: str | None,
+        *,
+        timeout: float,
+        session_id: str | None = None,
+        build_label: str | None = None,
     ) -> tuple[bool, str | None]:
         """Lightweight API probe: create a NotebookLMClient and list notebooks.
 
@@ -435,8 +447,13 @@ class AuthHealthChecker:
         try:
             from notebooklm_tools.core.client import NotebookLMClient
 
-            client = NotebookLMClient(cookies=cookie_dict, csrf_token=csrf_token or "")
-            client.list_notebooks()
+            with NotebookLMClient(
+                cookies=cookies,
+                csrf_token=csrf_token or "",
+                session_id=session_id or "",
+                build_label=build_label or "",
+            ) as client:
+                client.list_notebooks()
             return True, None
         except Exception as e:
             import httpx as _httpx

--- a/src/notebooklm_tools/services/auth.py
+++ b/src/notebooklm_tools/services/auth.py
@@ -38,6 +38,8 @@ __all__ = [
     "AuthProbeResult",  # defined locally in this module
     "AuthTokens",  # noqa: F822 — provided lazily via PEP 562 __getattr__
     "check_auth",
+    "confirm_auth_via_api",
+    "credentials_are_usable",
     "get_active_auth_mtime",
     "get_auth_health_checker",
     "get_cache_path",
@@ -549,6 +551,59 @@ class AuthHealthChecker:
 # ---------------------------------------------------------------------------
 # Process-wide singleton so the CLI and MCP share the same 30s cache
 # ---------------------------------------------------------------------------
+
+
+def confirm_auth_via_api(profile: str | None = None) -> tuple[bool, str | None]:
+    """Confirm credentials with a live NotebookLM API call.
+
+    Uses the same client parameters as ``nlm login --check`` (full cookie
+    list plus session fields), not a flattened cookie dict.
+    """
+    if profile is None:
+        from notebooklm_tools.utils.config import get_config
+
+        profile = get_config().auth.default_profile
+
+    from notebooklm_tools.core.auth import AuthManager
+    from notebooklm_tools.core.client import NotebookLMClient
+
+    manager = AuthManager(profile)
+    if not manager.profile_exists():
+        return False, "not_configured"
+
+    try:
+        p = manager.load_profile()
+        with NotebookLMClient(
+            cookies=p.cookies,
+            csrf_token=p.csrf_token or "",
+            session_id=p.session_id or "",
+            build_label=p.build_label or "",
+        ) as client:
+            client.list_notebooks()
+        return True, None
+    except Exception as exc:
+        return False, str(exc)
+
+
+def credentials_are_usable(*, force: bool = False) -> tuple[bool, str, str | None]:
+    """Return whether NotebookLM credentials can perform API operations.
+
+    Runs ``AuthHealthChecker`` first, then falls back to a direct API probe
+    when probes report ``stale`` or ``unverified`` — the semi-stale case
+    where the homepage rejects cookies but RPC calls still work (#224).
+    """
+    report = get_auth_health_checker().check(force=force)
+    if report.status == "configured":
+        return True, report.status, None
+
+    if report.status in ("stale", "unverified"):
+        ok, err = confirm_auth_via_api(profile=report.profile)
+        if ok:
+            return True, "configured", None
+        return False, report.status, err
+
+    detail = next((p.error for p in report.probes if p.error), None)
+    return False, report.status, detail
 
 
 _checker: AuthHealthChecker | None = None

--- a/tests/services/test_auth_health.py
+++ b/tests/services/test_auth_health.py
@@ -212,6 +212,48 @@ class TestCheckEndToEnd:
         probe_kinds = {p.probe for p in report.probes}
         assert probe_kinds == {"homepage", "api"}
 
+    def test_check_api_fallback_uses_full_cookie_list(self, tmp_path, monkeypatch):
+        """Regression: API fallback must pass profile.cookies (list) through to
+        NotebookLMClient. Flattening to dict drops domain-specific duplicates
+        and falsely reports stale for profiles that nlm login --check accepts."""
+        monkeypatch.setattr("notebooklm_tools.utils.config.get_storage_dir", lambda: tmp_path)
+        duplicate_cookies = [
+            {"name": "HSID", "value": "hsid-google", "domain": ".google.com", "path": "/"},
+            {"name": "HSID", "value": "hsid-other", "domain": ".example.com", "path": "/"},
+            {"name": "SID", "value": "sid", "domain": ".google.com", "path": "/"},
+        ]
+        AuthManager("default").save_profile(
+            cookies=duplicate_cookies,
+            csrf_token="csrf",
+            session_id="sess",
+            build_label="build",
+            email="test@example.com",
+        )
+
+        captured: dict = {}
+
+        def capture_probe(cookies, csrf_token, *, timeout, session_id=None, build_label=None):
+            captured["cookies"] = cookies
+            captured["csrf_token"] = csrf_token
+            captured["session_id"] = session_id
+            captured["build_label"] = build_label
+            return True, None
+
+        with patch("httpx.Client") as MockClient:
+            client = MockClient.return_value.__enter__.return_value
+            req = httpx.Request("GET", "https://accounts.google.com/ServiceLogin")
+            client.get.return_value = httpx.Response(200, request=req, text="login page")
+
+            with patch.object(AuthHealthChecker, "_probe_api", side_effect=capture_probe):
+                report = AuthHealthChecker().check(force=True, timeout=2.0)
+
+        assert report.status == "configured"
+        assert isinstance(captured["cookies"], list)
+        assert len(captured["cookies"]) == 3
+        assert captured["csrf_token"] == "csrf"
+        assert captured["session_id"] == "sess"
+        assert captured["build_label"] == "build"
+
     def test_check_homepage_expired_api_network_error_returns_unverified(
         self, tmp_path, monkeypatch
     ):
@@ -262,6 +304,14 @@ class TestCheckEndToEnd:
 # ---------------------------------------------------------------------------
 
 
+def _enterable_client_mock(MockClient):
+    """NotebookLMClient is used as a context manager in _probe_api."""
+    instance = MockClient.return_value
+    instance.__enter__.return_value = instance
+    instance.__exit__.return_value = None
+    return instance
+
+
 class TestProbeApiErrorClassification:
     """`_probe_api` must prefix transport errors with `network_error:`
     so the verdict logic can distinguish them. The original PR emitted
@@ -272,18 +322,37 @@ class TestProbeApiErrorClassification:
         _save_fake_profile(tmp_path, monkeypatch)
 
         with patch("notebooklm_tools.core.client.NotebookLMClient") as MockClient:
-            instance = MockClient.return_value
+            instance = _enterable_client_mock(MockClient)
             instance.list_notebooks.return_value = []
             ok, err = AuthHealthChecker()._probe_api({"SID": "x"}, csrf_token="", timeout=2.0)
         assert ok is True
         assert err is None
+
+    def test_probe_api_passes_session_fields(self):
+        checker = AuthHealthChecker()
+        with patch("notebooklm_tools.core.client.NotebookLMClient") as MockClient:
+            instance = _enterable_client_mock(MockClient)
+            instance.list_notebooks.return_value = []
+            checker._probe_api(
+                {"SID": "x"},
+                csrf_token="csrf",
+                timeout=2.0,
+                session_id="sess-1",
+                build_label="build-1",
+            )
+        MockClient.assert_called_once_with(
+            cookies={"SID": "x"},
+            csrf_token="csrf",
+            session_id="sess-1",
+            build_label="build-1",
+        )
 
     def test_probe_api_timeout_emits_network_error_prefix(self):
         """An httpx.TimeoutException from the API call must be reported
         with the ``network_error:`` prefix."""
         checker = AuthHealthChecker()
         with patch("notebooklm_tools.core.client.NotebookLMClient") as MockClient:
-            instance = MockClient.return_value
+            instance = _enterable_client_mock(MockClient)
             instance.list_notebooks.side_effect = httpx.ConnectTimeout("timed out")
             ok, err = checker._probe_api({"SID": "x"}, csrf_token="", timeout=2.0)
         assert ok is False
@@ -298,7 +367,7 @@ class TestProbeApiErrorClassification:
         """httpx.RequestError covers connection refused, DNS failures, etc."""
         checker = AuthHealthChecker()
         with patch("notebooklm_tools.core.client.NotebookLMClient") as MockClient:
-            instance = MockClient.return_value
+            instance = _enterable_client_mock(MockClient)
             instance.list_notebooks.side_effect = httpx.ConnectError("refused")
             ok, err = checker._probe_api({"SID": "x"}, csrf_token="", timeout=2.0)
         assert ok is False
@@ -315,7 +384,7 @@ class TestProbeApiErrorClassification:
 
         checker = AuthHealthChecker()
         with patch("notebooklm_tools.core.client.NotebookLMClient") as MockClient:
-            instance = MockClient.return_value
+            instance = _enterable_client_mock(MockClient)
             instance.list_notebooks.side_effect = FakeAuthError("bad creds")
             ok, err = checker._probe_api({"SID": "x"}, csrf_token="", timeout=2.0)
         assert ok is False

--- a/tests/services/test_auth_health.py
+++ b/tests/services/test_auth_health.py
@@ -312,6 +312,50 @@ def _enterable_client_mock(MockClient):
     return instance
 
 
+class TestCredentialsAreUsable:
+    def test_returns_configured_when_health_checker_passes(self, monkeypatch):
+        report = AuthHealthReport(
+            valid=True,
+            status="configured",
+            probes=[],
+            profile="default",
+            checked_at=0.0,
+        )
+        monkeypatch.setattr(
+            "notebooklm_tools.services.auth.get_auth_health_checker",
+            lambda: type("C", (), {"check": lambda self, **kw: report})(),
+        )
+        usable, status, detail = __import__(
+            "notebooklm_tools.services.auth", fromlist=["credentials_are_usable"]
+        ).credentials_are_usable()
+        assert usable is True
+        assert status == "configured"
+        assert detail is None
+
+    def test_falls_back_to_api_when_health_checker_reports_stale(self, monkeypatch):
+        report = AuthHealthReport(
+            valid=False,
+            status="stale",
+            probes=[AuthProbeResult(probe="homepage", valid=False, error="expired")],
+            profile="default",
+            checked_at=0.0,
+        )
+        monkeypatch.setattr(
+            "notebooklm_tools.services.auth.get_auth_health_checker",
+            lambda: type("C", (), {"check": lambda self, **kw: report})(),
+        )
+        monkeypatch.setattr(
+            "notebooklm_tools.services.auth.confirm_auth_via_api",
+            lambda **kw: (True, None),
+        )
+        from notebooklm_tools.services.auth import credentials_are_usable
+
+        usable, status, detail = credentials_are_usable()
+        assert usable is True
+        assert status == "configured"
+        assert detail is None
+
+
 class TestProbeApiErrorClassification:
     """`_probe_api` must prefix transport errors with `network_error:`
     so the verdict logic can distinguish them. The original PR emitted

--- a/tests/services/test_auth_service.py
+++ b/tests/services/test_auth_service.py
@@ -25,6 +25,8 @@ def test_shim_reexports_expected_auth_symbols():
             "AuthProbeResult",
             "AuthTokens",
             "check_auth",
+            "confirm_auth_via_api",
+            "credentials_are_usable",
             "get_active_auth_mtime",
             "get_auth_health_checker",
             "get_cache_path",

--- a/tests/test_mcp_auth_studio_failures.py
+++ b/tests/test_mcp_auth_studio_failures.py
@@ -17,6 +17,7 @@ import pytest
 auth_tools = importlib.import_module("notebooklm_tools.mcp.tools.auth")
 studio_tools = importlib.import_module("notebooklm_tools.mcp.tools.studio")
 core_auth = importlib.import_module("notebooklm_tools.core.auth")
+services_auth = importlib.import_module("notebooklm_tools.services.auth")
 
 
 # --------------------------------------------------------------------------- #
@@ -25,6 +26,15 @@ core_auth = importlib.import_module("notebooklm_tools.core.auth")
 def _auth_result(valid, reason=None):
     """Build a real AuthCheckResult so we exercise the production type."""
     return core_auth.AuthCheckResult(valid=valid, reason=reason, live=True, profile="default")
+
+
+def _patch_credentials_usable(monkeypatch, usable, status="stale", detail=None):
+    monkeypatch.setattr(
+        services_auth,
+        "credentials_are_usable",
+        lambda **kw: (usable, "configured" if usable else status, detail),
+        raising=True,
+    )
 
 
 class _FakeClient:
@@ -50,10 +60,8 @@ def test_refresh_auth_does_not_claim_success_when_tokens_are_expired(monkeypatch
         lambda: core_auth.AuthTokens(cookies={"SID": "x"}, extracted_at=0.0),
         raising=True,
     )
-    # ...but a live check reports them expired.
-    monkeypatch.setattr(
-        core_auth, "check_auth", lambda **kw: _auth_result(False, "expired"), raising=True
-    )
+    # ...but auth probes report stale even though this test expects failure.
+    _patch_credentials_usable(monkeypatch, usable=False, status="stale")
     monkeypatch.delenv("NOTEBOOKLM_COOKIES", raising=False)
 
     result = auth_tools.refresh_auth()
@@ -104,11 +112,29 @@ def test_refresh_auth_reports_success_when_tokens_are_valid(monkeypatch):
         lambda: core_auth.AuthTokens(cookies={"SID": "x"}, extracted_at=0.0),
         raising=True,
     )
-    monkeypatch.setattr(core_auth, "check_auth", lambda **kw: _auth_result(True), raising=True)
+    _patch_credentials_usable(monkeypatch, usable=True)
     monkeypatch.delenv("NOTEBOOKLM_COOKIES", raising=False)
 
     result = auth_tools.refresh_auth()
     assert result.get("status") == "success", f"Valid tokens should refresh OK, got: {result}"
+
+
+def test_refresh_auth_succeeds_when_probes_stale_but_api_works(monkeypatch):
+    """Semi-stale cookies: AuthHealthChecker may say stale while RPC still works.
+    refresh_auth must not block agents when the API confirmation succeeds."""
+    monkeypatch.setattr(auth_tools, "get_client", lambda: _FakeClient(), raising=True)
+    monkeypatch.setattr(auth_tools, "reset_client", lambda: None, raising=True)
+    monkeypatch.setattr(
+        core_auth,
+        "load_cached_tokens",
+        lambda: core_auth.AuthTokens(cookies={"SID": "x"}, extracted_at=0.0),
+        raising=True,
+    )
+    _patch_credentials_usable(monkeypatch, usable=True)
+    monkeypatch.delenv("NOTEBOOKLM_COOKIES", raising=False)
+
+    result = auth_tools.refresh_auth()
+    assert result.get("status") == "success", f"API-confirmed auth should refresh OK, got: {result}"
 
 
 # --------------------------------------------------------------------------- #
@@ -119,9 +145,7 @@ def test_studio_create_fails_loudly_on_stale_auth(monkeypatch):
     — not status:"success" with an artifact_id that immediately fails.
     """
     studio_tools._auth_guard_expires = 0.0  # force guard expired so auth is re-checked
-    monkeypatch.setattr(
-        core_auth, "check_auth", lambda **kw: _auth_result(False, "expired"), raising=True
-    )
+    _patch_credentials_usable(monkeypatch, usable=False, status="stale")
 
     # If the code wrongly proceeds, make the client call explode so the test can't pass by luck.
     def _boom():
@@ -147,7 +171,7 @@ def test_studio_create_fails_loudly_on_stale_auth(monkeypatch):
 def test_studio_create_proceeds_when_auth_valid(monkeypatch):
     """With valid auth, studio_create() must still create the artifact normally."""
     studio_tools._auth_guard_expires = 0.0  # force guard expired so auth is re-checked
-    monkeypatch.setattr(core_auth, "check_auth", lambda **kw: _auth_result(True), raising=True)
+    _patch_credentials_usable(monkeypatch, usable=True)
     monkeypatch.setattr(studio_tools, "get_client", lambda: _FakeClient(), raising=True)
     monkeypatch.setattr(
         studio_tools.studio_service,
@@ -163,6 +187,26 @@ def test_studio_create_proceeds_when_auth_valid(monkeypatch):
     )
     assert result.get("status") == "success", f"Valid auth should create artifact, got: {result}"
     assert result.get("artifact_id") == "art-1"
+
+
+def test_studio_create_proceeds_when_probes_stale_but_api_works(monkeypatch):
+    """Issue #224 class: server_info/AuthHealthChecker may say stale while RPC works."""
+    studio_tools._auth_guard_expires = 0.0
+    _patch_credentials_usable(monkeypatch, usable=True)
+    monkeypatch.setattr(studio_tools, "get_client", lambda: _FakeClient(), raising=True)
+    monkeypatch.setattr(
+        studio_tools.studio_service,
+        "create_artifact",
+        lambda *a, **k: {"artifact_id": "art-semi", "status": "in_progress"},
+        raising=True,
+    )
+
+    result = studio_tools.studio_create(
+        notebook_id="nb-123",
+        artifact_type="audio",
+        confirm=True,
+    )
+    assert result.get("status") == "success", f"Semi-stale API auth should create, got: {result}"
 
 
 # --------------------------------------------------------------------------- #
@@ -254,9 +298,7 @@ def test_studio_create_e2e_per_auth_state(monkeypatch, auth_state, valid, reason
     status:"error" (never a fake success).
     """
     studio_tools._auth_guard_expires = 0.0  # force guard expired so auth is re-checked
-    monkeypatch.setattr(
-        core_auth, "check_auth", lambda **kw: _auth_result(valid, reason), raising=True
-    )
+    _patch_credentials_usable(monkeypatch, usable=valid, status=reason or "stale")
     monkeypatch.setattr(studio_tools, "get_client", lambda: _FakeClient(), raising=True)
     monkeypatch.setattr(
         studio_tools.studio_service,
@@ -300,9 +342,7 @@ def test_studio_create_resets_auth_guard_on_invalid_auth(monkeypatch):
     the TTL has already expired and we just detected the invalid auth: we
     should not let a future-valid guard leak forward to the next call.
     """
-    monkeypatch.setattr(
-        core_auth, "check_auth", lambda **kw: _auth_result(False, "expired"), raising=True
-    )
+    _patch_credentials_usable(monkeypatch, usable=False, status="stale")
     monkeypatch.setattr(studio_tools, "get_client", lambda: _FakeClient(), raising=True)
 
     # Pre-seed the guard with a future timestamp, simulating "auth was valid
@@ -332,13 +372,13 @@ def test_studio_create_invalidates_auth_guard_when_auth_file_changes(monkeypatch
     """
     check_call_count = {"n": 0}
 
-    def _counting_check_auth(**_kw):
+    def _counting_credentials(**_kw):
         check_call_count["n"] += 1
-        return _auth_result(True)
+        return True, "configured", None
 
     # First call: mtime=N. Guard populated with mtime=N.
     monkeypatch.setattr(studio_tools, "_get_auth_file_mtime", lambda: 1000.0, raising=True)
-    monkeypatch.setattr(core_auth, "check_auth", _counting_check_auth, raising=True)
+    monkeypatch.setattr(services_auth, "credentials_are_usable", _counting_credentials, raising=True)
     monkeypatch.setattr(studio_tools, "get_client", lambda: _FakeClient(), raising=True)
     monkeypatch.setattr(
         studio_tools.studio_service,
@@ -376,13 +416,13 @@ def test_studio_create_invalidates_auth_guard_when_auth_file_appears(monkeypatch
     """
     check_call_count = {"n": 0}
 
-    def _counting_check_auth(**_kw):
+    def _counting_credentials(**_kw):
         check_call_count["n"] += 1
-        return _auth_result(True)
+        return True, "configured", None
 
     # First call: file does not exist (mtime=0.0). Guard populated with mtime=0.0.
     monkeypatch.setattr(studio_tools, "_get_auth_file_mtime", lambda: 0.0, raising=True)
-    monkeypatch.setattr(core_auth, "check_auth", _counting_check_auth, raising=True)
+    monkeypatch.setattr(services_auth, "credentials_are_usable", _counting_credentials, raising=True)
     monkeypatch.setattr(studio_tools, "get_client", lambda: _FakeClient(), raising=True)
     monkeypatch.setattr(
         studio_tools.studio_service,

--- a/tests/test_mcp_auth_studio_failures.py
+++ b/tests/test_mcp_auth_studio_failures.py
@@ -378,7 +378,9 @@ def test_studio_create_invalidates_auth_guard_when_auth_file_changes(monkeypatch
 
     # First call: mtime=N. Guard populated with mtime=N.
     monkeypatch.setattr(studio_tools, "_get_auth_file_mtime", lambda: 1000.0, raising=True)
-    monkeypatch.setattr(services_auth, "credentials_are_usable", _counting_credentials, raising=True)
+    monkeypatch.setattr(
+        services_auth, "credentials_are_usable", _counting_credentials, raising=True
+    )
     monkeypatch.setattr(studio_tools, "get_client", lambda: _FakeClient(), raising=True)
     monkeypatch.setattr(
         studio_tools.studio_service,
@@ -422,7 +424,9 @@ def test_studio_create_invalidates_auth_guard_when_auth_file_appears(monkeypatch
 
     # First call: file does not exist (mtime=0.0). Guard populated with mtime=0.0.
     monkeypatch.setattr(studio_tools, "_get_auth_file_mtime", lambda: 0.0, raising=True)
-    monkeypatch.setattr(services_auth, "credentials_are_usable", _counting_credentials, raising=True)
+    monkeypatch.setattr(
+        services_auth, "credentials_are_usable", _counting_credentials, raising=True
+    )
     monkeypatch.setattr(studio_tools, "get_client", lambda: _FakeClient(), raising=True)
     monkeypatch.setattr(
         studio_tools.studio_service,


### PR DESCRIPTION
## Summary

Fixes the remaining semi-stale auth false negatives from PR #219 and closes **#224**.

## Root cause (#219 API fallback)

When the homepage probe redirects to `accounts.google.com`, the API fallback flattened `profile.cookies` to a dict before calling `NotebookLMClient`, dropping domain-specific duplicates and omitting `session_id` / `build_label`. `nlm login --check` passed the full cookie list and succeeded, so checks disagreed.

## Root cause (#224 MCP split-brain)

Even after #219, MCP paths still disagreed:

| Path | Before | Problem |
|------|--------|---------|
| `server_info` | `AuthHealthChecker` | Broken API fallback → false `stale` |
| `refresh_auth` | homepage-only `check_auth` | False `expired` on semi-stale cookies |
| `studio_create` | `check_auth` + partial API fallback | Could block while `notebook_list` worked |
| CLI / `notebook_list` | full cookie list via `get_client()` | worked |

## Fix

- API probe passes `profile.cookies` unchanged + `session_id` / `build_label`
- New `credentials_are_usable()` (`AuthHealthChecker` + live API confirmation) shared by `refresh_auth` and `studio_create`
- `load_cached_tokens()` forwards `build_label` to the MCP client

Fixes #224

## Test plan

- [x] `uv run pytest tests/services/test_auth_health.py tests/test_mcp_auth_studio_failures.py` (69 passed)
- [x] Live semi-stale profile: `server_info` → `configured`, `refresh_auth` → success, `studio_create` pre-flight → OK