### PR TITLE
fix: prevent login --check crash on slow accounts and retry connect-phase RPC failures

### DIFF
--- a/src/notebooklm_tools/cli/main.py
+++ b/src/notebooklm_tools/cli/main.py
@@ -88,33 +88,101 @@ profile_app = typer.Typer(
 )
 
 
-def _validate_saved_profile(auth: Any) -> tuple[Any, int]:
-    """Validate saved credentials by making a real NotebookLM API call."""
+def _auth_failure_from_result(result: Any) -> Exception:
+    """Translate a failed AuthCheckResult into a CLI-facing AuthenticationError.
+
+    Args:
+        result: An AuthCheckResult with ``valid=False``.
+
+    Returns:
+        An AuthenticationError whose message/hint match the failure reason.
+    """
+    from notebooklm_tools.core.exceptions import AuthenticationError
+
+    reason = result.reason or "unknown"
+    if reason == "no_tokens":
+        return AuthenticationError(
+            "No saved credentials found.",
+            hint="Run 'nlm login' to authenticate.",
+        )
+    if reason == "expired":
+        return AuthenticationError(
+            "Credentials have expired.",
+            hint="Run 'nlm login' to re-authenticate.",
+        )
+    if reason.startswith("network_error"):
+        return AuthenticationError(
+            f"Could not reach NotebookLM ({reason}).",
+            hint="Check your connection and try again — your saved credentials may still be valid.",
+        )
+    return AuthenticationError(
+        f"Authentication check failed ({reason}).",
+        hint="Run 'nlm login' to re-authenticate.",
+    )
+
+
+def _best_effort_notebook_count(profile: Any) -> int | None:
+    """Return the notebook count, or None if it cannot be retrieved quickly.
+
+    The notebook count is a convenience shown alongside a successful auth
+    check. A slow or timed-out notebook list must never turn an otherwise-valid
+    session into a failure, so every error here degrades to ``None``.
+
+    Args:
+        profile: The loaded profile whose credentials are used for the call.
+
+    Returns:
+        The number of notebooks, or None if the list could not be fetched.
+    """
     from notebooklm_tools.core.client import NotebookLMClient
 
+    try:
+        with NotebookLMClient(
+            cookies=profile.cookies,
+            csrf_token=profile.csrf_token or "",
+            session_id=profile.session_id or "",
+            build_label=profile.build_label or "",
+        ) as client:
+            return len(client.list_notebooks())
+    except Exception:
+        return None
+
+
+def _validate_saved_profile(auth: Any) -> tuple[Any, int | None]:
+    """Validate saved credentials using the lightweight authoritative check.
+
+    Validity is decided by ``check_validity`` (a homepage probe), not by a full
+    ``list_notebooks()`` call, so a slow notebook list on a large account cannot
+    turn a valid session into a crash or false failure. The notebook count is
+    fetched as a best-effort extra and is None when it cannot be retrieved.
+
+    Args:
+        auth: The AuthManager for the profile being checked.
+
+    Returns:
+        A tuple of (profile, notebook_count) where notebook_count may be None.
+
+    Raises:
+        AuthenticationError: If the credentials are not valid.
+    """
     p = auth.load_profile()
-    with NotebookLMClient(
-        cookies=p.cookies,
-        csrf_token=p.csrf_token or "",
-        session_id=p.session_id or "",
-        build_label=p.build_label or "",
-    ) as client:
-        notebooks = client.list_notebooks()
 
-    auth.save_profile(
-        cookies=p.cookies,
-        csrf_token=p.csrf_token,
-        session_id=p.session_id,
-        email=p.email,
-        build_label=p.build_label,
-    )
-    return p, len(notebooks)
+    result = auth.check_validity(live=True)
+    if not result.valid:
+        raise _auth_failure_from_result(result)
+
+    return p, _best_effort_notebook_count(p)
 
 
-def _print_auth_valid(profile: Any, notebook_count: int) -> None:
+def _print_auth_valid(profile: Any, notebook_count: int | None) -> None:
     console.print("[green]✓[/green] Authentication valid!")
     console.print(f"  Profile: {profile.name}")
