### PR TITLE
feat(mcp): add optional plugin loader

### DIFF
--- a/docs/MCP_PLUGIN_GUIDE.md
+++ b/docs/MCP_PLUGIN_GUIDE.md
@@ -7,6 +7,22 @@ modules such as `server.py`, `tools/sources.py`, or `tools/downloads.py`.
 
 Plugins are disabled by default.
 
+## Why this exists
+
+Some integrations need to extend NotebookLM MCP with local workflow-specific
+tools, tunnel routes, file handoff logic, or organization policy checks. Without
+a plugin seam, those integrations must patch built-in modules and repeatedly
+rebase whenever upstream changes core tools, auth, or transport code.
+
+The plugin loader keeps the core server stable while giving downstream users a
+supported extension point. Core NotebookLM MCP continues to own built-in tools,
+authentication, and transport startup. Plugins own optional behavior and can be
+installed, audited, enabled, disabled, or upgraded independently.
+
+This is especially useful for integrations that are valuable locally but too
+specific or too security-sensitive to enable for every NotebookLM MCP user by
+default.
+
 ## Configuration
 
 Load plugins with a comma-separated environment variable:
@@ -93,3 +109,19 @@ NOTEBOOKLM_MCP_PLUGINS=chatgpt_bridge notebooklm-mcp
 The plugin seam is intentionally small. Core NotebookLM MCP remains responsible
 for built-in NotebookLM tools and authentication. Plugins should depend on
 public service-layer APIs and should avoid monkey-patching built-in tools.
+
+## Plugin ideas
+
+The plugin hook is intentionally generic. Examples of extensions it can support:
+
+- **ChatGPT file bridge** — inbound ChatGPT-hosted file URLs to NotebookLM sources, and outbound NotebookLM artifacts behind short-lived tokenized routes.
+- **Enterprise policy gate** — enforce organization-specific allowlists, source limits, file-type restrictions, retention rules, or audit metadata before calling NotebookLM services.
+- **Local knowledge-base sync** — import/export NotebookLM sources or notes from a local folder, Obsidian vault, Notion workspace, SharePoint mirror, or legal evidence directory.
+- **Artifact post-processing** — transcode audio, convert slide decks, normalize filenames, generate sidecar metadata, or package NotebookLM outputs for downstream tools.
+- **Webhook/callback routes** — expose local-only HTTP endpoints for workflow orchestrators that need to notify the MCP server when a file, job, or external process is ready.
+- **Domain-specific tool packs** — add legal, research, education, medical-literature, or engineering workflow tools that compose NotebookLM primitives without expanding the core tool surface.
+- **Observability plugin** — add health probes, metrics, redacted audit logs, queue status, or runtime diagnostics for long-lived MCP deployments.
+- **Rate-limit/coordinator plugin** — coordinate local concurrency, backoff, or queueing across multiple MCP clients that share one NotebookLM account.
+
+Plugins should remain opt-in and should document their own threat model when
+they expose routes, touch local files, or call third-party services.

