### PR TITLE
feat: RPC resilience — runtime overrides, drift detection, RESOURCE_EXHAUSTED retry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,16 @@ save_auth_tokens(cookies=<cookie_header>)
 | `NOTEBOOKLM_SESSION_ID` | No | (DEPRECATED - auto-extracted) |
 | `NOTEBOOKLM_BL` | No | Override for build label / bl URL param (auto-extracted from page) |
 | `NOTEBOOKLM_HL` | No | Interface language and default artifact language (default: `en`) |
+| `NOTEBOOKLM_RPC_OVERRIDES` | No | Hot-patch rotated batchexecute RPC method IDs without a release. JSON object mapping `BaseClient` RPC attribute names to new IDs, e.g. `{"RPC_LIST_NOTEBOOKS": "abc123"}` |
+
+### Resilience: rotated RPC IDs
+
+NotebookLM's internal API uses short RPC "method IDs" (e.g. `wXbhsf`) that Google rotates without notice. When one rotates, calls using the old ID fail. The client now:
+
+- **Detects drift loudly**: raises `RPCDriftError` (instead of returning silently) when the server responds with different RPC IDs than the one requested.
+- **Discovers the new ID**: run with `--debug` to log `RPC IDs in response: [...]` — the new ID for your call appears there.
+- **Hot-patches without a release**: set `NOTEBOOKLM_RPC_OVERRIDES='{"RPC_LIST_NOTEBOOKS": "<new_id>"}'` (use the `RPC_*` attribute name from `core/base.py`) to override the ID for the current session.
+- **Auto-retries throttling**: `RESOURCE_EXHAUSTED` (RPC error code 8) responses are retried with exponential backoff.
 
 ### Token Expiration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "notebooklm-mcp-cli"
-version = "0.7.3"
+version = "0.7.4"
 description = "Unified CLI and MCP server for Google NotebookLM"
 readme = "README.md"
 license = "MIT"

--- a/src/notebooklm_tools/__init__.py
+++ b/src/notebooklm_tools/__init__.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import notebooklm_tools.utils.env_sanitize as _env_sanitize  # noqa: F401
 
-__version__ = "0.7.3"
+__version__ = "0.7.4"
 
 __all__ = ["NotebookLMClient", "__version__"]
 

--- a/src/notebooklm_tools/core/base.py
+++ b/src/notebooklm_tools/core/base.py
@@ -25,7 +25,7 @@ from notebooklm_tools.utils.config import get_base_url
 from . import constants
 from .data_types import ConversationTurn
 from .errors import ClientAuthenticationError as AuthenticationError