-    console.print(f"  Notebooks found: {notebook_count}")
+    if notebook_count is not None:
+        console.print(f"  Notebooks found: {notebook_count}")
+    else:
+        console.print(
+            "  [dim]Notebook count unavailable (network slow); credentials are valid[/dim]"
+        )
     if profile.email:
         console.print(f"  Account: {profile.email}")
 

--- a/src/notebooklm_tools/core/base.py
+++ b/src/notebooklm_tools/core/base.py
@@ -26,7 +26,13 @@ from . import constants
 from .data_types import ConversationTurn
 from .errors import ClientAuthenticationError as AuthenticationError
 from .errors import ResourceExhaustedError, RPCDriftError, RPCError
-from .retry import DEFAULT_BASE_DELAY, DEFAULT_MAX_DELAY, DEFAULT_MAX_RETRIES, is_retryable_error
+from .retry import (
+    DEFAULT_BASE_DELAY,
+    DEFAULT_MAX_DELAY,
+    DEFAULT_MAX_RETRIES,
+    RETRYABLE_CONNECT_ERRORS,
+    is_retryable_error,
+)
 from .utils import (
     RPC_NAMES,
     _decode_request_body,
@@ -830,6 +836,36 @@ class BaseClient:
 
             # Fall through to auth recovery below
             pass
+
+        except RETRYABLE_CONNECT_ERRORS as e:
+            # Connection never established → the server never received the
+            # request, so retrying is always safe (even for mutating RPCs).
+            # Read/write timeouts are intentionally excluded; see
+            # retry.RETRYABLE_CONNECT_ERRORS.
+            if _server_retry < DEFAULT_MAX_RETRIES:
+                import time as _time
+
+                delay = min(DEFAULT_BASE_DELAY * (2**_server_retry), DEFAULT_MAX_DELAY)
+                logger.warning(
+                    "Connection error (%s) on %s, attempt %d/%d, retrying in %.1fs...",
+                    type(e).__name__,
+                    rpc_id,
+                    _server_retry + 1,
+                    DEFAULT_MAX_RETRIES + 1,
+                    delay,
+                )
+                _time.sleep(delay)
+                return self._call_rpc(
+                    rpc_id,
+                    params,
+                    path,
+                    timeout,
+                    _retry,
+                    _deep_retry,
+                    _server_retry=_server_retry + 1,
+                )
+            # Exhausted retries, re-raise
+            raise
 
         except ResourceExhaustedError:
             # RPC-level rate limit (HTTP 200, error code 8). Back off and retry.

--- a/src/notebooklm_tools/core/retry.py
+++ b/src/notebooklm_tools/core/retry.py
@@ -30,6 +30,17 @@ def is_retryable_error(exc: Exception) -> bool:
     return False
 
 
+# Transport errors that are always safe to retry: the connection was never
+# established, so the server never received the request. This is deliberately
+# narrower than ``httpx.TimeoutException`` — a read or write timeout means the
+# request may already have been delivered and processed, so retrying it could
+# duplicate side effects on mutating RPCs (e.g. create notebook, add source).
+RETRYABLE_CONNECT_ERRORS: tuple[type[Exception], ...] = (
+    httpx.ConnectError,
+    httpx.ConnectTimeout,
+)
+
+
 def retry_on_server_error(
     max_retries: int = DEFAULT_MAX_RETRIES,
     base_delay: float = DEFAULT_BASE_DELAY,

--- a/tests/cli/test_login.py
+++ b/tests/cli/test_login.py
@@ -88,3 +88,191 @@ def test_login_force_bypasses_saved_profile_validation(monkeypatch, tmp_path):
         }
     ]
     assert "Successfully authenticated!" in result.output
