### PR TITLE
feat(mcp): add hardened ChatGPT file bridge

### DIFF
--- a/docs/PR_CHATGPT_HARDENED_BRIDGE.md
+++ b/docs/PR_CHATGPT_HARDENED_BRIDGE.md
@@ -65,9 +65,10 @@ NOTEBOOKLM_CHATGPT_FILE_CACHE_DIR=<custom cache directory>
 Static and unit validation:
 
 ```text
-ruff: All checks passed
-pytest: 27 passed
-server import ok
+ruff check: All checks passed
+ruff format --check: clean
+pytest: 29 passed locally for PR-specific tests
+GitHub Actions: lint, tests, and version alignment passed
 ```
 
 Live NotebookLM validation:

--- a/docs/PR_CHATGPT_HARDENED_BRIDGE.md
+++ b/docs/PR_CHATGPT_HARDENED_BRIDGE.md
@@ -35,6 +35,16 @@ This implementation addresses those by construction:
 - no `download_url` is added to `source_get_content` or `download_artifact`;
 - ordinary read-only tools do not write files to disk.
 
+## Issues addressed
+
+This PR explicitly addresses the issues raised against the earlier reverted bridge:
+
+- SSRF risk is addressed with `https://`-only URLs, required host allowlisting, DNS resolution checks, and rejection of private/link-local/loopback addresses.
+- Redirect bypass risk is addressed by manually following redirects and revalidating every redirected URL.
+- Disk leak risk is addressed by making downloads temporary, explicit, size-limited, and cleaned up after upload by default.
+- Surprise behavior is addressed by keeping ordinary read-only MCP tools unchanged: no implicit file writes and no automatic `download_url` injection.
+- Accidental upload risk is addressed by requiring an explicit bridge tool call and `confirm=True` before NotebookLM upload.
+
 ## New tools
 
 ```text
@@ -42,6 +52,48 @@ chatgpt_bridge_status
 chatgpt_add_file_source
 chatgpt_bridge_cleanup
 ```
+
+## How to use with ChatGPT
+
+This PR covers the inbound flow:
+
+```text
+ChatGPT-accessible HTTPS file URL -> NotebookLM file source
+```
+
+1. Enable the bridge in the MCP server environment:
+
+   ```text
+   NOTEBOOKLM_CHATGPT_BRIDGE_ENABLED=true
+   NOTEBOOKLM_CHATGPT_FILE_HOST_ALLOWLIST=host.example.com,*.trusted.example.com
+   ```
+
+2. Put the file somewhere ChatGPT/the MCP server can reach by HTTPS, and make sure the hostname is in `NOTEBOOKLM_CHATGPT_FILE_HOST_ALLOWLIST`.
+
+3. In the MCP client, call:
+
+   ```text
+   chatgpt_bridge_status
+   ```
+
+   Confirm the bridge is enabled and the allowlist is loaded.
+
+4. Ask ChatGPT to provide or use the trusted HTTPS file URL, then call:
+
+   ```text
+   chatgpt_add_file_source(
+     notebook_id="<notebook-id>",
+     file_url="https://host.example.com/path/to/file.pdf",
+     title="Optional source title",
+     confirm=true
+   )
+   ```
+
+5. The bridge downloads the file into a temporary cache, validates it, uploads it to NotebookLM as a source, and deletes the temporary file by default.
+
+6. Use `chatgpt_bridge_cleanup` to clear any expired temporary downloads.
+
+Important limitation: this does not let arbitrary ChatGPT-provided URLs through. The URL must be HTTPS and must resolve to a public address on an explicitly allowed hostname.
 
 ## Configuration
 

--- a/docs/PR_CHATGPT_HARDENED_BRIDGE.md
+++ b/docs/PR_CHATGPT_HARDENED_BRIDGE.md
@@ -1,0 +1,104 @@
+# PR: Hardened ChatGPT file bridge
+
+## Summary
+
+This PR reintroduces ChatGPT-to-NotebookLM file handoff in a narrow, opt-in form after the reverted ChatGPT file bridge.
+
+It intentionally keeps the earlier safe polling/auth branch as the base and adds only an explicit inbound bridge:
+
+```text
+trusted HTTPS file URL -> validated temporary download -> NotebookLM file source upload -> temp cleanup
+```
+
+It does not restore public artifact serving or add download links to ordinary MCP tool results.
+
+## Why this is different from the reverted bridge
+
+The reverted bridge had three review-blocking issues:
+
+1. SSRF risk from accepting remote URLs without strict hostname/IP validation.
+2. Disk leak risk from ordinary `source_get_content` calls writing files to disk.
+3. Global behavior changes from injecting download URLs and file-serving behavior into existing tools.
+
+This implementation addresses those by construction:
+
+- the bridge is disabled by default;
+- remote downloads require an explicit bridge tool call;
+- a non-empty host allowlist is required;
+- only `https://` URLs are accepted;
+- hostnames are resolved and non-public addresses are rejected;
+- redirects are manually followed and revalidated;
+- file size and file extension allowlists are enforced;
+- `confirm=True` is required before upload;
+- temp files are deleted after upload by default;
+- no `/artifacts` route is added;
+- no `download_url` is added to `source_get_content` or `download_artifact`;
+- ordinary read-only tools do not write files to disk.
+
+## New tools
+
+```text
+chatgpt_bridge_status
+chatgpt_add_file_source
+chatgpt_bridge_cleanup
+```
+
+## Configuration
+
+Required to enable the bridge:
+
+```text
+NOTEBOOKLM_CHATGPT_BRIDGE_ENABLED=true
+NOTEBOOKLM_CHATGPT_FILE_HOST_ALLOWLIST=host.example.com,*.trusted.example.com
+```
+
+Optional limits:
+
+```text
+NOTEBOOKLM_CHATGPT_FILE_MAX_BYTES=26214400
+NOTEBOOKLM_CHATGPT_FILE_TTL_SECONDS=3600
+NOTEBOOKLM_CHATGPT_FILE_CACHE_DIR=<custom cache directory>
+```
+
+## Validation performed
+
+Static and unit validation:
+
+```text
+ruff: All checks passed
+pytest: 27 passed
+server import ok
+```
+
+Live NotebookLM validation:
+
+```text
+profile: pte
+account: personaltouchelectronics@gmail.com
+created disposable notebook: success
+added trusted HTTPS test file as source: success
+verified source_count: 1
+cache cleanup: success
+deleted disposable notebook: success
+```
+
+## Scope intentionally deferred
+
+This PR only covers inbound ChatGPT file URL upload into NotebookLM.
+
+The inverse flow is intentionally separate:
+
+```text
+NotebookLM artifact/source -> short-lived authenticated download link for ChatGPT
+```
+
+That outbound flow needs a separate design because it requires scoped file serving, tokens, TTLs, retention cleanup, and careful tunnel exposure controls.
+
+## Files changed
+
+```text
+src/notebooklm_tools/mcp/tools/chatgpt_bridge.py
+tests/test_mcp_chatgpt_bridge_hardened.py
+src/notebooklm_tools/mcp/tools/__init__.py
+src/notebooklm_tools/mcp/server.py
+```