-from .errors import ResourceExhaustedError, RPCError
+from .errors import ResourceExhaustedError, RPCDriftError, RPCError
 from .retry import DEFAULT_BASE_DELAY, DEFAULT_MAX_DELAY, DEFAULT_MAX_RETRIES, is_retryable_error
 from .utils import (
     RPC_NAMES,
@@ -687,6 +687,9 @@ class BaseClient:
                                 except json.JSONDecodeError:
                                     return result_str
                             return result_str
+        present = self._extract_present_rpc_ids(parsed_response)
+        if present and rpc_id not in present:
+            raise RPCDriftError(rpc_id, present)
         return None
 
     def _extract_present_rpc_ids(self, parsed_response: list) -> list[str]:

--- a/src/notebooklm_tools/core/base.py
+++ b/src/notebooklm_tools/core/base.py
@@ -60,6 +60,28 @@ def _safe_int_env(name: str, default: int) -> int:
     return value
 
 
+def load_rpc_overrides() -> dict[str, str]:
+    """Load runtime RPC-ID overrides from NOTEBOOKLM_RPC_OVERRIDES.
+
+    Lets users hot-patch rotated batchexecute method IDs without a release.
+    The value is a JSON object mapping BaseClient RPC attribute names to new
+    IDs, e.g. '{"RPC_LIST_NOTEBOOKS": "abc123"}'. Returns {} if unset, empty,
+    or malformed (a warning is logged on malformed input).
+    """
+    raw = os.environ.get("NOTEBOOKLM_RPC_OVERRIDES", "").strip()
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        logger.warning("Ignoring malformed NOTEBOOKLM_RPC_OVERRIDES: %s", e)
+        return {}
+    if not isinstance(data, dict):
+        logger.warning("Ignoring NOTEBOOKLM_RPC_OVERRIDES: expected a JSON object")
+        return {}
+    return {str(k): str(v) for k, v in data.items()}
+
+
 def _extract_user_message(detail_data: Any, _depth: int = 0) -> str:
     """Recursively extract human-readable strings from a protobuf detail payload.
 
@@ -370,6 +392,9 @@ class BaseClient:
         # It is never held during network I/O.
         self._state_lock = threading.Lock()
 
+        # Apply any runtime RPC-ID overrides (hot-patch for rotated method IDs).
+        self._apply_rpc_overrides()
+
         # Only refresh CSRF token if not provided - tokens actually last hours/days, not minutes
         # The retry logic in _call_rpc() handles expired tokens gracefully
         if not self.csrf_token:
@@ -386,6 +411,21 @@ class BaseClient:
         if self._client:
             self._client.close()
             self._client = None
+
+    def _apply_rpc_overrides(self) -> None:
+        """Apply NOTEBOOKLM_RPC_OVERRIDES as instance attributes.
+
+        Each entry shadows the matching class-level RPC_* constant on this
+        instance only. Unknown keys (not an existing RPC_* attribute) are
+        logged and ignored so a typo can never silently disable a tool.
+        """
+        for name, new_id in load_rpc_overrides().items():
+            if not name.startswith("RPC_") or not hasattr(type(self), name):
+                logger.warning("Ignoring unknown RPC override: %s", name)
+                continue
+            old_id = getattr(type(self), name)
+            setattr(self, name, new_id)
+            logger.warning("RPC override applied: %s %s -> %s", name, old_id, new_id)
 
     # =========================================================================
     # Cookie Handling

--- a/src/notebooklm_tools/core/base.py
+++ b/src/notebooklm_tools/core/base.py
@@ -829,6 +829,31 @@ class BaseClient:
             # Fall through to auth recovery below
             pass
 
+        except ResourceExhaustedError:
+            # RPC-level rate limit (HTTP 200, error code 8). Back off and retry.
+            if _server_retry < DEFAULT_MAX_RETRIES:
+                import time as _time
+
+                delay = min(DEFAULT_BASE_DELAY * (2**_server_retry), DEFAULT_MAX_DELAY)
+                logger.warning(
+                    "RPC rate limit (RESOURCE_EXHAUSTED) on %s, attempt %d/%d, retrying in %.1fs...",
+                    rpc_id,
+                    _server_retry + 1,
+                    DEFAULT_MAX_RETRIES + 1,
+                    delay,
+                )
+                _time.sleep(delay)
+                return self._call_rpc(
+                    rpc_id,
+                    params,
+                    path,
+                    timeout,
+                    _retry,
+                    _deep_retry,
+                    _server_retry=_server_retry + 1,
+                )
+            raise
+
         except AuthenticationError:
             # RPC Error 16 - fall through to auth recovery below
             pass

--- a/src/notebooklm_tools/core/base.py
+++ b/src/notebooklm_tools/core/base.py
@@ -689,6 +689,26 @@ class BaseClient:
                             return result_str
         return None
 
+    def _extract_present_rpc_ids(self, parsed_response: list) -> list[str]:
+        """Return the rpc_ids of every wrb.fr chunk in a parsed response.
+
+        Used for drift diagnostics: when the expected rpc_id is missing, this
+        reveals which IDs the server actually returned so the user can set
+        NOTEBOOKLM_RPC_OVERRIDES.
+        """
+        present: list[str] = []
+        for chunk in parsed_response:
+            if isinstance(chunk, list):
+                for item in chunk:
+                    if (
+                        isinstance(item, list)
+                        and len(item) >= 2
+                        and item[0] == "wrb.fr"
+                        and isinstance(item[1], str)
+                    ):
+                        present.append(item[1])
+        return present
+
     def _call_rpc(
         self,
         rpc_id: str,
@@ -754,6 +774,8 @@ class BaseClient:
 
             # Check for RPC-level errors (soft auth failure)
             parsed = self._parse_response(response.text)
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug("RPC IDs in response: %s", self._extract_present_rpc_ids(parsed))
             result = self._extract_rpc_result(parsed, rpc_id)
 
             # Enhanced debug logging for extracted result

--- a/src/notebooklm_tools/core/errors.py
+++ b/src/notebooklm_tools/core/errors.py
@@ -142,3 +142,23 @@ class ResourceExhaustedError(RPCError):
 
     def __init__(self, message: str, detail_type: str = "", detail_data=None):
         super().__init__(message, error_code=8, detail_type=detail_type, detail_data=detail_data)
+
+
+class RPCDriftError(NotebookLMError):
+    """Raised when the response contains other RPC IDs but not the one requested.
+
+    The usual cause is Google rotating the batchexecute method ID. The message
+    names the missing id, lists the ids the server *did* return, and points the
+    user at NOTEBOOKLM_RPC_OVERRIDES to hot-patch it without a release.
+    """
+
+    def __init__(self, rpc_id: str, present_ids: list[str] | None = None):
+        present = ", ".join(present_ids) if present_ids else "(none)"
+        super().__init__(
+            f"No result for RPC '{rpc_id}' — the method ID may have been rotated by Google. "
+            f"RPC IDs present in the response: {present}. "
+            f'Hot-patch it by setting NOTEBOOKLM_RPC_OVERRIDES=\'{{"<ATTR_NAME>": "<new_id>"}}\' '
+            f"(run with --debug to inspect the response)."
+        )
+        self.rpc_id = rpc_id
+        self.present_ids = present_ids or []

--- a/src/notebooklm_tools/core/errors.py
+++ b/src/notebooklm_tools/core/errors.py
@@ -150,6 +150,13 @@ class RPCDriftError(NotebookLMError):
     The usual cause is Google rotating the batchexecute method ID. The message
     names the missing id, lists the ids the server *did* return, and points the
     user at NOTEBOOKLM_RPC_OVERRIDES to hot-patch it without a release.
+
+    Deliberately extends NotebookLMError directly, NOT RPCError: drift must
+    bypass the service-layer ``except RPCError`` handlers so its actionable
+    NOTEBOOKLM_RPC_OVERRIDES guidance reaches the user verbatim instead of
+    being reformatted into a generic service error. (Contrast with
+    ResourceExhaustedError, which subclasses RPCError on purpose so existing
+    handlers still catch it.)
     """
 
     def __init__(self, rpc_id: str, present_ids: list[str] | None = None):

--- a/tests/core/test_base.py
+++ b/tests/core/test_base.py
@@ -422,3 +422,18 @@ class TestBuildLabelPriority:
                 build_label="test_bl_value",
             )
         assert client._bl == "test_bl_value"
