### PR TITLE
fix: align version files to 0.7.4 + address PR #233 review notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,6 +269,14 @@ When adding new features:
 8. Update the "Features NOT Yet Implemented" checklist
 9. Add test case to docs/MCP_TEST_PLAN.md
 
+**Bumping the version:** the `Version Alignment Check` workflow (`.github/workflows/version-check.yml`) requires the **same** version in all 5 of these files — bump them together or CI fails:
+
+- `pyproject.toml` → `version = "X.Y.Z"`
+- `src/notebooklm_tools/__init__.py` → `__version__ = "X.Y.Z"`
+- `src/notebooklm_tools/data/SKILL.md` → `version: "X.Y.Z"`
+- `src/notebooklm_tools/data/AGENTS_SECTION.md` → `<!-- nlm-version: X.Y.Z -->`
+- `desktop-extension/manifest.json` → `"version": "X.Y.Z"`
+
 ## License
 
 MIT License

--- a/desktop-extension/manifest.json
+++ b/desktop-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "notebooklm-mcp",
   "display_name": "NotebookLM MCP Server",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Connect Claude to Google NotebookLM. Create podcasts, research topics, generate quizzes, flashcards, mind maps, and more from your notebooks.",
   "long_description": "This extension connects Claude Desktop to Google NotebookLM via the Model Context Protocol. It provides 29 tools for managing notebooks, sources, and generating AI content.\n\n**Prerequisites:**\n1. Install the package: `pip install notebooklm-mcp-cli` or `uv tool install notebooklm-mcp-cli`\n2. Authenticate: Run `nlm login` to set up your Google account\n\n**Features:**\n- Create and manage notebooks\n- Add sources (URLs, YouTube, Google Drive, text, files)\n- Generate podcasts (Audio Overview)\n- Create quizzes, flashcards, mind maps, reports\n- Research topics with web or Drive search",
   "author": {

--- a/src/notebooklm_tools/core/base.py
+++ b/src/notebooklm_tools/core/base.py
@@ -425,7 +425,9 @@ class BaseClient:
                 continue
             old_id = getattr(type(self), name)
             setattr(self, name, new_id)
-            logger.warning("RPC override applied: %s %s -> %s", name, old_id, new_id)
+            # INFO, not WARNING: an applied override is an intentional, benign
+            # event and should not pollute the warning stream.
+            logger.info("RPC override applied: %s %s -> %s", name, old_id, new_id)
 
     # =========================================================================
     # Cookie Handling

--- a/src/notebooklm_tools/data/AGENTS_SECTION.md
+++ b/src/notebooklm_tools/data/AGENTS_SECTION.md
@@ -1,5 +1,5 @@
 <!-- nlm-skill-start -->
-<!-- nlm-version: 0.7.3 -->
+<!-- nlm-version: 0.7.4 -->
 ## NLM - NotebookLM CLI Expert
 
 **Triggers:** "nlm", "notebooklm", "notebook lm", "podcast", "audio overview", "research"

--- a/src/notebooklm_tools/data/SKILL.md
+++ b/src/notebooklm_tools/data/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nlm-skill
-version: "0.7.3"
+version: "0.7.4"
 description: "Expert guide for the NotebookLM CLI (`nlm`) and MCP server - interfaces for Google NotebookLM. Use this skill when users want to interact with NotebookLM programmatically, including: creating/managing notebooks, adding sources (URLs, YouTube, text, Google Drive), generating content (podcasts, reports, quizzes, flashcards, mind maps, slides, infographics, videos, data tables), conducting research, chatting with sources, or automating NotebookLM workflows. Triggers on mentions of \"nlm\", \"notebooklm\", \"notebook lm\", \"podcast generation\", \"audio overview\", or any NotebookLM-related automation task."
 ---
 

--- a/src/notebooklm_tools/services/research.py
+++ b/src/notebooklm_tools/services/research.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 
 from ..core.client import NotebookLMClient
 from ..core.constants import RESULT_TYPE_DEEP_REPORT
-from ..core.errors import RPCError
+from ..core.errors import RPCDriftError, RPCError
 from ._compat import TypedDict
 from .errors import ServiceError, ValidationError
 
@@ -256,6 +256,9 @@ def start_research(
                 f"This is likely a transient issue. Try again in a few minutes, or use --mode fast."
             ),
         ) from e
+    except RPCDriftError:
+        # Let the actionable NOTEBOOKLM_RPC_OVERRIDES guidance reach the user verbatim.
+        raise
     except Exception as e:
         raise ServiceError(f"Failed to start research: {e}") from e
 

--- a/src/notebooklm_tools/services/sources.py
+++ b/src/notebooklm_tools/services/sources.py
@@ -409,7 +409,9 @@ def list_drive_sources(
         }
 
         if source.get("can_sync"):
-            is_fresh = freshness_map.get(source["id"]) if isinstance(source.get("id"), str) else None
+            is_fresh = (
+                freshness_map.get(source["id"]) if isinstance(source.get("id"), str) else None
+            )
             source_id = source.get("id")
             source_title = source.get("title")
             source_type_name = source.get("source_type_name")

--- a/src/notebooklm_tools/services/studio.py
+++ b/src/notebooklm_tools/services/studio.py
@@ -16,7 +16,7 @@ from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
 from notebooklm_tools.core import constants
-from notebooklm_tools.core.errors import ResourceExhaustedError, RPCError
+from notebooklm_tools.core.errors import ResourceExhaustedError, RPCDriftError, RPCError
 
 from ._compat import TypedDict
 from .errors import ServiceError, ValidationError