--- a/docs/MCP_PLUGIN_GUIDE.md
+++ b/docs/MCP_PLUGIN_GUIDE.md
@@ -1,0 +1,95 @@
+# NotebookLM MCP Plugin Guide
+
+NotebookLM MCP supports optional plugins for third-party tools and HTTP routes.
+The core server registers built-in tools first, then loads explicitly configured
+plugins. This lets local integrations add behavior without patching core tool
+modules such as `server.py`, `tools/sources.py`, or `tools/downloads.py`.
+
+Plugins are disabled by default.
+
+## Configuration
+
+Load plugins with a comma-separated environment variable:
+
+```text
+NOTEBOOKLM_MCP_PLUGINS=my_package.plugin,my_package.plugin:register_tools
+```
+
+Each item can be one of:
+
+- an entry point name from the `notebooklm_tools.mcp_plugins` group;
+- a Python module exposing `register(mcp)`;
+- a `module:function` callable spec.
+
+Optional settings:
+
+```text
+NOTEBOOKLM_MCP_PLUGIN_STRICT=true
+NOTEBOOKLM_MCP_PLUGIN_AUTOLOAD=false
+```
+
+`NOTEBOOKLM_MCP_PLUGIN_STRICT=true` is the default. Explicit plugin load
+failures stop server startup so a missing or broken integration is not silently
+ignored. Set it to `false` only when best-effort loading is desired.
+
+`NOTEBOOKLM_MCP_PLUGIN_AUTOLOAD=true` loads every installed entry point in the
+`notebooklm_tools.mcp_plugins` group. Explicit `NOTEBOOKLM_MCP_PLUGINS` is
+preferred for production because it is easier to audit.
+
+## Minimal plugin module
+
+```python
+# my_package/plugin.py
+
+def register(mcp):
+    @mcp.tool()
+    def plugin_status() -> dict[str, str]:
+        """Return plugin health."""
+        return {"status": "success"}
+```
+
+Run the MCP server with:
+
+```text
+NOTEBOOKLM_MCP_PLUGINS=my_package.plugin notebooklm-mcp
+```
+
+## Custom HTTP routes
+
+Plugins receive the FastMCP instance, so they can register routes when they need
+HTTP callbacks or short-lived download endpoints:
+
+```python
+from starlette.responses import JSONResponse
+
+
+def register(mcp):
+    @mcp.custom_route("/plugins/example/health", methods=["GET"])
+    async def plugin_health(request):
+        return JSONResponse({"status": "healthy"})
+```
+
+Plugins that expose routes are responsible for their own security model:
+confirmation gates, token validation, TTLs, path validation, cleanup, and any
+public-tunnel exposure controls.
+
+## Packaging entry point
+
+A plugin package can advertise itself through Python package metadata:
+
+```toml
+[project.entry-points."notebooklm_tools.mcp_plugins"]
+chatgpt_bridge = "notebooklm_chatgpt_bridge:register"
+```
+
+Then load it explicitly:
+
+```text
+NOTEBOOKLM_MCP_PLUGINS=chatgpt_bridge notebooklm-mcp
+```
+
+## Design intent
+
+The plugin seam is intentionally small. Core NotebookLM MCP remains responsible
+for built-in NotebookLM tools and authentication. Plugins should depend on
+public service-layer APIs and should avoid monkey-patching built-in tools.

--- a/src/notebooklm_tools/mcp/plugins.py
+++ b/src/notebooklm_tools/mcp/plugins.py
@@ -91,7 +91,9 @@ def _load_module_plugin(spec: str) -> PluginCallable:
         try:
             return _coerce_plugin_callable(getattr(module, attr_name), spec)
         except AttributeError as exc:
-            raise PluginLoadError(f"Plugin attribute '{attr_name}' not found in {module_name}.") from exc
+            raise PluginLoadError(
+                f"Plugin attribute '{attr_name}' not found in {module_name}."
+            ) from exc
 
     entry_point = _load_entry_point(spec)
     if entry_point is not None:
@@ -116,13 +118,11 @@ def _invoke_plugin(plugin: PluginCallable, mcp: Any) -> Any:
         in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
     ]
     accepts_variadic = any(
-        param.kind == inspect.Parameter.VAR_POSITIONAL
-        for param in signature.parameters.values()
+        param.kind == inspect.Parameter.VAR_POSITIONAL for param in signature.parameters.values()
     )
     accepts_keyword_mcp = any(
         param.name == "mcp"
-        and param.kind
-        in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+        and param.kind in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
         for param in signature.parameters.values()
     )
 