+
+
+def test_extract_present_rpc_ids():
+    """_extract_present_rpc_ids returns every rpc_id present in a parsed response."""
+    from notebooklm_tools.core.base import BaseClient
+
+    with patch.object(BaseClient, "_refresh_auth_tokens"):
+        client = BaseClient(cookies={}, csrf_token="t")
+
+    parsed = [
+        [["wrb.fr", "abc123", "[1,2]", None, None, None, "generic"]],
+        [["wrb.fr", "def456", "[]", None, None, None, "generic"]],
+        [["di", 42]],  # non-wrb.fr noise must be ignored
+    ]
+    assert client._extract_present_rpc_ids(parsed) == ["abc123", "def456"]

--- a/tests/core/test_rpc_errors.py
+++ b/tests/core/test_rpc_errors.py
@@ -1,0 +1,41 @@
+"""Tests for RPC drift detection and RPC-level retry in BaseClient."""
+
+from unittest.mock import patch
+
+import pytest
+
+from notebooklm_tools.core.base import BaseClient
+from notebooklm_tools.core.errors import RPCDriftError
+
+
+def _client():
+    with patch.object(BaseClient, "_refresh_auth_tokens"):
+        return BaseClient(cookies={}, csrf_token="t")
+
+
+def test_drift_when_other_ids_present_but_not_ours():
+    client = _client()
+    parsed = [[["wrb.fr", "ROTATED", "[1]", None, None, None, "generic"]]]
+    with pytest.raises(RPCDriftError) as exc:
+        client._extract_rpc_result(parsed, "EXPECTED")
+    msg = str(exc.value)
+    assert "EXPECTED" in msg
+    assert "ROTATED" in msg
+    assert "NOTEBOOKLM_RPC_OVERRIDES" in msg
+
+
+def test_empty_response_returns_none_not_drift():
+    client = _client()
+    assert client._extract_rpc_result([], "EXPECTED") is None
+
+
+def test_matched_chunk_with_null_result_returns_none():
+    client = _client()
+    parsed = [[["wrb.fr", "EXPECTED", None, None, None, None, "generic"]]]
+    assert client._extract_rpc_result(parsed, "EXPECTED") is None
+
+
+def test_matched_chunk_returns_parsed_json():
+    client = _client()
+    parsed = [[["wrb.fr", "EXPECTED", "[1,2,3]", None, None, None, "generic"]]]
+    assert client._extract_rpc_result(parsed, "EXPECTED") == [1, 2, 3]