--- a/docs/SAFE_POLLING_AND_AUTH.md
+++ b/docs/SAFE_POLLING_AND_AUTH.md
@@ -1,0 +1,25 @@
+# Safe polling and auth-health changes
+
+This note documents the hardened subset intentionally kept after reverting the ChatGPT file bridge.
+
+## Included
+
+- `source_get_content` now accepts `wait`, `wait_timeout`, and `poll_interval`.
+- `download_artifact` now accepts `wait`, `wait_timeout`, and `poll_interval`.
+- `studio_create` uses the shared `AuthHealthChecker` path introduced by the multi-probe auth-health work.
+- Headless Chrome profile detection recognizes both legacy and modern cookie database locations:
+  - `Default/Cookies`
+  - `Default/Network/Cookies`
+
+## Intentionally excluded
+
+The ChatGPT file upload/download bridge is not included in this branch.
+
+Specifically, this branch does not add:
+
+- a public `/artifacts/{filename}` route;
+- automatic disk writes from read-only tools such as `source_get_content`;
+- automatic `download_url` fields in ordinary MCP tool results;
+- broad remote URL downloading from ChatGPT file references.
+
+Those behaviors require a hardened design with explicit opt-in, strict host allowlisting, bounded retention/cleanup, and no behavioral changes for non-ChatGPT users.

--- a/src/notebooklm_tools/mcp/server.py
+++ b/src/notebooklm_tools/mcp/server.py
@@ -80,6 +80,7 @@ def _register_tools() -> None:
         auth,
         batch,
         chat,
+        chatgpt_bridge,
         cross_notebook,
         downloads,
         exports,

--- a/src/notebooklm_tools/mcp/tools/__init__.py
+++ b/src/notebooklm_tools/mcp/tools/__init__.py
@@ -7,6 +7,11 @@ from .chat import (
     chat_configure,
     notebook_query,
 )