+
+
+class CheckAuthManager(FakeAuthManager):
+    """AuthManager whose check_validity returns a preconfigured result."""
+
+    result = None  # set per-test before invoking the CLI
+
+    def load_profile(self):
+        return SimpleNamespace(
+            name=self.profile_name,
+            email="user@example.com",
+            cookies={"SID": "sid"},
+            csrf_token="csrf",
+            session_id="session",
+            build_label="build",
+        )
+
+    def check_validity(self, *, live: bool = True, timeout: float = 12.0):
+        return CheckAuthManager.result
+
+
+def test_check_valid_reports_notebook_count(monkeypatch):
+    from notebooklm_tools.core.auth import AuthCheckResult
+
+    CheckAuthManager.result = AuthCheckResult(valid=True, live=True, profile="KS")
+    monkeypatch.setattr("notebooklm_tools.core.auth.AuthManager", CheckAuthManager)
+    monkeypatch.setattr("notebooklm_tools.cli.main._best_effort_notebook_count", lambda profile: 5)
+
+    result = CliRunner().invoke(app, ["login", "--check", "--profile", "KS"])
+
+    assert result.exit_code == 0
+    assert "Authentication valid!" in result.output
+    assert "Notebooks found: 5" in result.output
+
+
+def test_check_valid_when_notebook_count_unavailable_does_not_fail(monkeypatch):
+    """The reported bug: a slow/timed-out notebook list must not fail a valid check."""
+    from notebooklm_tools.core.auth import AuthCheckResult
+
+    CheckAuthManager.result = AuthCheckResult(valid=True, live=True, profile="KS")
+    monkeypatch.setattr("notebooklm_tools.core.auth.AuthManager", CheckAuthManager)
+    # Simulate list_notebooks timing out → best-effort count degrades to None
+    monkeypatch.setattr(
+        "notebooklm_tools.cli.main._best_effort_notebook_count", lambda profile: None
+    )
+
+    result = CliRunner().invoke(app, ["login", "--check", "--profile", "KS"])
+
+    assert result.exit_code == 0
+    assert "Authentication valid!" in result.output
+    assert "Notebook count unavailable" in result.output
+
+
+def test_check_invalid_credentials_exit_2(monkeypatch):
+    from notebooklm_tools.core.auth import AuthCheckResult
+
+    CheckAuthManager.result = AuthCheckResult(
+        valid=False, reason="expired", live=True, profile="KS"
+    )
+    monkeypatch.setattr("notebooklm_tools.core.auth.AuthManager", CheckAuthManager)
+
+    def fail_count(profile):
+        raise AssertionError("notebook count must not be fetched for invalid auth")
+
+    monkeypatch.setattr("notebooklm_tools.cli.main._best_effort_notebook_count", fail_count)
+
+    result = CliRunner().invoke(app, ["login", "--check", "--profile", "KS"])
+
+    assert result.exit_code == 2
+    assert "Authentication failed" in result.output
+
+
+def test_best_effort_notebook_count_swallows_timeout(monkeypatch):
+    """_best_effort_notebook_count returns None instead of raising on a read timeout."""
+    import httpx
+
+    from notebooklm_tools.cli.main import _best_effort_notebook_count
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def list_notebooks(self):
+            raise httpx.ReadTimeout("read timed out")
+
+    monkeypatch.setattr("notebooklm_tools.core.client.NotebookLMClient", FakeClient)
+    profile = SimpleNamespace(
+        cookies={"SID": "sid"}, csrf_token="csrf", session_id="session", build_label="build"
+    )
+
+    assert _best_effort_notebook_count(profile) is None
+
+
+def test_best_effort_notebook_count_returns_count(monkeypatch):
+    from notebooklm_tools.cli.main import _best_effort_notebook_count
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def list_notebooks(self):
+            return ["nb1", "nb2", "nb3"]
+
+    monkeypatch.setattr("notebooklm_tools.core.client.NotebookLMClient", FakeClient)
+    profile = SimpleNamespace(
+        cookies={"SID": "sid"}, csrf_token="csrf", session_id="session", build_label="build"
+    )
+
+    assert _best_effort_notebook_count(profile) == 3
+
+
+def test_best_effort_notebook_count_swallows_non_timeout_error(monkeypatch):
+    """Any error (not just a timeout) from the count call degrades to None."""
+    from notebooklm_tools.cli.main import _best_effort_notebook_count
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def list_notebooks(self):
+            raise ValueError("malformed batchexecute response")
+
+    monkeypatch.setattr("notebooklm_tools.core.client.NotebookLMClient", FakeClient)
+    profile = SimpleNamespace(
+        cookies={"SID": "sid"}, csrf_token="csrf", session_id="session", build_label="build"
+    )
+
+    assert _best_effort_notebook_count(profile) is None
+
+
+def test_auth_failure_network_error_keeps_credentials_hint():
+    """A homepage-probe network blip must not tell the user to re-login; it
+    must signal the credentials may still be valid (the heart of the bug)."""
+    from notebooklm_tools.cli.main import _auth_failure_from_result
+
+    exc = _auth_failure_from_result(SimpleNamespace(reason="network_error: ReadTimeout"))
+
+    assert "Could not reach NotebookLM" in exc.message
+    assert "may still be valid" in (exc.hint or "")
+
+
+def test_auth_failure_no_tokens_prompts_login():
+    from notebooklm_tools.cli.main import _auth_failure_from_result
+
+    exc = _auth_failure_from_result(SimpleNamespace(reason="no_tokens"))
+
+    assert "No saved credentials" in exc.message
+    assert "nlm login" in (exc.hint or "")
+
+
+def test_check_network_error_exits_2_without_crashing(monkeypatch):
+    """When the lightweight probe itself times out, --check fails gracefully
+    (exit 2, no traceback) and surfaces the 'may still be valid' hint — it
+    never reaches the notebook-count call."""
+    from notebooklm_tools.core.auth import AuthCheckResult
+
+    CheckAuthManager.result = AuthCheckResult(
+        valid=False, reason="network_error: ReadTimeout", live=True, profile="KS"
+    )
+    monkeypatch.setattr("notebooklm_tools.core.auth.AuthManager", CheckAuthManager)
+
+    def fail_count(profile):
+        raise AssertionError("notebook count must not be fetched when the probe failed")
+
+    monkeypatch.setattr("notebooklm_tools.cli.main._best_effort_notebook_count", fail_count)
+
+    result = CliRunner().invoke(app, ["login", "--check", "--profile", "KS"])
+
+    assert result.exit_code == 2
+    assert "may still be valid" in result.output