--- a/tests/core/test_rpc_errors.py
+++ b/tests/core/test_rpc_errors.py
@@ -39,3 +39,45 @@ def test_matched_chunk_returns_parsed_json():
     client = _client()
     parsed = [[["wrb.fr", "EXPECTED", "[1,2,3]", None, None, None, "generic"]]]
     assert client._extract_rpc_result(parsed, "EXPECTED") == [1, 2, 3]
+
+
+def test_call_rpc_retries_on_resource_exhausted(monkeypatch):
+    """A code-8 RESOURCE_EXHAUSTED envelope triggers backoff retry, then succeeds."""
+    client = _client()
+
+    exhausted = [[["wrb.fr", "EXPECTED", None, None, None, [8], "generic"]]]
+    ok = [[["wrb.fr", "EXPECTED", "[1]", None, None, None, "generic"]]]
+
+    fake_resp = type(
+        "R", (), {"text": "", "status_code": 200, "raise_for_status": lambda self: None}
+    )()
+
+    with (
+        patch.object(client, "_get_client") as mock_get_client,
+        patch.object(client, "_parse_response", side_effect=[exhausted, ok]),
+        patch("time.sleep"),
+    ):
+        mock_get_client.return_value.post.return_value = fake_resp
+        result = client._call_rpc("EXPECTED", [])
+
+    assert result == [1]
+
+
+def test_call_rpc_resource_exhausted_exhausts_retries(monkeypatch):
+    """After max retries, ResourceExhaustedError propagates."""
+    from notebooklm_tools.core.errors import ResourceExhaustedError
+
+    client = _client()
+    exhausted = [[["wrb.fr", "EXPECTED", None, None, None, [8], "generic"]]]
+    fake_resp = type(
+        "R", (), {"text": "", "status_code": 200, "raise_for_status": lambda self: None}
+    )()
+
+    with (
+        patch.object(client, "_get_client") as mock_get_client,
+        patch.object(client, "_parse_response", return_value=exhausted),
+        patch("time.sleep"),
+    ):
+        mock_get_client.return_value.post.return_value = fake_resp
+        with pytest.raises(ResourceExhaustedError):
+            client._call_rpc("EXPECTED", [])