--- a/src/notebooklm_tools/mcp/plugins.py
+++ b/src/notebooklm_tools/mcp/plugins.py
@@ -1,0 +1,184 @@
+"""Optional MCP plugin loading for third-party NotebookLM extensions.
+
+The core server owns built-in tool registration. This module adds a small,
+stable extension seam for optional tools/routes without requiring downstream
+integrations to patch ``server.py`` or built-in tool modules.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import logging
+import os
+from collections.abc import Callable, Sequence
+from importlib import metadata
+from typing import Any
+
+PLUGIN_ENTRY_POINT_GROUP = "notebooklm_tools.mcp_plugins"
+PLUGIN_ENV_VAR = "NOTEBOOKLM_MCP_PLUGINS"
+PLUGIN_AUTOLOAD_ENV_VAR = "NOTEBOOKLM_MCP_PLUGIN_AUTOLOAD"
+PLUGIN_STRICT_ENV_VAR = "NOTEBOOKLM_MCP_PLUGIN_STRICT"
+
+_FALSY = frozenset({"", "false", "0", "no", "off"})
+_TRUE_VALUES = frozenset({"true", "1", "yes", "on"})
+logger = logging.getLogger("notebooklm_tools.mcp.plugins")
+PluginCallable = Callable[..., Any]
+PluginLoadResult = dict[str, str]
+
+
+class PluginLoadError(RuntimeError):
+    """Raised when an explicitly configured plugin cannot be loaded."""
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    normalized = raw.strip().lower()
+    if normalized in _FALSY:
+        return False
+    if normalized in _TRUE_VALUES:
+        return True
+    return default
+
+
+def _split_plugin_specs(raw: str | None) -> list[str]:
+    """Split a comma-separated plugin spec list while ignoring blanks."""
+    if not raw:
+        return []
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def _entry_points() -> list[metadata.EntryPoint]:
+    """Return installed NotebookLM MCP plugin entry points."""
+    eps = metadata.entry_points()
+    if hasattr(eps, "select"):
+        return list(eps.select(group=PLUGIN_ENTRY_POINT_GROUP))
+    return list(eps.get(PLUGIN_ENTRY_POINT_GROUP, []))  # type: ignore[attr-defined]
+
+
+def _load_entry_point(name: str) -> PluginCallable | None:
+    """Load an entry point by name, returning None when absent."""
+    for entry_point in _entry_points():
+        if entry_point.name == name:
+            loaded = entry_point.load()
+            return _coerce_plugin_callable(loaded, name)
+    return None
+
+
+def _coerce_plugin_callable(obj: Any, spec: str) -> PluginCallable:
+    """Normalize a plugin object/module into a callable registration function."""
+    if callable(obj):
+        return obj
+    register = getattr(obj, "register", None)
+    if callable(register):
+        return register
+    raise PluginLoadError(
+        f"Plugin '{spec}' must be callable or expose a callable register(mcp) function."
+    )
+
+
+def _load_module_plugin(spec: str) -> PluginCallable:
+    """Load a plugin from module or module:attribute syntax."""
+    if ":" in spec:
+        module_name, attr_name = spec.split(":", 1)
+        module_name = module_name.strip()
+        attr_name = attr_name.strip()
+        if not module_name or not attr_name:
+            raise PluginLoadError(f"Invalid plugin spec '{spec}'. Expected module:attribute.")
+        module = importlib.import_module(module_name)
+        try:
+            return _coerce_plugin_callable(getattr(module, attr_name), spec)
+        except AttributeError as exc:
+            raise PluginLoadError(f"Plugin attribute '{attr_name}' not found in {module_name}.") from exc
+
+    entry_point = _load_entry_point(spec)
+    if entry_point is not None:
+        return entry_point
+
+    module = importlib.import_module(spec)
+    return _coerce_plugin_callable(module, spec)
+
+
+def _invoke_plugin(plugin: PluginCallable, mcp: Any) -> Any:
+    """Invoke a plugin callable with the FastMCP instance when it accepts one."""
+    try:
+        signature = inspect.signature(plugin)
+    except (TypeError, ValueError):
+        return plugin(mcp)
+
+    required_positional = [
+        param
+        for param in signature.parameters.values()
+        if param.default is inspect.Parameter.empty
+        and param.kind
+        in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    ]
+    accepts_variadic = any(
+        param.kind == inspect.Parameter.VAR_POSITIONAL
+        for param in signature.parameters.values()
+    )
+    accepts_keyword_mcp = any(
+        param.name == "mcp"
+        and param.kind
+        in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+        for param in signature.parameters.values()
+    )
+
+    if accepts_keyword_mcp and not required_positional:
+        return plugin(mcp=mcp)
+    if required_positional or accepts_variadic:
+        return plugin(mcp)
+    return plugin()
+
+
+def _configured_plugin_specs() -> list[str]:
+    specs = _split_plugin_specs(os.environ.get(PLUGIN_ENV_VAR))
+    if specs:
+        return specs
+    if _env_bool(PLUGIN_AUTOLOAD_ENV_VAR):
+        return [entry_point.name for entry_point in _entry_points()]
+    return []
+
+
+def load_plugins(
+    mcp: Any,
+    plugin_specs: Sequence[str] | None = None,
+    *,
+    strict: bool | None = None,
+) -> list[PluginLoadResult]:
+    """Load and register optional MCP plugins.
+
+    Plugins are disabled by default. Configure explicit plugins with
+    ``NOTEBOOKLM_MCP_PLUGINS`` as a comma-separated list. Each item can be:
+
+    - an entry point name from ``notebooklm_tools.mcp_plugins``;
+    - a Python module exposing ``register(mcp)``;
+    - ``module:function`` pointing at a callable.
+
+    Set ``NOTEBOOKLM_MCP_PLUGIN_AUTOLOAD=true`` to load all installed entry
+    points from the group. Explicit plugin failures are fatal by default;
+    set ``NOTEBOOKLM_MCP_PLUGIN_STRICT=false`` to log failures and continue.
+    """
+    specs = list(plugin_specs) if plugin_specs is not None else _configured_plugin_specs()
+    if not specs:
+        return []
+
+    strict_mode = _env_bool(PLUGIN_STRICT_ENV_VAR, default=True) if strict is None else strict
+    results: list[PluginLoadResult] = []
+
+    for spec in specs:
+        try:
+            plugin = _load_module_plugin(spec)
+            _invoke_plugin(plugin, mcp)
+            results.append({"name": spec, "status": "loaded"})
+            logger.info("Loaded NotebookLM MCP plugin: %s", spec)
+        except Exception as exc:
+            message = f"Failed to load NotebookLM MCP plugin '{spec}': {exc}"
+            if strict_mode:
+                raise PluginLoadError(message) from exc
+            logger.exception(message)
+            results.append({"name": spec, "status": "error", "error": str(exc)})
+
+    return results

--- a/src/notebooklm_tools/mcp/server.py
+++ b/src/notebooklm_tools/mcp/server.py
@@ -76,6 +76,7 @@ async def health_check(request: Request) -> JSONResponse:
 def _register_tools() -> None:
     """Import and register all tools from the modular tools package."""
     # Import all tool modules to populate the registry
+    from .plugins import load_plugins
     from .tools import (  # noqa: F401
         auth,
         batch,
@@ -96,8 +97,10 @@ def _register_tools() -> None:
     )
     from .tools._utils import register_all_tools
 
-    # Register collected tools with mcp
+    # Register collected built-in tools with mcp first. Optional plugins may then
+    # add their own tools/routes without patching core tool modules.
     register_all_tools(mcp)
+    load_plugins(mcp)
 
 
 # Register tools on import
@@ -127,6 +130,8 @@ Environment Variables:
   NOTEBOOKLM_MCP_PATH          MCP endpoint path (default: /mcp)
   NOTEBOOKLM_MCP_STATELESS     Stateless HTTP sessions (default: true, set false to disable)
   NOTEBOOKLM_MCP_DEBUG         Debug logging (default: false)
+  NOTEBOOKLM_MCP_PLUGINS       Comma-separated optional plugin specs to load
+  NOTEBOOKLM_MCP_PLUGIN_STRICT Fail startup on plugin load errors (default: true)
   NOTEBOOKLM_HL                Interface language and default artifact language (default: en)
   NOTEBOOKLM_QUERY_TIMEOUT     Query timeout in seconds (default: 120.0)
 

--- a/tests/test_mcp_plugins.py
+++ b/tests/test_mcp_plugins.py
@@ -1,0 +1,137 @@
+"""Tests for optional MCP plugin loading."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from notebooklm_tools.mcp import plugins
+
+
+class FakeMCP:
+    def __init__(self) -> None:
+        self.tools: list[str] = []
+        self.routes: list[tuple[str, tuple[str, ...]]] = []
+
+    def tool(self):
+        def decorator(func):
+            self.tools.append(func.__name__)
+            return func
+
+        return decorator
+
+    def custom_route(self, path: str, methods: list[str]):
+        def decorator(func):
+            self.routes.append((path, tuple(methods)))
+            return func
+
+        return decorator
+
+
+@dataclass
+class FakeEntryPoint:
+    name: str
+    loaded: Any
+
+    def load(self) -> Any:
+        return self.loaded
+
+
+def test_load_plugins_disabled_by_default(monkeypatch):
+    monkeypatch.delenv(plugins.PLUGIN_ENV_VAR, raising=False)
+    monkeypatch.delenv(plugins.PLUGIN_AUTOLOAD_ENV_VAR, raising=False)
+
+    result = plugins.load_plugins(FakeMCP())
+
+    assert result == []
+
+
+def test_load_module_register_function(monkeypatch, tmp_path):
+    module_path = tmp_path / "sample_plugin.py"
+    module_path.write_text(
+        "def register(mcp):\n"
+        "    @mcp.tool()\n"
+        "    def sample_plugin_status():\n"
+        "        return {'status': 'success'}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setenv(plugins.PLUGIN_ENV_VAR, "sample_plugin")
+    mcp = FakeMCP()
+
+    result = plugins.load_plugins(mcp)
+
+    assert result == [{"name": "sample_plugin", "status": "loaded"}]
+    assert mcp.tools == ["sample_plugin_status"]
+
+
+def test_load_module_attribute_function(monkeypatch, tmp_path):
+    module_path = tmp_path / "attribute_plugin.py"
+    module_path.write_text(
+        "def install(mcp):\n"
+        "    @mcp.custom_route('/plugin-health', methods=['GET'])\n"
+        "    async def plugin_health(request):\n"
+        "        return None\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    mcp = FakeMCP()
+
+    result = plugins.load_plugins(mcp, ["attribute_plugin:install"])
+
+    assert result == [{"name": "attribute_plugin:install", "status": "loaded"}]
+    assert mcp.routes == [("/plugin-health", ("GET",))]
+
+
+def test_missing_plugin_is_strict_by_default():
+    with pytest.raises(plugins.PluginLoadError, match="missing_plugin"):
+        plugins.load_plugins(FakeMCP(), ["missing_plugin"])
+
+
+def test_missing_plugin_can_be_non_strict():
+    result = plugins.load_plugins(FakeMCP(), ["missing_plugin"], strict=False)
+
+    assert result[0]["name"] == "missing_plugin"
+    assert result[0]["status"] == "error"
+    assert "No module named" in result[0]["error"]
+
+
+def test_entry_point_plugin_loads_by_name(monkeypatch):
+    def register(mcp):
+        @mcp.tool()
+        def entry_point_tool():
+            return {"status": "success"}
+
+    monkeypatch.setattr(
+        plugins,
+        "_entry_points",
+        lambda: [FakeEntryPoint("sample-entry", register)],
+    )
+    mcp = FakeMCP()
+
+    result = plugins.load_plugins(mcp, ["sample-entry"])
+
+    assert result == [{"name": "sample-entry", "status": "loaded"}]
+    assert mcp.tools == ["entry_point_tool"]
+
+
+def test_autoload_entry_points(monkeypatch):
+    def register(mcp):
+        mcp.loaded = True
+
+    monkeypatch.setenv(plugins.PLUGIN_AUTOLOAD_ENV_VAR, "true")
+    monkeypatch.delenv(plugins.PLUGIN_ENV_VAR, raising=False)
+    monkeypatch.setattr(
+        plugins,
+        "_entry_points",
+        lambda: [FakeEntryPoint("auto-entry", register)],
+    )
+    mcp = SimpleNamespace(loaded=False)
+
+    result = plugins.load_plugins(mcp)
+
+    assert result == [{"name": "auto-entry", "status": "loaded"}]
+    assert mcp.loaded is True


### PR DESCRIPTION
# NotebookLM MCP Plugin Guide

NotebookLM MCP supports optional plugins for third-party tools and HTTP routes.
The core server registers built-in tools first, then loads explicitly configured
plugins. This lets local integrations add behavior without patching core tool
modules such as `server.py`, `tools/sources.py`, or `tools/downloads.py`.

Plugins are disabled by default.

## Why this exists

Some integrations need to extend NotebookLM MCP with local workflow-specific
tools, tunnel routes, file handoff logic, or organization policy checks. Without
a plugin seam, those integrations must patch built-in modules and repeatedly
rebase whenever upstream changes core tools, auth, or transport code.

The plugin loader keeps the core server stable while giving downstream users a
supported extension point. Core NotebookLM MCP continues to own built-in tools,
authentication, and transport startup. Plugins own optional behavior and can be
installed, audited, enabled, disabled, or upgraded independently.

This is especially useful for integrations that are valuable locally but too
specific or too security-sensitive to enable for every NotebookLM MCP user by
default.

## Configuration

Load plugins with a comma-separated environment variable:

```text
NOTEBOOKLM_MCP_PLUGINS=my_package.plugin,my_package.plugin:register_tools
```

Each item can be one of:

- an entry point name from the `notebooklm_tools.mcp_plugins` group;
- a Python module exposing `register(mcp)`;
- a `module:function` callable spec.

Optional settings:

```text
NOTEBOOKLM_MCP_PLUGIN_STRICT=true
NOTEBOOKLM_MCP_PLUGIN_AUTOLOAD=false
```

`NOTEBOOKLM_MCP_PLUGIN_STRICT=true` is the default. Explicit plugin load
failures stop server startup so a missing or broken integration is not silently
ignored. Set it to `false` only when best-effort loading is desired.

`NOTEBOOKLM_MCP_PLUGIN_AUTOLOAD=true` loads every installed entry point in the
`notebooklm_tools.mcp_plugins` group. Explicit `NOTEBOOKLM_MCP_PLUGINS` is
preferred for production because it is easier to audit.

## Minimal plugin module

```python
# my_package/plugin.py

def register(mcp):
    @mcp.tool()
    def plugin_status() -> dict[str, str]:
        """Return plugin health."""
        return {"status": "success"}
```

Run the MCP server with:

```text
NOTEBOOKLM_MCP_PLUGINS=my_package.plugin notebooklm-mcp
```

## Custom HTTP routes

Plugins receive the FastMCP instance, so they can register routes when they need
HTTP callbacks or short-lived download endpoints:

```python
from starlette.responses import JSONResponse


def register(mcp):
    @mcp.custom_route("/plugins/example/health", methods=["GET"])
    async def plugin_health(request):
        return JSONResponse({"status": "healthy"})
```

Plugins that expose routes are responsible for their own security model:
confirmation gates, token validation, TTLs, path validation, cleanup, and any
public-tunnel exposure controls.

## Packaging entry point

A plugin package can advertise itself through Python package metadata:

```toml
[project.entry-points."notebooklm_tools.mcp_plugins"]
chatgpt_bridge = "notebooklm_chatgpt_bridge:register"
```

Then load it explicitly:

```text
NOTEBOOKLM_MCP_PLUGINS=chatgpt_bridge notebooklm-mcp
```

## Design intent

The plugin seam is intentionally small. Core NotebookLM MCP remains responsible
for built-in NotebookLM tools and authentication. Plugins should depend on
public service-layer APIs and should avoid monkey-patching built-in tools.

## Plugin ideas

The plugin hook is intentionally generic. Examples of extensions it can support:

- **ChatGPT file bridge** — inbound ChatGPT-hosted file URLs to NotebookLM sources, and outbound NotebookLM artifacts behind short-lived tokenized routes.
- **Enterprise policy gate** — enforce organization-specific allowlists, source limits, file-type restrictions, retention rules, or audit metadata before calling NotebookLM services.
- **Local knowledge-base sync** — import/export NotebookLM sources or notes from a local folder, Obsidian vault, Notion workspace, SharePoint mirror, or legal evidence directory.
- **Artifact post-processing** — transcode audio, convert slide decks, normalize filenames, generate sidecar metadata, or package NotebookLM outputs for downstream tools.
- **Webhook/callback routes** — expose local-only HTTP endpoints for workflow orchestrators that need to notify the MCP server when a file, job, or external process is ready.
- **Domain-specific tool packs** — add legal, research, education, medical-literature, or engineering workflow tools that compose NotebookLM primitives without expanding the core tool surface.
- **Observability plugin** — add health probes, metrics, redacted audit logs, queue status, or runtime diagnostics for long-lived MCP deployments.
- **Rate-limit/coordinator plugin** — coordinate local concurrency, backoff, or queueing across multiple MCP clients that share one NotebookLM account.

Plugins should remain opt-in and should document their own threat model when
they expose routes, touch local files, or call third-party services.