--- a/tests/core/test_auth_check.py
+++ b/tests/core/test_auth_check.py
@@ -113,6 +113,30 @@ class TestCheckAuthAPI:
             assert result.reason == "expired"
             assert result.live is True
 
+    def test_check_auth_live_true_degrades_on_read_timeout(self, tmp_path, monkeypatch):
+        """Regression for #243: a real httpx.ReadTimeout from the homepage probe
+        must degrade to a graceful invalid result, never propagate as an uncaught
+        exception (which previously crashed `nlm login --check`). This pins the
+        fault line directly — narrowing the except in check_auth fails this test.
+        """
+        monkeypatch.setattr("notebooklm_tools.utils.config.get_storage_dir", lambda: tmp_path)
+
+        mgr = AuthManager("default")
+        mgr.save_profile(
+            cookies={"SID": "x", "HSID": "x", "SSID": "x", "APISID": "x", "SAPISID": "x"},
+            email="test@example.com",
+        )
+
+        with patch("httpx.Client") as MockClient:
+            client = MockClient.return_value.__enter__.return_value
+            client.get.side_effect = httpx.ReadTimeout("read timed out")
+
+            result = check_auth(live=True, timeout=5.0)
+
+        assert result.valid is False
+        assert result.reason == "network_error: ReadTimeout"
+        assert result.live is True
+
     def test_auth_manager_has_check_validity(self, tmp_path, monkeypatch):
         """AuthManager should expose a convenient .check_validity() method."""
         monkeypatch.setattr("notebooklm_tools.utils.config.get_storage_dir", lambda: tmp_path)