--- a/tests/core/test_rpc_overrides.py
+++ b/tests/core/test_rpc_overrides.py
@@ -1,0 +1,43 @@
+"""Tests for runtime RPC-ID override mechanism."""
+
+import json
+from unittest.mock import patch
+
+from notebooklm_tools.core.base import BaseClient, load_rpc_overrides
+
+
+def test_load_rpc_overrides_empty(monkeypatch):
+    monkeypatch.delenv("NOTEBOOKLM_RPC_OVERRIDES", raising=False)
+    assert load_rpc_overrides() == {}
+
+
+def test_load_rpc_overrides_valid(monkeypatch):
+    monkeypatch.setenv("NOTEBOOKLM_RPC_OVERRIDES", json.dumps({"RPC_LIST_NOTEBOOKS": "newId"}))
+    assert load_rpc_overrides() == {"RPC_LIST_NOTEBOOKS": "newId"}
+
+
+def test_load_rpc_overrides_malformed_returns_empty(monkeypatch):
+    monkeypatch.setenv("NOTEBOOKLM_RPC_OVERRIDES", "{not json")
+    assert load_rpc_overrides() == {}
+
+
+def test_load_rpc_overrides_non_object_returns_empty(monkeypatch):
+    monkeypatch.setenv("NOTEBOOKLM_RPC_OVERRIDES", json.dumps(["a", "b"]))
+    assert load_rpc_overrides() == {}
+
+
+def test_apply_rpc_overrides_known_attr(monkeypatch):
+    monkeypatch.setenv("NOTEBOOKLM_RPC_OVERRIDES", json.dumps({"RPC_LIST_NOTEBOOKS": "newId"}))
+    with patch.object(BaseClient, "_refresh_auth_tokens"):
+        client = BaseClient(cookies={"x": "y"}, csrf_token="t")
+    assert client.RPC_LIST_NOTEBOOKS == "newId"
+    assert BaseClient.RPC_LIST_NOTEBOOKS == "wXbhsf"  # class attr untouched
+
+
+def test_apply_rpc_overrides_unknown_attr_ignored(monkeypatch):
+    monkeypatch.setenv(
+        "NOTEBOOKLM_RPC_OVERRIDES", json.dumps({"RPC_DOES_NOT_EXIST": "z", "NOT_AN_RPC": "z"})
+    )
+    with patch.object(BaseClient, "_refresh_auth_tokens"):
+        client = BaseClient(cookies={"x": "y"}, csrf_token="t")
+    assert not hasattr(client, "RPC_DOES_NOT_EXIST")


### PR DESCRIPTION
@
## Summary

NotebookLM rotates its internal `batchexecute` RPC method IDs (and throttles via RPC-level error code 8) without notice. Today a rotation surfaces as a silent `None` and a confusing downstream failure, and a code-8 throttle fails immediately. This PR hardens `core/` against both, with no change to public tool behavior.

- **Runtime RPC-ID overrides** — set `NOTEBOOKLM_RPC_OVERRIDES={RPC_LIST_NOTEBOOKS:<new_id>}` to hot-patch a rotated method ID without a release. Overrides shadow the `BaseClient.RPC_*` class attributes per-instance; unknown keys are warned and ignored.
- **Drift discovery logging** — with `--debug`, `_call_rpc` logs `RPC IDs in response: [...]` so the new ID is easy to find.
- **`RPCDriftError`** — raised when the response contains other `wrb.fr` IDs but not the requested one, instead of returning `None` silently. The message names the missing ID, lists what the server returned, and points at `NOTEBOOKLM_RPC_OVERRIDES`. Empty/null responses still return `None` (fire-and-forget paths unaffected). It intentionally sits outside the `RPCError` tree so its actionable guidance reaches the user verbatim.
- **Backoff retry for `RESOURCE_EXHAUSTED` (code 8)** — `_call_rpc` now retries the existing typed `ResourceExhaustedError` with exponential backoff, reusing the `_server_retry` counter (same contract as the HTTP 429/5xx path).
- Docs (`CLAUDE.md`) updated with a "Resilience: rotated RPC IDs" section; version bumped to 0.7.4.

## Test Plan
- [x] New unit tests: `tests/core/test_rpc_overrides.py`, `tests/core/test_rpc_errors.py`, plus a case in `test_base.py` (override load/apply, drift vs. empty/null, code-8 retry-then-success and retry-exhaustion).
- [x] `uv run pytest tests/core/ tests/services/ -q` → 728 passed, 0 failed.
- [x] `uv run --dev ruff check .` and `ruff format --check .` clean.
- [ ] Maintainer: confirm the chosen default backoff/retry counts (reuses existing `DEFAULT_MAX_RETRIES`/delays) match desired behavior for throttling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@