@@ -375,6 +375,9 @@ def create_artifact(
             f"Failed to create {artifact_type}: {formatted_error}",
             user_message=f"Could not create {artifact_type.replace('_', ' ')} — {formatted_error}.",
         ) from e
+    except RPCDriftError:
+        # Let the actionable NOTEBOOKLM_RPC_OVERRIDES guidance reach the user verbatim.
+        raise
     except Exception as e:
         logger.error("Studio create failed: %s: %s", type(e).__name__, e, exc_info=True)
         raise ServiceError(
@@ -851,6 +854,9 @@ def revise_artifact(
             user_message=f"Failed to revise slide deck — {formatted_error}.",
             hint=hint,
         ) from e
+    except RPCDriftError:
+        # Let the actionable NOTEBOOKLM_RPC_OVERRIDES guidance reach the user verbatim.
+        raise
     except Exception as e:
         raise ServiceError(
             f"Failed to revise slide deck: {e}",

--- a/tests/services/test_research.py
+++ b/tests/services/test_research.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from notebooklm_tools.core.errors import RPCError
+from notebooklm_tools.core.errors import RPCDriftError, RPCError
 from notebooklm_tools.services.errors import ServiceError, ValidationError
 from notebooklm_tools.services.research import (
     annotate_cited_sources,
@@ -102,6 +102,12 @@ class TestStartResearch:
 
         # Should mention method-specific error code, not generic "Failed to start research"
         assert "error code 3" in str(exc_info.value)
+
+    def test_drift_error_propagates_verbatim(self, mock_client):
+        """RPCDriftError must NOT be re-wrapped into a generic ServiceError."""
+        mock_client.start_research.side_effect = RPCDriftError("Ljjv0c", ["QA9ei"])
+        with pytest.raises(RPCDriftError):
+            start_research(mock_client, "nb-1", "query")
 
     def test_drive_fast_works(self, mock_client):
         mock_client.start_research.return_value = {"task_id": "t-1"}

--- a/tests/services/test_studio.py
+++ b/tests/services/test_studio.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from notebooklm_tools.core.errors import ResourceExhaustedError, RPCError
+from notebooklm_tools.core.errors import ResourceExhaustedError, RPCDriftError, RPCError
 from notebooklm_tools.services.errors import ServiceError, ValidationError
 from notebooklm_tools.services.studio import (
     VALID_ARTIFACT_TYPES,
@@ -225,6 +225,12 @@ class TestCreateArtifact:
         assert "SomeErrorDetail" in err.user_message
         assert "code 7" in err.user_message
 
+    def test_drift_error_propagates_verbatim(self, mock_client):
+        """RPCDriftError must NOT be re-wrapped into a generic ServiceError."""
+        mock_client.create_infographic.side_effect = RPCDriftError("izAoDd", ["wXbhsf", "ozz5Z"])
+        with pytest.raises(RPCDriftError):
+            create_artifact(mock_client, "nb-1", "infographic")
+
 
 class TestNormalizeVideoStyle:
     """Test video style normalization rules."""
@@ -377,6 +383,16 @@ class TestReviseArtifact:
         assert err.hint is not None
         assert "editable notebook you own" in err.hint
         assert "view-only/shared decks" in err.hint
+
+    def test_drift_error_propagates_verbatim(self, mock_client):
+        """RPCDriftError must NOT be re-wrapped into a generic ServiceError."""
+        mock_client.revise_slide_deck.side_effect = RPCDriftError("KmcKPe", ["rc3d8d"])
+        with pytest.raises(RPCDriftError):
+            revise_artifact(
+                mock_client,
+                "art-123",
+                [{"slide": 1, "instruction": "Tighten the title"}],
+            )
 
     def test_rpc_error_without_detail_type_preserves_original_message(self, mock_client):
         mock_client.revise_slide_deck.side_effect = RPCError(


### PR DESCRIPTION
Follow-up to #233 (merged). Fixes the failing **Version Alignment Check** and addresses the two non-blocking review notes.

## Version alignment (the actual breakage)
PR #233 bumped only `pyproject.toml` and `__init__.py`, but the Version Alignment Check requires **5** files to match. The v0.7.4 release left three at `0.7.3`, so the check is red on `main`. This bumps them to `0.7.4`:
- `src/notebooklm_tools/data/SKILL.md`
- `src/notebooklm_tools/data/AGENTS_SECTION.md`
- `desktop-extension/manifest.json`

All five now report `0.7.4`. Apologies for the miss in the original PR.

## Review notes addressed (were non-blocking)
1. **`RPC override applied` log level** — changed from `WARNING` to `INFO`. An applied override is intentional and benign; logging at WARNING would create noise that could mask real warnings.
2. **`RPCDriftError` re-wrapping** — added `except RPCDriftError: raise` before the broad `except Exception` handlers in `create_artifact` / `revise_artifact` (studio) and `start_research` (research) — the three handlers with explicit `except RPCError` blocks. This lets the actionable `NOTEBOOKLM_RPC_OVERRIDES` guidance reach the user verbatim instead of being flattened into a generic `ServiceError` user_message. Scoped to these primary generative operations per the review's example ("near the existing `except RPCError` blocks"); happy to extend to the remaining wrap-and-raise handlers if you prefer full coverage.

## Test Plan
- [x] New tests assert `RPCDriftError` propagates verbatim from `create_artifact`, `revise_artifact`, and `start_research`.
- [x] `uv run pytest tests/core/ tests/services/ -q` -> 738 passed, 0 failed.
- [x] `uv run --dev ruff check .` and `ruff format --check .` clean.
- [x] All 5 version files verified aligned at 0.7.4 (simulated the workflow locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