+from .chatgpt_bridge import (
+    chatgpt_add_file_source,
+    chatgpt_bridge_cleanup,
+    chatgpt_bridge_status,
+)
 from .cross_notebook import cross_notebook_query
 from .downloads import download_artifact
 from .exports import (
@@ -89,6 +94,10 @@ __all__ = [
     # Chat (2)
     "notebook_query",
     "chat_configure",
+    # ChatGPT file bridge (3; disabled by default)
+    "chatgpt_bridge_status",
+    "chatgpt_add_file_source",
+    "chatgpt_bridge_cleanup",
     # Exports (1)
     "export_artifact",
     # Notes (1 consolidated)

--- a/src/notebooklm_tools/mcp/tools/chatgpt_bridge.py
+++ b/src/notebooklm_tools/mcp/tools/chatgpt_bridge.py
@@ -1,0 +1,289 @@
+"""Disabled-by-default hardened helpers for ChatGPT file handoff.
+
+This module intentionally does not expose a public file-serving route and does
+not alter ordinary source/download tools. It only downloads remote files when an
+explicit ChatGPT bridge tool is called and the bridge is enabled by environment.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+import socket
+import time
+from contextlib import suppress
+from pathlib import Path
+from urllib.parse import urljoin, urlparse
+
+import httpx
+
+from ...services import ServiceError, ValidationError
+from ...services import sources as sources_service
+from ...utils.config import get_data_dir
+from ._utils import ResultDict, error_result, get_client, logged_tool
+
+_FALSY = {"0", "false", "no", "off", ""}
+_DEFAULT_MAX_BYTES = 25 * 1024 * 1024
+_DEFAULT_TTL_SECONDS = 3600
+_MAX_REDIRECTS = 3
+
+_ALLOWED_EXTENSIONS = {
+    ".pdf", ".txt", ".md", ".docx", ".csv", ".epub",
+    ".mp3", ".m4a", ".wav", ".aac", ".ogg", ".opus",
+    ".mp4", ".jpg", ".jpeg", ".png", ".gif", ".webp",
+}
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() not in _FALSY
+
+
+def _enabled() -> bool:
+    return _env_bool("NOTEBOOKLM_CHATGPT_BRIDGE_ENABLED", False)
+
+
+def _allowed_hosts() -> list[str]:
+    raw = os.environ.get("NOTEBOOKLM_CHATGPT_FILE_HOST_ALLOWLIST", "")
+    return [item.strip().lower() for item in raw.split(",") if item.strip()]
+
+
+def _max_bytes() -> int:
+    raw = os.environ.get("NOTEBOOKLM_CHATGPT_FILE_MAX_BYTES", str(_DEFAULT_MAX_BYTES))
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return _DEFAULT_MAX_BYTES
+
+
+def _cache_dir() -> Path:
+    return Path(
+        os.environ.get("NOTEBOOKLM_CHATGPT_FILE_CACHE_DIR", "")
+        or get_data_dir() / "chatgpt_file_bridge"
+    )
+
+
+def _ttl_seconds() -> int:
+    raw = os.environ.get("NOTEBOOKLM_CHATGPT_FILE_TTL_SECONDS", str(_DEFAULT_TTL_SECONDS))
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return _DEFAULT_TTL_SECONDS
+
+
+def _host_allowed(hostname: str, allowed_hosts: list[str]) -> bool:
+    host = hostname.lower().rstrip(".")
+    for pattern in allowed_hosts:
+        pattern = pattern.lower().rstrip(".")
+        if pattern.startswith("*."):
+            suffix = pattern[1:]
+            if host.endswith(suffix) and host != pattern[2:]:
+                return True
+        elif host == pattern:
+            return True
+    return False
+
+
+def _public_ip_check(hostname: str) -> None:
+    try:
+        ipaddress.ip_address(hostname)
+        addresses = [hostname]
+    except ValueError:
+        infos = socket.getaddrinfo(hostname, None, type=socket.SOCK_STREAM)
+        addresses = [info[4][0] for info in infos]
+
+    if not addresses:
+        raise ValidationError("URL host did not resolve to any address.")
+
+    for address in addresses:
+        ip = ipaddress.ip_address(address)
+        if any(
+            (
+                ip.is_private,
+                ip.is_loopback,
+                ip.is_link_local,
+                ip.is_multicast,
+                ip.is_reserved,
+                ip.is_unspecified,
+            )
+        ):
+            raise ValidationError("URL host resolves to a non-public address.")
+
+
+def _validate_remote_url(url: str, allowed_hosts: list[str]) -> str:
+    parsed = urlparse(url)
+    if parsed.scheme.lower() != "https":
+        raise ValidationError("Only https:// ChatGPT file URLs are allowed.")
+    if not parsed.hostname:
+        raise ValidationError("URL must include a hostname.")
+    if not allowed_hosts:
+        raise ValidationError(
+            "No ChatGPT file host allowlist configured. Set "
+            "NOTEBOOKLM_CHATGPT_FILE_HOST_ALLOWLIST."
+        )
+    if not _host_allowed(parsed.hostname, allowed_hosts):
+        raise ValidationError("URL host is not in NOTEBOOKLM_CHATGPT_FILE_HOST_ALLOWLIST.")
+
+    _public_ip_check(parsed.hostname)
+    return url
+
+
+def _safe_filename(name: str | None, fallback: str = "chatgpt-file") -> str:
+    raw = Path(name or fallback).name.strip().strip(".") or fallback
+    safe = "".join(ch if ch.isalnum() or ch in "._- " else "_" for ch in raw)
+    suffix = Path(safe).suffix.lower()
+    if suffix not in _ALLOWED_EXTENSIONS:
+        raise ValidationError(
+            f"File extension '{suffix or '[none]'}' is not allowed for ChatGPT bridge uploads."
+        )
+    return safe[:180]
+
+
+def cleanup_chatgpt_bridge_cache(max_age_seconds: int | None = None) -> int:
+    """Delete stale files from the explicit ChatGPT bridge cache."""
+    cutoff = time.time() - (max_age_seconds if max_age_seconds is not None else _ttl_seconds())
+    removed = 0
+    directory = _cache_dir()
+    if not directory.exists():
+        return 0
+    for path in directory.iterdir():
+        try:
+            if path.is_file() and path.stat().st_mtime < cutoff:
+                path.unlink()
+                removed += 1
+        except OSError:
+            continue
+    return removed
+
+
+def _download_remote_file(download_url: str, file_name: str | None) -> tuple[Path, int]:
+    allowed_hosts = _allowed_hosts()
+    current_url = _validate_remote_url(download_url, allowed_hosts)
+    filename = _safe_filename(file_name or Path(urlparse(current_url).path).name)
+    max_bytes = _max_bytes()
+    directory = _cache_dir()
+    directory.mkdir(parents=True, exist_ok=True)
+    target = directory / f"{int(time.time())}-{os.urandom(4).hex()}-{filename}"
+
+    total = 0
+    try:
+        for _redirect in range(_MAX_REDIRECTS + 1):
+            with httpx.stream("GET", current_url, follow_redirects=False, timeout=30.0) as resp:
+                if resp.status_code in (301, 302, 303, 307, 308):
+                    location = resp.headers.get("location")
+                    if not location:
+                        raise ValidationError("Redirect response did not include a Location header.")
+                    current_url = _validate_remote_url(urljoin(current_url, location), allowed_hosts)
+                    continue
+
+                resp.raise_for_status()
+                content_length = resp.headers.get("content-length")
+                if content_length and int(content_length) > max_bytes:
+                    raise ValidationError("ChatGPT file is larger than NOTEBOOKLM_CHATGPT_FILE_MAX_BYTES.")
+
+                with target.open("wb") as handle:
+                    for chunk in resp.iter_bytes():
+                        total += len(chunk)
+                        if total > max_bytes:
+                            raise ValidationError("ChatGPT file exceeded NOTEBOOKLM_CHATGPT_FILE_MAX_BYTES.")
+                        handle.write(chunk)
+                return target, total
+        raise ValidationError("Too many redirects while downloading ChatGPT file.")
+    except Exception:
+        with suppress(OSError):
+            target.unlink(missing_ok=True)
+        raise
+
+
+@logged_tool()
+def chatgpt_bridge_status() -> ResultDict:
+    """Return current hardened ChatGPT file bridge configuration."""
+    return {
+        "status": "success",
+        "enabled": _enabled(),
+        "allowed_hosts": _allowed_hosts(),
+        "max_bytes": _max_bytes(),
+        "cache_dir": str(_cache_dir()),
+        "ttl_seconds": _ttl_seconds(),
+    }
+
+
+@logged_tool()
+def chatgpt_add_file_source(
+    notebook_id: str,
+    download_url: str,
+    file_name: str,
+    title: str | None = None,
+    wait: bool = True,
+    wait_timeout: float = 120.0,
+    confirm: bool = False,
+    delete_after_upload: bool = True,
+) -> ResultDict:
+    """Download an explicitly allowed ChatGPT file URL and add it as a source.
+
+    The bridge is disabled by default. Enable it with
+    NOTEBOOKLM_CHATGPT_BRIDGE_ENABLED=true and configure a strict host allowlist
+    in NOTEBOOKLM_CHATGPT_FILE_HOST_ALLOWLIST.
+    """
+    if not _enabled():
+        return error_result(
+            "ChatGPT file bridge is disabled.",
+            hint="Set NOTEBOOKLM_CHATGPT_BRIDGE_ENABLED=true and configure NOTEBOOKLM_CHATGPT_FILE_HOST_ALLOWLIST.",
+        )
+    if not confirm:
+        return {
+            "status": "pending_confirmation",
+            "message": "Confirm adding this ChatGPT-hosted file to NotebookLM.",
+            "settings": {
+                "notebook_id": notebook_id,
+                "file_name": file_name,
+                "title": title or file_name,
+                "allowed_hosts": _allowed_hosts(),
+                "max_bytes": _max_bytes(),
+                "delete_after_upload": delete_after_upload,
+            },
+            "note": "Set confirm=True after verifying the file URL source is trusted.",
+        }
+
+    local_path: Path | None = None
+    try:
+        cleanup_chatgpt_bridge_cache()
+        local_path, bytes_downloaded = _download_remote_file(download_url, file_name)
+        result = sources_service.add_source(
+            get_client(),
+            notebook_id,
+            "file",
+            file_path=str(local_path),
+            title=title or file_name,
+            wait=wait,
+            wait_timeout=wait_timeout,
+        )
+        payload = {
+            "status": "success",
+            **result,
+            "bytes_downloaded": bytes_downloaded,
+            "local_file_retained": not delete_after_upload,
+        }
+        return payload
+    except ValidationError as e:
+        return error_result(str(e))
+    except ServiceError as e:
+        return error_result(e.user_message, hint=e.hint)
+    except Exception as e:
+        return error_result(str(e))
+    finally:
+        if delete_after_upload and local_path is not None:
+            with suppress(OSError):
+                local_path.unlink(missing_ok=True)
+
+
+@logged_tool()
+def chatgpt_bridge_cleanup(max_age_seconds: int | None = None) -> ResultDict:
+    """Delete stale files from the explicit ChatGPT bridge cache."""
+    try:
+        removed = cleanup_chatgpt_bridge_cache(max_age_seconds)
+        return {"status": "success", "removed": removed, "cache_dir": str(_cache_dir())}
+    except Exception as e:
+        return error_result(str(e))

--- a/src/notebooklm_tools/mcp/tools/chatgpt_bridge.py
+++ b/src/notebooklm_tools/mcp/tools/chatgpt_bridge.py
@@ -28,9 +28,24 @@ _DEFAULT_TTL_SECONDS = 3600
 _MAX_REDIRECTS = 3
 
 _ALLOWED_EXTENSIONS = {
-    ".pdf", ".txt", ".md", ".docx", ".csv", ".epub",
-    ".mp3", ".m4a", ".wav", ".aac", ".ogg", ".opus",
-    ".mp4", ".jpg", ".jpeg", ".png", ".gif", ".webp",
+    ".pdf",
+    ".txt",
+    ".md",
+    ".docx",
+    ".csv",
+    ".epub",
+    ".mp3",
+    ".m4a",
+    ".wav",
+    ".aac",
+    ".ogg",
+    ".opus",
+    ".mp4",
+    ".jpg",
+    ".jpeg",
+    ".png",
+    ".gif",
+    ".webp",
 }
 
 
@@ -120,8 +135,7 @@ def _validate_remote_url(url: str, allowed_hosts: list[str]) -> str:
         raise ValidationError("URL must include a hostname.")
     if not allowed_hosts:
         raise ValidationError(
-            "No ChatGPT file host allowlist configured. Set "
-            "NOTEBOOKLM_CHATGPT_FILE_HOST_ALLOWLIST."
+            "No ChatGPT file host allowlist configured. Set NOTEBOOKLM_CHATGPT_FILE_HOST_ALLOWLIST."
         )
     if not _host_allowed(parsed.hostname, allowed_hosts):
         raise ValidationError("URL host is not in NOTEBOOKLM_CHATGPT_FILE_HOST_ALLOWLIST.")
@@ -174,20 +188,28 @@ def _download_remote_file(download_url: str, file_name: str | None) -> tuple[Pat
                 if resp.status_code in (301, 302, 303, 307, 308):
                     location = resp.headers.get("location")
                     if not location:
-                        raise ValidationError("Redirect response did not include a Location header.")
-                    current_url = _validate_remote_url(urljoin(current_url, location), allowed_hosts)
+                        raise ValidationError(
+                            "Redirect response did not include a Location header."
+                        )
+                    current_url = _validate_remote_url(
+                        urljoin(current_url, location), allowed_hosts
+                    )
                     continue
 
                 resp.raise_for_status()
                 content_length = resp.headers.get("content-length")
                 if content_length and int(content_length) > max_bytes:
-                    raise ValidationError("ChatGPT file is larger than NOTEBOOKLM_CHATGPT_FILE_MAX_BYTES.")
+                    raise ValidationError(
+                        "ChatGPT file is larger than NOTEBOOKLM_CHATGPT_FILE_MAX_BYTES."
+                    )
 
                 with target.open("wb") as handle:
                     for chunk in resp.iter_bytes():
                         total += len(chunk)
                         if total > max_bytes:
-                            raise ValidationError("ChatGPT file exceeded NOTEBOOKLM_CHATGPT_FILE_MAX_BYTES.")
+                            raise ValidationError(
+                                "ChatGPT file exceeded NOTEBOOKLM_CHATGPT_FILE_MAX_BYTES."
+                            )
                         handle.write(chunk)
                 return target, total
         raise ValidationError("Too many redirects while downloading ChatGPT file.")

--- a/src/notebooklm_tools/mcp/tools/downloads.py
+++ b/src/notebooklm_tools/mcp/tools/downloads.py
@@ -1,10 +1,27 @@
 """Download tools - Consolidated download_artifact for all artifact types."""
 
 import asyncio
+import time
 
 from ...services import ServiceError, ValidationError
 from ...services import downloads as downloads_service
 from ._utils import ResultDict, error_result, get_client, logged_tool
+
+
+def _download_transient(message: str) -> bool:
+    """Return True for artifact states that may resolve after polling."""
+    lowered = message.lower()
+    return any(
+        phrase in lowered
+        for phrase in (
+            "not ready",
+            "does not exist",
+            "still propagating",
+            "try again",
+            "download failed",
+            "is complete, but its media download url is still propagating",
+        )
+    )
 
 
 @logged_tool()
@@ -15,6 +32,9 @@ def download_artifact(
     artifact_id: str | None = None,
     output_format: str = "json",
     slide_deck_format: str = "pdf",
+    wait: bool = True,
+    wait_timeout: float = 180.0,
+    poll_interval: float = 5.0,
 ) -> ResultDict:
     """Download any NotebookLM artifact to a file.
 
@@ -38,6 +58,9 @@ def download_artifact(
         artifact_id: Optional specific artifact ID (uses latest if not provided)
         output_format: For quiz/flashcards only: json|markdown|html (default: json)
         slide_deck_format: For slide_deck only: pdf (default) or pptx
+        wait: If True, poll while NotebookLM is still generating or propagating the artifact.
+        wait_timeout: Maximum seconds to wait when wait=True.
+        poll_interval: Seconds between readiness checks.
 
     Returns:
         dict with status and saved file path
@@ -49,18 +72,27 @@ def download_artifact(
     """
     try:
         client = get_client()
-        download_result = asyncio.run(
-            downloads_service.download_async(
-                client,
-                notebook_id,
-                artifact_type,
-                output_path,
-                artifact_id=artifact_id,
-                output_format=output_format,
-                slide_deck_format=slide_deck_format,
-            )
-        )
-        return {"status": "success", **download_result}
+        deadline = time.monotonic() + max(0.0, wait_timeout)
+
+        while True:
+            try:
+                download_result = asyncio.run(
+                    downloads_service.download_async(
+                        client,
+                        notebook_id,
+                        artifact_type,
+                        output_path,
+                        artifact_id=artifact_id,
+                        output_format=output_format,
+                        slide_deck_format=slide_deck_format,
+                    )
+                )
+                return {"status": "success", **download_result}
+            except ServiceError as e:
+                message = f"{e.user_message} {e}"
+                if not wait or not _download_transient(message) or time.monotonic() >= deadline:
+                    raise
+                time.sleep(max(0.5, poll_interval))
     except ValidationError as e:
         message = str(e)
         if message.startswith("Unknown artifact type "):

--- a/src/notebooklm_tools/mcp/tools/sources.py
+++ b/src/notebooklm_tools/mcp/tools/sources.py
@@ -295,7 +295,11 @@ def source_get_content(
             except ServiceError as e:
                 last_error = e
                 message = f"{e.user_message} {e}"
-                if not wait or not _source_content_transient(message) or time.monotonic() >= deadline:
+                if (
+                    not wait
+                    or not _source_content_transient(message)
+                    or time.monotonic() >= deadline
+                ):
                     raise
 
             if not wait or time.monotonic() >= deadline:

--- a/src/notebooklm_tools/mcp/tools/sources.py
+++ b/src/notebooklm_tools/mcp/tools/sources.py
@@ -1,5 +1,7 @@
 """Source tools - Source management with consolidated source_add."""
 
+import time
+
 from ...services import ServiceError, ValidationError
 from ...services import sources as sources_service
 from ._utils import ResultDict, coerce_list, error_result, get_client, logged_tool
@@ -242,8 +244,29 @@ def source_describe(source_id: str) -> ResultDict:
         return error_result(str(e))
 
 
+def _source_content_transient(message: str) -> bool:
+    """Return True for source-content states that may resolve after polling."""
+    lowered = message.lower()
+    return any(
+        phrase in lowered
+        for phrase in (
+            "failed to get source content",
+            "no content returned",
+            "not ready",
+            "processing",
+            "indexing",
+            "try again",
+        )
+    )
+
+
 @logged_tool()
-def source_get_content(source_id: str) -> ResultDict:
+def source_get_content(
+    source_id: str,
+    wait: bool = True,
+    wait_timeout: float = 120.0,
+    poll_interval: float = 3.0,
+) -> ResultDict:
     """Get raw text content of a source (no AI processing).
 
     Returns the original indexed text from PDFs, web pages, pasted text,
@@ -251,13 +274,42 @@ def source_get_content(source_id: str) -> ResultDict:
 
     Args:
         source_id: Source UUID
+        wait: If True, poll while NotebookLM is still indexing the source.
+        wait_timeout: Maximum seconds to wait when wait=True.
+        poll_interval: Seconds between readiness checks.
 
     Returns: content (str), title (str), source_type (str), char_count (int)
     """
     try:
         client = get_client()
-        result = sources_service.get_source_content(client, source_id)
-        return {"status": "success", **result}
+        deadline = time.monotonic() + max(0.0, wait_timeout)
+        attempts = 0
+        last_error: ServiceError | None = None
+
+        while True:
+            attempts += 1
+            try:
+                result = sources_service.get_source_content(client, source_id)
+                if result.get("content") or not wait:
+                    return {"status": "success", **result}
+            except ServiceError as e:
+                last_error = e
+                message = f"{e.user_message} {e}"
+                if not wait or not _source_content_transient(message) or time.monotonic() >= deadline:
+                    raise
+
+            if not wait or time.monotonic() >= deadline:
+                if last_error:
+                    raise last_error
+                return error_result(
+                    "Source content is not ready yet.",
+                    status="pending",
+                    hint="NotebookLM may still be indexing this source. Retry source_get_content shortly or increase wait_timeout.",
+                    source_id=source_id,
+                    attempts=attempts,
+                )
+
+            time.sleep(max(0.5, poll_interval))
     except ServiceError as e:
         return error_result(e.user_message, hint=e.hint)
     except Exception as e:

--- a/src/notebooklm_tools/mcp/tools/studio.py
+++ b/src/notebooklm_tools/mcp/tools/studio.py
@@ -205,20 +205,18 @@ def studio_create(
     _now = _time.monotonic()
     _current_mtime = _get_auth_file_mtime()
     if _now >= _auth_guard_expires or _current_mtime != _auth_guard_mtime:
-        from ...services.auth import get_auth_health_checker
-
-        auth = get_auth_health_checker().check()
-        if not auth.valid:
+        auth_valid, auth_reason, auth_error = _studio_auth_is_valid()
+        if not auth_valid:
             _auth_guard_expires = 0.0
             _auth_guard_mtime = 0.0
             return error_result(
                 f"Cannot create {artifact_type}: NotebookLM auth is not valid "
-                f"(status: {auth.status}). Run `nlm login` in a terminal to "
+                f"(status: {auth_reason}). Run `nlm login` in a terminal to "
                 "re-authenticate, then retry. `refresh_auth()` will NOT help if the "
                 "tokens are expired — it only reloads them from disk.",
                 hint="nlm login",
-                reason=auth.status,
-                profile=auth.profile,
+                reason=auth_reason,
+                details=auth_error,
             )
         _auth_guard_expires = _now + _AUTH_GUARD_TTL
         _auth_guard_mtime = _current_mtime

--- a/src/notebooklm_tools/mcp/tools/studio.py
+++ b/src/notebooklm_tools/mcp/tools/studio.py
@@ -205,17 +205,20 @@ def studio_create(
     _now = _time.monotonic()
     _current_mtime = _get_auth_file_mtime()
     if _now >= _auth_guard_expires or _current_mtime != _auth_guard_mtime:
-        auth_valid, auth_reason, auth_error = _studio_auth_is_valid()
-        if not auth_valid:
+        from ...services.auth import get_auth_health_checker
+
+        auth = get_auth_health_checker().check()
+        if not auth.valid:
             _auth_guard_expires = 0.0
             _auth_guard_mtime = 0.0
             return error_result(
-                f"Cannot create {artifact_type}: NotebookLM auth is not valid. "
-                "Run `nlm login` in a terminal to re-authenticate, then retry. "
-                "`refresh_auth()` will NOT help if the tokens are expired — it only reloads them from disk.",
+                f"Cannot create {artifact_type}: NotebookLM auth is not valid "
+                f"(status: {auth.status}). Run `nlm login` in a terminal to "
+                "re-authenticate, then retry. `refresh_auth()` will NOT help if the "
+                "tokens are expired — it only reloads them from disk.",
                 hint="nlm login",
-                reason=auth_reason,
-                details=auth_error,
+                reason=auth.status,
+                profile=auth.profile,
             )
         _auth_guard_expires = _now + _AUTH_GUARD_TTL
         _auth_guard_mtime = _current_mtime

--- a/src/notebooklm_tools/utils/cdp.py
+++ b/src/notebooklm_tools/utils/cdp.py
@@ -1319,6 +1319,7 @@ def has_chrome_profile(profile_name: str = "default") -> bool:
 
     Checks both standard and snap-accessible profile directories.
     """
+
     def _profile_has_cookie_db(profile_dir: Path) -> bool:
         cookie_paths = (
             profile_dir / "Default" / "Cookies",

--- a/src/notebooklm_tools/utils/cdp.py
+++ b/src/notebooklm_tools/utils/cdp.py
@@ -1319,7 +1319,6 @@ def has_chrome_profile(profile_name: str = "default") -> bool:
 
     Checks both standard and snap-accessible profile directories.
     """
-
     def _profile_has_cookie_db(profile_dir: Path) -> bool:
         cookie_paths = (
             profile_dir / "Default" / "Cookies",

--- a/tests/test_mcp_auth_studio_failures.py
+++ b/tests/test_mcp_auth_studio_failures.py
@@ -37,6 +37,29 @@ def _patch_credentials_usable(monkeypatch, usable, status="stale", detail=None):
     )
 
 
+def _health_report(valid, status=None):
+    """Build a real AuthHealthReport for studio_create's shared checker."""
+    return services_auth.AuthHealthReport(
+        valid=valid,
+        status=status or ("configured" if valid else "stale"),
+        probes=[],
+        profile="default",
+        checked_at=0.0,
+    )
+
+
+def _patch_auth_health(monkeypatch, valid, status=None, counter=None):
+    """Patch the shared auth-health singleton used by studio_create."""
+
+    class _Checker:
+        def check(self):
+            if counter is not None:
+                counter["n"] += 1
+            return _health_report(valid, status)
+
+    monkeypatch.setattr(services_auth, "get_auth_health_checker", lambda: _Checker(), raising=True)
+
+
 class _FakeClient:
     """Stand-in for NotebookLMClient; never touches the network."""
 
@@ -145,7 +168,7 @@ def test_studio_create_fails_loudly_on_stale_auth(monkeypatch):
     — not status:"success" with an artifact_id that immediately fails.
     """
     studio_tools._auth_guard_expires = 0.0  # force guard expired so auth is re-checked
-    _patch_credentials_usable(monkeypatch, usable=False, status="stale")
+    _patch_auth_health(monkeypatch, False, "expired")
 
     # If the code wrongly proceeds, make the client call explode so the test can't pass by luck.
     def _boom():
@@ -206,7 +229,7 @@ def test_studio_create_proceeds_when_probes_stale_but_api_works(monkeypatch):
         artifact_type="audio",
         confirm=True,
     )
-    assert result.get("status") == "success", f"Semi-stale API auth should create, got: {result}"
+    assert result.get("status") == "success", f"API-confirmed auth should create, got: {result}"
 
 
 # --------------------------------------------------------------------------- #
@@ -298,7 +321,7 @@ def test_studio_create_e2e_per_auth_state(monkeypatch, auth_state, valid, reason
     status:"error" (never a fake success).
     """
     studio_tools._auth_guard_expires = 0.0  # force guard expired so auth is re-checked
-    _patch_credentials_usable(monkeypatch, usable=valid, status=reason or "stale")
+    _patch_auth_health(monkeypatch, valid, reason)
     monkeypatch.setattr(studio_tools, "get_client", lambda: _FakeClient(), raising=True)
     monkeypatch.setattr(
         studio_tools.studio_service,
@@ -342,7 +365,7 @@ def test_studio_create_resets_auth_guard_on_invalid_auth(monkeypatch):
     the TTL has already expired and we just detected the invalid auth: we
     should not let a future-valid guard leak forward to the next call.
     """
-    _patch_credentials_usable(monkeypatch, usable=False, status="stale")
+    _patch_auth_health(monkeypatch, False, "expired")
     monkeypatch.setattr(studio_tools, "get_client", lambda: _FakeClient(), raising=True)
 
     # Pre-seed the guard with a future timestamp, simulating "auth was valid
@@ -372,15 +395,9 @@ def test_studio_create_invalidates_auth_guard_when_auth_file_changes(monkeypatch
     """
     check_call_count = {"n": 0}
 
-    def _counting_credentials(**_kw):
-        check_call_count["n"] += 1
-        return True, "configured", None
-
     # First call: mtime=N. Guard populated with mtime=N.
     monkeypatch.setattr(studio_tools, "_get_auth_file_mtime", lambda: 1000.0, raising=True)
-    monkeypatch.setattr(
-        services_auth, "credentials_are_usable", _counting_credentials, raising=True
-    )
+    _patch_auth_health(monkeypatch, True, counter=check_call_count)
     monkeypatch.setattr(studio_tools, "get_client", lambda: _FakeClient(), raising=True)
     monkeypatch.setattr(
         studio_tools.studio_service,
@@ -418,15 +435,9 @@ def test_studio_create_invalidates_auth_guard_when_auth_file_appears(monkeypatch
     """
     check_call_count = {"n": 0}
 
-    def _counting_credentials(**_kw):
-        check_call_count["n"] += 1
-        return True, "configured", None
-
     # First call: file does not exist (mtime=0.0). Guard populated with mtime=0.0.
     monkeypatch.setattr(studio_tools, "_get_auth_file_mtime", lambda: 0.0, raising=True)
-    monkeypatch.setattr(
-        services_auth, "credentials_are_usable", _counting_credentials, raising=True
-    )
+    _patch_auth_health(monkeypatch, True, counter=check_call_count)
     monkeypatch.setattr(studio_tools, "get_client", lambda: _FakeClient(), raising=True)
     monkeypatch.setattr(
         studio_tools.studio_service,

--- a/tests/test_mcp_auth_studio_failures.py
+++ b/tests/test_mcp_auth_studio_failures.py
@@ -28,36 +28,20 @@ def _auth_result(valid, reason=None):
     return core_auth.AuthCheckResult(valid=valid, reason=reason, live=True, profile="default")
 
 
-def _patch_credentials_usable(monkeypatch, usable, status="stale", detail=None):
+def _patch_credentials_usable(monkeypatch, usable, status="stale", detail=None, counter=None):
+    """Patch the service-layer auth wrapper used by refresh_auth and studio_create."""
+
+    def _credentials_are_usable(**_kw):
+        if counter is not None:
+            counter["n"] += 1
+        return usable, "configured" if usable else status, detail
+
     monkeypatch.setattr(
         services_auth,
         "credentials_are_usable",
-        lambda **kw: (usable, "configured" if usable else status, detail),
+        _credentials_are_usable,
         raising=True,
     )
-
-
-def _health_report(valid, status=None):
-    """Build a real AuthHealthReport for studio_create's shared checker."""
-    return services_auth.AuthHealthReport(
-        valid=valid,
-        status=status or ("configured" if valid else "stale"),
-        probes=[],
-        profile="default",
-        checked_at=0.0,
-    )
-
-
-def _patch_auth_health(monkeypatch, valid, status=None, counter=None):
-    """Patch the shared auth-health singleton used by studio_create."""
-
-    class _Checker:
-        def check(self):
-            if counter is not None:
-                counter["n"] += 1
-            return _health_report(valid, status)
-
-    monkeypatch.setattr(services_auth, "get_auth_health_checker", lambda: _Checker(), raising=True)
 
 
 class _FakeClient:
@@ -168,7 +152,7 @@ def test_studio_create_fails_loudly_on_stale_auth(monkeypatch):
     — not status:"success" with an artifact_id that immediately fails.
     """
     studio_tools._auth_guard_expires = 0.0  # force guard expired so auth is re-checked
-    _patch_auth_health(monkeypatch, False, "expired")
+    _patch_credentials_usable(monkeypatch, usable=False, status="expired")
 
     # If the code wrongly proceeds, make the client call explode so the test can't pass by luck.
     def _boom():
@@ -321,7 +305,7 @@ def test_studio_create_e2e_per_auth_state(monkeypatch, auth_state, valid, reason
     status:"error" (never a fake success).
     """
     studio_tools._auth_guard_expires = 0.0  # force guard expired so auth is re-checked
-    _patch_auth_health(monkeypatch, valid, reason)
+    _patch_credentials_usable(monkeypatch, usable=valid, status=reason or "stale")
     monkeypatch.setattr(studio_tools, "get_client", lambda: _FakeClient(), raising=True)
     monkeypatch.setattr(
         studio_tools.studio_service,
@@ -365,7 +349,7 @@ def test_studio_create_resets_auth_guard_on_invalid_auth(monkeypatch):
     the TTL has already expired and we just detected the invalid auth: we
     should not let a future-valid guard leak forward to the next call.
     """
-    _patch_auth_health(monkeypatch, False, "expired")
+    _patch_credentials_usable(monkeypatch, usable=False, status="expired")
     monkeypatch.setattr(studio_tools, "get_client", lambda: _FakeClient(), raising=True)
 
     # Pre-seed the guard with a future timestamp, simulating "auth was valid
@@ -397,7 +381,7 @@ def test_studio_create_invalidates_auth_guard_when_auth_file_changes(monkeypatch
 
     # First call: mtime=N. Guard populated with mtime=N.
     monkeypatch.setattr(studio_tools, "_get_auth_file_mtime", lambda: 1000.0, raising=True)
-    _patch_auth_health(monkeypatch, True, counter=check_call_count)
+    _patch_credentials_usable(monkeypatch, usable=True, counter=check_call_count)
     monkeypatch.setattr(studio_tools, "get_client", lambda: _FakeClient(), raising=True)
     monkeypatch.setattr(
         studio_tools.studio_service,
@@ -437,7 +421,7 @@ def test_studio_create_invalidates_auth_guard_when_auth_file_appears(monkeypatch
 
     # First call: file does not exist (mtime=0.0). Guard populated with mtime=0.0.
     monkeypatch.setattr(studio_tools, "_get_auth_file_mtime", lambda: 0.0, raising=True)
-    _patch_auth_health(monkeypatch, True, counter=check_call_count)
+    _patch_credentials_usable(monkeypatch, usable=True, counter=check_call_count)
     monkeypatch.setattr(studio_tools, "get_client", lambda: _FakeClient(), raising=True)
     monkeypatch.setattr(
         studio_tools.studio_service,

--- a/tests/test_mcp_chatgpt_bridge_hardened.py
+++ b/tests/test_mcp_chatgpt_bridge_hardened.py
@@ -36,7 +36,9 @@ def test_validate_remote_url_requires_allowlist(monkeypatch):
 def test_validate_remote_url_rejects_non_https(monkeypatch):
     monkeypatch.setattr(chatgpt_bridge, "_public_ip_check", lambda _host: None)
     with pytest.raises(ValidationError, match="https"):
-        chatgpt_bridge._validate_remote_url("http://files.example.com/doc.pdf", ["files.example.com"])
+        chatgpt_bridge._validate_remote_url(
+            "http://files.example.com/doc.pdf", ["files.example.com"]
+        )
 
 
 def test_validate_remote_url_rejects_private_ip_even_when_allowlisted():

--- a/tests/test_mcp_chatgpt_bridge_hardened.py
+++ b/tests/test_mcp_chatgpt_bridge_hardened.py
@@ -1,0 +1,99 @@
+"""Tests for the hardened, opt-in ChatGPT file bridge."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from notebooklm_tools.mcp.tools import chatgpt_bridge
+from notebooklm_tools.services import ValidationError
+
+
+def test_chatgpt_bridge_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("NOTEBOOKLM_CHATGPT_BRIDGE_ENABLED", raising=False)
+    result = chatgpt_bridge.chatgpt_add_file_source(
+        notebook_id="nb-1",
+        download_url="https://files.example.com/doc.pdf",
+        file_name="doc.pdf",
+        confirm=True,
+    )
+    assert result["status"] == "error"
+    assert "disabled" in result["error"].lower()
+
+
+def test_chatgpt_bridge_status_reports_disabled(monkeypatch):
+    monkeypatch.delenv("NOTEBOOKLM_CHATGPT_BRIDGE_ENABLED", raising=False)
+    result = chatgpt_bridge.chatgpt_bridge_status()
+    assert result["status"] == "success"
+    assert result["enabled"] is False
+
+
+def test_validate_remote_url_requires_allowlist(monkeypatch):
+    monkeypatch.setattr(chatgpt_bridge, "_public_ip_check", lambda _host: None)
+    with pytest.raises(ValidationError, match="allowlist"):
+        chatgpt_bridge._validate_remote_url("https://files.example.com/doc.pdf", [])
+
+
+def test_validate_remote_url_rejects_non_https(monkeypatch):
+    monkeypatch.setattr(chatgpt_bridge, "_public_ip_check", lambda _host: None)
+    with pytest.raises(ValidationError, match="https"):
+        chatgpt_bridge._validate_remote_url("http://files.example.com/doc.pdf", ["files.example.com"])
+
+
+def test_validate_remote_url_rejects_private_ip_even_when_allowlisted():
+    with pytest.raises(ValidationError, match="non-public"):
+        chatgpt_bridge._validate_remote_url("https://127.0.0.1/doc.pdf", ["127.0.0.1"])
+
+
+def test_validate_remote_url_accepts_exact_allowlisted_host(monkeypatch):
+    monkeypatch.setattr(chatgpt_bridge, "_public_ip_check", lambda _host: None)
+    assert (
+        chatgpt_bridge._validate_remote_url(
+            "https://files.example.com/doc.pdf", ["files.example.com"]
+        )
+        == "https://files.example.com/doc.pdf"
+    )
+
+
+def test_safe_filename_rejects_unsupported_extension():
+    with pytest.raises(ValidationError, match="extension"):
+        chatgpt_bridge._safe_filename("payload.exe")
+
+
+def test_add_file_source_requires_confirmation(monkeypatch):
+    monkeypatch.setenv("NOTEBOOKLM_CHATGPT_BRIDGE_ENABLED", "true")
+    result = chatgpt_bridge.chatgpt_add_file_source(
+        notebook_id="nb-1",
+        download_url="https://files.example.com/doc.pdf",
+        file_name="doc.pdf",
+        confirm=False,
+    )
+    assert result["status"] == "pending_confirmation"
+
+
+def test_add_file_source_deletes_temp_file_by_default(monkeypatch, tmp_path):
+    temp_file = tmp_path / "doc.pdf"
+    temp_file.write_bytes(b"pdf")
+    monkeypatch.setenv("NOTEBOOKLM_CHATGPT_BRIDGE_ENABLED", "true")
+    monkeypatch.setattr(chatgpt_bridge, "_download_remote_file", lambda *_args: (temp_file, 3))
+    monkeypatch.setattr(chatgpt_bridge, "get_client", lambda: MagicMock())
+    monkeypatch.setattr(
+        chatgpt_bridge.sources_service,
+        "add_source",
+        lambda *_args, **_kwargs: {
+            "source_type": "file",
+            "source_id": "src-1",
+            "title": "doc.pdf",
+        },
+    )
+
+    result = chatgpt_bridge.chatgpt_add_file_source(
+        notebook_id="nb-1",
+        download_url="https://files.example.com/doc.pdf",
+        file_name="doc.pdf",
+        confirm=True,
+    )
+
+    assert result["status"] == "success"
+    assert result["bytes_downloaded"] == 3
+    assert result["local_file_retained"] is False
+    assert not temp_file.exists()

--- a/tests/test_mcp_safe_polling.py
+++ b/tests/test_mcp_safe_polling.py
@@ -1,0 +1,75 @@
+"""Tests for safe MCP polling behavior.
+
+These tests intentionally verify that polling does not add ChatGPT-specific
+side effects such as public file staging or download URLs.
+"""
+
+from unittest.mock import MagicMock
+
+from notebooklm_tools.mcp.tools import downloads, sources
+from notebooklm_tools.services import ServiceError
+
+
+def test_source_get_content_polls_until_content(monkeypatch):
+    calls = {"n": 0}
+
+    def _get_source_content(_client, _source_id):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return {"content": "", "title": "Pending", "source_type": "text", "char_count": 0}
+        return {"content": "ready", "title": "Ready", "source_type": "text", "char_count": 5}
+
+    monkeypatch.setattr(sources, "get_client", lambda: MagicMock())
+    monkeypatch.setattr(sources.sources_service, "get_source_content", _get_source_content)
+    monkeypatch.setattr(sources.time, "sleep", lambda _seconds: None)
+
+    result = sources.source_get_content("src-1", wait=True, wait_timeout=1, poll_interval=0.5)
+
+    assert result["status"] == "success"
+    assert result["content"] == "ready"
+    assert "download_url" not in result
+    assert calls["n"] == 2
+
+
+def test_source_get_content_pending_without_disk_side_effect(monkeypatch):
+    monkeypatch.setattr(sources, "get_client", lambda: MagicMock())
+    monkeypatch.setattr(
+        sources.sources_service,
+        "get_source_content",
+        lambda _client, _source_id: {"content": "", "title": "Pending", "source_type": "text", "char_count": 0},
+    )
+
+    result = sources.source_get_content("src-1", wait=True, wait_timeout=0, poll_interval=0.5)
+
+    assert result["status"] == "pending"
+    assert "download_url" not in result
+
+
+def test_download_artifact_polls_transient_service_error(monkeypatch, tmp_path):
+    calls = {"n": 0}
+    out = tmp_path / "audio.m4a"
+
+    async def _download_async(*_args, **_kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise ServiceError("audio is complete, but its media download URL is still propagating")
+        out.write_bytes(b"audio")
+        return {"artifact_type": "audio", "path": str(out)}
+
+    monkeypatch.setattr(downloads, "get_client", lambda: MagicMock())
+    monkeypatch.setattr(downloads.downloads_service, "download_async", _download_async)
+    monkeypatch.setattr(downloads.time, "sleep", lambda _seconds: None)
+
+    result = downloads.download_artifact(
+        notebook_id="nb-1",
+        artifact_type="audio",
+        output_path=str(out),
+        wait=True,
+        wait_timeout=1,
+        poll_interval=0.5,
+    )
+
+    assert result["status"] == "success"
+    assert result["path"] == str(out)
+    assert "download_url" not in result
+    assert calls["n"] == 2

--- a/tests/test_mcp_safe_polling.py
+++ b/tests/test_mcp_safe_polling.py
@@ -36,7 +36,12 @@ def test_source_get_content_pending_without_disk_side_effect(monkeypatch):
     monkeypatch.setattr(
         sources.sources_service,
         "get_source_content",
-        lambda _client, _source_id: {"content": "", "title": "Pending", "source_type": "text", "char_count": 0},
+        lambda _client, _source_id: {
+            "content": "",
+            "title": "Pending",
+            "source_type": "text",
+            "char_count": 0,
+        },
     )
 
     result = sources.source_get_content("src-1", wait=True, wait_timeout=0, poll_interval=0.5)


### PR DESCRIPTION
# PR: Hardened ChatGPT file bridge

## Summary

This PR reintroduces ChatGPT-to-NotebookLM file handoff in a narrow, opt-in form after the reverted ChatGPT file bridge.

It intentionally keeps the earlier safe polling/auth branch as the base and adds only an explicit inbound bridge:

```text
trusted HTTPS file URL -> validated temporary download -> NotebookLM file source upload -> temp cleanup
```

It does not restore public artifact serving or add download links to ordinary MCP tool results.

## Why this is different from the reverted bridge

The reverted bridge had three review-blocking issues:

1. SSRF risk from accepting remote URLs without strict hostname/IP validation.
2. Disk leak risk from ordinary `source_get_content` calls writing files to disk.
3. Global behavior changes from injecting download URLs and file-serving behavior into existing tools.

This implementation addresses those by construction:

- the bridge is disabled by default;
- remote downloads require an explicit bridge tool call;
- a non-empty host allowlist is required;
- only `https://` URLs are accepted;
- hostnames are resolved and non-public addresses are rejected;
- redirects are manually followed and revalidated;
- file size and file extension allowlists are enforced;
- `confirm=True` is required before upload;
- temp files are deleted after upload by default;
- no `/artifacts` route is added;
- no `download_url` is added to `source_get_content` or `download_artifact`;
- ordinary read-only tools do not write files to disk.

## Issues addressed

This PR explicitly addresses the issues raised against the earlier reverted bridge:

- SSRF risk is addressed with `https://`-only URLs, required host allowlisting, DNS resolution checks, and rejection of private/link-local/loopback addresses.
- Redirect bypass risk is addressed by manually following redirects and revalidating every redirected URL.
- Disk leak risk is addressed by making downloads temporary, explicit, size-limited, and cleaned up after upload by default.
- Surprise behavior is addressed by keeping ordinary read-only MCP tools unchanged: no implicit file writes and no automatic `download_url` injection.
- Accidental upload risk is addressed by requiring an explicit bridge tool call and `confirm=True` before NotebookLM upload.

## New tools

```text
chatgpt_bridge_status
chatgpt_add_file_source
chatgpt_bridge_cleanup
```

## How to use with ChatGPT

This PR covers the inbound flow:

```text
ChatGPT-accessible HTTPS file URL -> NotebookLM file source
```

1. Enable the bridge in the MCP server environment:

   ```text
   NOTEBOOKLM_CHATGPT_BRIDGE_ENABLED=true
   NOTEBOOKLM_CHATGPT_FILE_HOST_ALLOWLIST=host.example.com,*.trusted.example.com
   ```

2. Put the file somewhere ChatGPT/the MCP server can reach by HTTPS, and make sure the hostname is in `NOTEBOOKLM_CHATGPT_FILE_HOST_ALLOWLIST`.

3. In the MCP client, call:

   ```text
   chatgpt_bridge_status
   ```

   Confirm the bridge is enabled and the allowlist is loaded.

4. Ask ChatGPT to provide or use the trusted HTTPS file URL, then call:

   ```text
   chatgpt_add_file_source(
     notebook_id="<notebook-id>",
     file_url="https://host.example.com/path/to/file.pdf",
     title="Optional source title",
     confirm=true
   )
   ```

5. The bridge downloads the file into a temporary cache, validates it, uploads it to NotebookLM as a source, and deletes the temporary file by default.

6. Use `chatgpt_bridge_cleanup` to clear any expired temporary downloads.

Important limitation: this does not let arbitrary ChatGPT-provided URLs through. The URL must be HTTPS and must resolve to a public address on an explicitly allowed hostname.

## Configuration

Required to enable the bridge:

```text
NOTEBOOKLM_CHATGPT_BRIDGE_ENABLED=true
NOTEBOOKLM_CHATGPT_FILE_HOST_ALLOWLIST=host.example.com,*.trusted.example.com
```

Optional limits:

```text
NOTEBOOKLM_CHATGPT_FILE_MAX_BYTES=26214400
NOTEBOOKLM_CHATGPT_FILE_TTL_SECONDS=3600
NOTEBOOKLM_CHATGPT_FILE_CACHE_DIR=<custom cache directory>
```

## Validation performed

Static and unit validation:

```text
ruff check: All checks passed
ruff format --check: clean
pytest: 29 passed locally for PR-specific tests
GitHub Actions: lint, tests, and version alignment passed
```

Live NotebookLM validation:

```text
profile: pte
account: personaltouchelectronics@gmail.com
created disposable notebook: success
added trusted HTTPS test file as source: success
verified source_count: 1
cache cleanup: success
deleted disposable notebook: success
```

## Scope intentionally deferred

This PR only covers inbound ChatGPT file URL upload into NotebookLM.

The inverse flow is intentionally separate:

```text
NotebookLM artifact/source -> short-lived authenticated download link for ChatGPT
```

That outbound flow needs a separate design because it requires scoped file serving, tokens, TTLs, retention cleanup, and careful tunnel exposure controls.

## Files changed

```text
src/notebooklm_tools/mcp/tools/chatgpt_bridge.py
tests/test_mcp_chatgpt_bridge_hardened.py
src/notebooklm_tools/mcp/tools/__init__.py
src/notebooklm_tools/mcp/server.py
```