--- a/tests/core/test_retry.py
+++ b/tests/core/test_retry.py
@@ -4,6 +4,7 @@ import httpx
 import pytest
 
 from notebooklm_tools.core.retry import (
+    RETRYABLE_CONNECT_ERRORS,
     execute_with_retry,
     is_retryable_error,
     retry_on_server_error,
@@ -102,3 +103,18 @@ def test_retry_decorator():
 
     assert result == "decorated success"
     assert mock_func.call_count == 2
+
+
+def test_retryable_connect_errors_boundary():
+    """The connect-error tuple captures connection-establishment failures and
+    nothing else. Read/write/pool timeouts must be excluded so they are never
+    auto-retried — a post-connection timeout may already have been processed
+    server-side, and retrying it could duplicate side effects on mutating RPCs.
+    """
+    # Connection-establishment failures ARE captured (safe to retry).
+    assert issubclass(httpx.ConnectError, RETRYABLE_CONNECT_ERRORS)
+    assert issubclass(httpx.ConnectTimeout, RETRYABLE_CONNECT_ERRORS)
+    # Post-connection timeouts are NOT captured.
+    assert not issubclass(httpx.ReadTimeout, RETRYABLE_CONNECT_ERRORS)
+    assert not issubclass(httpx.WriteTimeout, RETRYABLE_CONNECT_ERRORS)
+    assert not issubclass(httpx.PoolTimeout, RETRYABLE_CONNECT_ERRORS)

--- a/tests/core/test_rpc_errors.py
+++ b/tests/core/test_rpc_errors.py
@@ -81,3 +81,66 @@ def test_call_rpc_resource_exhausted_exhausts_retries(monkeypatch):
         mock_get_client.return_value.post.return_value = fake_resp
         with pytest.raises(ResourceExhaustedError):
             client._call_rpc("EXPECTED", [])
+
+
+def test_call_rpc_retries_on_connect_timeout():
+    """A connect timeout (connection never established) is retried, then succeeds."""
+    import httpx
+
+    client = _client()
+    ok = [[["wrb.fr", "EXPECTED", "[1]", None, None, None, "generic"]]]
+    fake_resp = type(
+        "R", (), {"text": "", "status_code": 200, "raise_for_status": lambda self: None}
+    )()
+
+    with (
+        patch.object(client, "_get_client") as mock_get_client,
+        patch.object(client, "_parse_response", return_value=ok),
+        patch("time.sleep"),
+    ):
+        mock_get_client.return_value.post.side_effect = [
+            httpx.ConnectTimeout("connect timed out"),
+            fake_resp,
+        ]
+        result = client._call_rpc("EXPECTED", [])
+
+    assert result == [1]
+    assert mock_get_client.return_value.post.call_count == 2
+
+
+def test_call_rpc_connect_timeout_exhausts_retries():
+    """After max retries the connect timeout propagates."""
+    import httpx
+
+    from notebooklm_tools.core.retry import DEFAULT_MAX_RETRIES
+
+    client = _client()
+
+    with (
+        patch.object(client, "_get_client") as mock_get_client,
+        patch("time.sleep"),
+    ):
+        mock_get_client.return_value.post.side_effect = httpx.ConnectTimeout("connect timed out")
+        with pytest.raises(httpx.ConnectTimeout):
+            client._call_rpc("EXPECTED", [])
+
+    # initial attempt + DEFAULT_MAX_RETRIES retries
+    assert mock_get_client.return_value.post.call_count == DEFAULT_MAX_RETRIES + 1
+
+
+def test_call_rpc_does_not_retry_read_timeout():
+    """A read timeout may already have been processed server-side, so it is NOT
+    auto-retried — it propagates after a single attempt."""
+    import httpx
+
+    client = _client()
+
+    with (
+        patch.object(client, "_get_client") as mock_get_client,
+        patch("time.sleep"),
+    ):
+        mock_get_client.return_value.post.side_effect = httpx.ReadTimeout("read timed out")
+        with pytest.raises(httpx.ReadTimeout):
+            client._call_rpc("EXPECTED", [])
+
+    assert mock_get_client.return_value.post.call_count == 1


### PR DESCRIPTION
## What

Fixes #243 — `nlm login --check` crashes with an uncaught `httpx.ReadTimeout`, and connect-phase RPC failures are never retried.

Two scoped changes:

### 1. `login --check` uses a lightweight validity probe

`_validate_saved_profile` previously decided validity by running the full
`list_notebooks()` RPC. On a large account (the reporter had a big
notebook list) or during a transient slowdown, that call exceeds the 30 s
client timeout and raises an **uncaught** `httpx.ReadTimeout`, crashing the
command with a traceback — even though the credentials are perfectly valid.

It now decides validity with the existing lightweight `check_validity()`
homepage probe. The notebook count is fetched **best-effort**
(`_best_effort_notebook_count`) and degrades to a friendly
`Notebook count unavailable (network slow); credentials are valid` line
instead of failing the whole check.

### 2. `_call_rpc` retries connection-establishment failures only

`_call_rpc` already retries 5xx/429 (`HTTPStatusError`) and RPC code-8
`ResourceExhaustedError` with exponential backoff, but transport timeouts
fell straight through. It now also retries `httpx.ConnectError` /
`httpx.ConnectTimeout`.

Read/write timeouts are **deliberately excluded** (`RETRYABLE_CONNECT_ERRORS`
in `core/retry.py`): a connect-phase failure means the server never
received the request, so a retry is always safe — but a read/write timeout
may mean the request was already processed server-side, and blindly
retrying could duplicate side effects on mutating RPCs (notebook create,
source add). The narrow tuple makes that safety boundary explicit and
test-pinned.

## Why this scope

The naive fix ("retry all timeouts") is unsafe because `_call_rpc` is shared
by mutating RPCs. Scoping the retry to connect-phase errors keeps the fix
idempotency-safe, and routing `--check` through the lightweight probe removes
the crash at its source rather than papering over it with a longer timeout.

## Tests

14 new tests:

- `tests/core/test_auth_check.py` — **direct regression for #243**: a real
  `httpx.ReadTimeout` raised from the homepage probe degrades to
  `valid=False, reason="network_error: ReadTimeout"` instead of propagating
  as an uncaught exception. This pins the actual fault line — narrowing the
  `except` in `check_auth` fails this test.
- `tests/core/test_retry.py` — `RETRYABLE_CONNECT_ERRORS` captures
  `ConnectError`/`ConnectTimeout` and excludes `ReadTimeout`/`WriteTimeout`/
  `PoolTimeout` (the safety boundary, asserted against the httpx MRO).
- `tests/core/test_rpc_errors.py` — `_call_rpc` retries a `ConnectTimeout`
  then succeeds; exhausts retries and re-raises; and a `ReadTimeout`
  propagates after a **single** attempt (pins the no-retry-on-read-timeout
  property so a future widening of the retry can't slip through silently).
- `tests/cli/test_login.py` — valid check reports the count; a timed-out
  count degrades gracefully without failing; invalid creds exit 2; a
  network-blip probe exits 2 with a "credentials may still be valid" hint
  (no traceback); `_best_effort_notebook_count` swallows timeout and generic
  errors.

```
uv run pytest tests/cli/test_login.py tests/core/test_retry.py \
  tests/core/test_rpc_errors.py tests/core/test_auth_check.py -q
35 passed

uv run pytest -q
1041 passed, 37 skipped
```

`uv run ruff check` / `uv run ruff format --check` clean on all changed
files; `uv run mypy` introduces no new errors (all pre-existing `--strict`
findings are in untouched functions).

## Live verification

CLI, against the real NotebookLM API (modified build):

```
$ uv run nlm login --check
Checking credentials for profile: default...
✓ Authentication valid!
  Profile: default
  Notebooks found: 375
```

The timeout/degraded paths are inherently transient (that transience is the
bug), so they're pinned by the unit tests rather than reproduced live.

<!-- MCP: TODO — exercise the equivalent path via the MCP server in your
client and paste evidence here before submitting, per CONTRIBUTING.md. -->

## Notes for the maintainer

- No version bump (per CONTRIBUTING.md).
- While testing I hit one **pre-existing** flaky test unrelated to this
  change — `tests/services/test_sources.py::TestListDriveSources::test_per_source_error_does_not_fail_others`
  fails non-deterministically (~1 in 3) even on a clean tree; it asserts an
  order-dependent `side_effect` list against what looks like concurrent
  freshness checks. Left untouched (out of scope) but flagging it.
- Possible follow-up: `_validate_saved_profile` in `cli/main.py` reaches into
  `core.client` / `auth.check_validity()` directly, mirroring the existing
  pre-existing pattern in that function. I kept it consistent with the
  surrounding code rather than re-routing through `services/` in this PR —
  happy to adjust if you'd prefer it go through the service layer.
