### PR TITLE
feat(studio): expose per-artifact source_ids in studio status

### DIFF
--- a/src/notebooklm_tools/cli/formatters.py
+++ b/src/notebooklm_tools/cli/formatters.py
@@ -311,6 +311,7 @@ class JsonFormatter(Formatter):
         "report_content",
         "flashcard_count",
         "duration_seconds",
+        "source_ids",
     )
 
     def format_notebooks(

--- a/src/notebooklm_tools/core/studio.py
+++ b/src/notebooklm_tools/core/studio.py
@@ -131,6 +131,47 @@ class StudioMixin(BaseClient):
 
         return None
 
+    @staticmethod
+    def _coerce_source_ids(raw: Any) -> list[str]:
+        """Coerce a raw source list into UUID strings.
+
+        Entries appear either as bare strings (``"uuid"``) or single-element
+        lists (``["uuid"]``); anything else is ignored.
+        """
+        if not isinstance(raw, list):
+            return []
+        ids: list[str] = []
+        for entry in raw:
+            if isinstance(entry, str):
+                ids.append(entry)
+            elif isinstance(entry, list) and entry and isinstance(entry[0], str):
+                ids.append(entry[0])
+        return ids
+
+    def _extract_artifact_source_ids(self, artifact_data: list[Any], type_code: Any) -> list[str]:
+        """Source UUIDs an artifact was generated from.
+
+        Per the ``gArtLc`` poll response (see ``docs/API_REFERENCE.md``), the
+        source list is carried at the top-level index ``[3]`` for all artifact
+        types. Some audio payloads also nest it inside the options blob at
+        ``[6][1][3]``; fall back to that when the top-level field is empty.
+        """
+        # Top-level source field — documented, type-agnostic.
+        if len(artifact_data) > 3:
+            ids = self._coerce_source_ids(artifact_data[3])
+            if ids:
+                return ids
+
+        # Audio fallback: sources nested in the options blob at [6][1][3].
+        if type_code == self.STUDIO_TYPE_AUDIO and len(artifact_data) > 6:
+            options_data = artifact_data[6]
+            if isinstance(options_data, list) and len(options_data) > 1:
+                inner = options_data[1]
+                if isinstance(inner, list) and len(inner) > 3:
+                    return self._coerce_source_ids(inner[3])
+
+        return []
+
     def _normalize_studio_status(self, artifact_data: Any) -> str:
         """Map raw artifact status codes to stable CLI status labels.
 
@@ -447,6 +488,7 @@ class StudioMixin(BaseClient):
                 # - Quiz/Flashcards: artifact_data[9][1][1]
                 custom_instructions = None
                 visual_style_prompt = None
+                source_ids = self._extract_artifact_source_ids(artifact_data, type_code)
 
                 if type_code == self.STUDIO_TYPE_AUDIO and len(artifact_data) > 6:
                     options_data = artifact_data[6]
@@ -492,6 +534,7 @@ class StudioMixin(BaseClient):
                         "status": status,
                         "created_at": created_at,
                         "custom_instructions": custom_instructions,
+                        "source_ids": source_ids,
                         "visual_style_prompt": visual_style_prompt,
                         "audio_url": audio_url,
                         "video_url": video_url,

--- a/src/notebooklm_tools/mcp/tools/studio.py
+++ b/src/notebooklm_tools/mcp/tools/studio.py
@@ -293,6 +293,7 @@ def studio_status(
                 - status: completed, in_progress, failed
                 - url: URL to view/download (if applicable)
                 - custom_instructions: The custom prompt/focus instructions used to generate the artifact (if any)
+                - source_ids: List of source UUIDs the artifact was generated from
             - summary: Counts of total, completed, in_progress
     """
     try:

--- a/src/notebooklm_tools/services/studio.py
+++ b/src/notebooklm_tools/services/studio.py
@@ -83,6 +83,7 @@ class ArtifactInfo(TypedDict, total=False):
     url: str | None
     custom_instructions: str | None
     visual_style_prompt: str | None
+    source_ids: list[str]
     audio_url: str | None
     video_url: str | None
     infographic_url: str | None
@@ -672,6 +673,11 @@ def get_studio_status(
             if isinstance(raw_artifact.get("duration_seconds"), int)
             or raw_artifact.get("duration_seconds") is None
             else None,
+            "source_ids": [
+                sid
+                for sid in (raw_artifact.get("source_ids") or [])
+                if isinstance(sid, str)
+            ],
         }
         artifact_id = raw_artifact.get("artifact_id")
         if isinstance(artifact_id, str):

--- a/tests/core/test_studio.py
+++ b/tests/core/test_studio.py
@@ -145,6 +145,79 @@ class TestStudioMixinMethods:
 
         assert mixin._extract_audio_media_url(artifact_data) == "https://example.com/audio.m4a"
 
+    def test_extract_artifact_source_ids_reads_top_level_field_any_type(self):
+        """Top-level [3] is the documented, type-agnostic source field."""
+        mixin = StudioMixin(cookies={"test": "cookie"}, csrf_token="test")
+
+        artifact_data = [
+            "art-1",
+            "Report Artifact",
+            mixin.STUDIO_TYPE_REPORT,
+            [["uuid-x"], ["uuid-y"]],  # [3] Source IDs used
+            3,
+            None,
+        ]
+
+        assert mixin._extract_artifact_source_ids(
+            artifact_data, mixin.STUDIO_TYPE_REPORT
+        ) == ["uuid-x", "uuid-y"]
+
+    def test_extract_artifact_source_ids_accepts_flat_string_entries(self):
+        mixin = StudioMixin(cookies={"test": "cookie"}, csrf_token="test")
+
+        artifact_data = [
+            "art-1",
+            "Audio Artifact",
+            mixin.STUDIO_TYPE_AUDIO,
+            ["uuid-a", "uuid-b"],  # bare strings instead of single-element lists
+            2,
+            None,
+        ]
+
+        assert mixin._extract_artifact_source_ids(
+            artifact_data, mixin.STUDIO_TYPE_AUDIO
+        ) == ["uuid-a", "uuid-b"]
+
+    def test_extract_artifact_source_ids_falls_back_to_audio_options(self):
+        """When the top-level field is empty, audio sources at [6][1][3] are used."""
+        mixin = StudioMixin(cookies={"test": "cookie"}, csrf_token="test")
+
+        artifact_data = [
+            "art-1",
+            "Audio Artifact",
+            mixin.STUDIO_TYPE_AUDIO,
+            [],  # empty top-level field -> forces the audio-options fallback
+            2,
+            None,
+            [
+                None,
+                ["", 2, None, [["uuid-aaa"], ["uuid-bbb"]], "en", True, 1],
+                "https://example.com/thumb",
+                "https://example.com/thumb-dv",
+                None,
+                [["https://example.com/audio.m4a", 1, "audio/mp4"]],
+                [],
+            ],
+        ]
+
+        assert mixin._extract_artifact_source_ids(
+            artifact_data, mixin.STUDIO_TYPE_AUDIO
+        ) == ["uuid-aaa", "uuid-bbb"]
+
+    def test_extract_artifact_source_ids_returns_empty_for_malformed_payload(self):
+        mixin = StudioMixin(cookies={"test": "cookie"}, csrf_token="test")
+
+        artifact_data = [
+            "art-1",
+            "Audio Artifact",
+            mixin.STUDIO_TYPE_AUDIO,
+            [],
+            2,
+            None,
+        ]
+
+        assert mixin._extract_artifact_source_ids(artifact_data, mixin.STUDIO_TYPE_AUDIO) == []
+
     def test_poll_studio_status_uses_normalized_status_mapping(self):
         mixin = StudioMixin(cookies={"test": "cookie"}, csrf_token="test")
         http_client = MagicMock()

--- a/tests/services/test_studio.py
+++ b/tests/services/test_studio.py
@@ -478,3 +478,26 @@ class TestDeleteArtifact:
         mock_client.delete_studio_artifact.side_effect = RuntimeError("fail")
         with pytest.raises(ServiceError, match="Failed to delete"):
             delete_artifact(mock_client, "art-1", "nb-1")
+
+
+class TestStudioStatusSourceIds:
+    """get_studio_status surfaces per-artifact source_ids from the client."""
+
+    def test_source_ids_propagate_to_artifact_info(self, mock_client):
+        mock_client.poll_studio_status.return_value = [
+            {
+                "artifact_id": "a1",
+                "type": "audio",
+                "status": "completed",
+                "source_ids": ["uuid-aaa", "uuid-bbb"],
+            },
+        ]
+        result = get_studio_status(mock_client, "nb-1")
+        assert result["artifacts"][0]["source_ids"] == ["uuid-aaa", "uuid-bbb"]
+
+    def test_source_ids_default_empty_when_absent(self, mock_client):
+        mock_client.poll_studio_status.return_value = [
+            {"artifact_id": "a1", "type": "report", "status": "completed"},
+        ]
+        result = get_studio_status(mock_client, "nb-1")
+        assert result["artifacts"][0]["source_ids"] == []


### PR DESCRIPTION
## What

`studio_status` (and `nlm studio status`) returns each artifact's metadata but not the **source IDs** the artifact was generated from — even though the `gArtLc` poll response carries them at the top-level index `[3]` (documented in `docs/API_REFERENCE.md`). This surfaces them end-to-end so callers can map an artifact back to its source documents without dropping to a direct `_call_rpc`.

## Changes

- **core** (`core/studio.py`): `_extract_artifact_source_ids` reads the documented top-level `[3]` field for all artifact types, with a fallback to the audio options blob at `[6][1][3]`; adds `source_ids` to each artifact dict in `poll_studio_status`.
- **service** (`services/studio.py`): `source_ids` added to `ArtifactInfo` and propagated through `get_studio_status`.
- **cli** (`cli/formatters.py`): `source_ids` included in `ARTIFACT_FULL_FIELDS` → appears in `nlm studio status --json --full`.
- **mcp** (`mcp/tools/studio.py`): documented in the `studio_status` return schema.

## Why

Lets you map studio artifacts (podcasts, videos, …) back to the sources they were built from — e.g. to organize or rename artifacts by their source — without re-deriving the mapping from a raw RPC payload.

## Tests

- Unit tests for top-level extraction (any artifact type, flat + nested entry forms), the audio-options fallback, and malformed payloads.
- Service-layer propagation test (`get_studio_status` surfaces `source_ids`).
- Full suite green (`uv run pytest`): **1016 passed, 37 skipped**. `ruff` clean; `mypy` clean on the changed core helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
