### PR TITLE
fix(cdp): verify mapped Chrome owns NLM profile before reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **CDP reuse with foreign Chrome on port 9222 (Issue #244)** — `find_existing_nlm_chrome()` now verifies mapped Chrome PIDs still use the NLM profile's `--user-data-dir` and the expected `--remote-debugging-port`, skips headless automation browsers on all platforms, and clears stale port-map entries instead of reconnecting to unrelated CDP listeners (e.g. agent-browser / Playwright on 9222).
+
 ## [0.8.0] - 2026-06-30
 
 ### Added

--- a/src/notebooklm_tools/utils/cdp.py
+++ b/src/notebooklm_tools/utils/cdp.py
@@ -520,6 +520,86 @@ def is_profile_locked(profile_name: str = "default", profile_dir: Path | None = 
     return lock_file.exists()
 
 
+def _get_process_cmdline(pid: int) -> str | None:
+    """Best-effort process command line for Chrome ownership checks."""
+    system = platform.system()
+    if system == "Linux":
+        try:
+            raw = Path(f"/proc/{pid}/cmdline").read_bytes()
+            return raw.replace(b"\x00", b" ").decode("utf-8", errors="replace").strip()
+        except OSError:
+            return None
+    if system == "Darwin":
+        try:
+            result = subprocess.run(
+                ["ps", "-p", str(pid), "-o", "command="],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+            if result.returncode == 0:
+                return result.stdout.strip()
+        except Exception:
+            return None
+    if system == "Windows":
+        try:
+            result = subprocess.run(
+                [
+                    "powershell",
+                    "-NoProfile",
+                    "-Command",
+                    f'(Get-CimInstance Win32_Process -Filter "ProcessId={pid}").CommandLine',
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+            if result.returncode == 0:
+                cmd = result.stdout.strip()
+                return cmd if cmd else None
+        except Exception:
+            return None
+    return None
+
+
+def _mapped_chrome_owns_profile(pid: int | None, profile_name: str, port: int) -> bool:
+    """Return True when the mapped PID was launched with this profile's user-data-dir."""
+    if pid is None:
+        return True
+
+    chrome_path = get_chrome_path()
+    if chrome_path:
+        profile_dir = _get_profile_dir_for_launch(chrome_path, profile_name)
+    else:
+        from notebooklm_tools.utils.config import get_chrome_profile_dir
+
+        profile_dir = get_chrome_profile_dir(profile_name)
+
+    cmdline = _get_process_cmdline(pid)
+    if cmdline is None:
+        # Can't verify ownership — fail closed so we never attach to a foreign CDP listener.
+        return False
+
+    normalized_cmdline = cmdline.replace("\\", "/")
+    profile_path = str(profile_dir).replace("\\", "/")
+    port_flag = f"--remote-debugging-port={port}"
+
+    if port_flag not in normalized_cmdline:
+        return False
+
+    # Match --user-data-dir=... with optional quotes around the path (common on Windows).
+    for prefix in (f"--user-data-dir={profile_path}", f'--user-data-dir="{profile_path}"'):
+        if prefix in normalized_cmdline:
+            return True
+
+    # Fallback: path appears as a standalone token (snap / unusual launchers).
+    return f" {profile_path}" in f" {normalized_cmdline}" or normalized_cmdline.endswith(
+        profile_path
+    )
+
+
 def find_existing_nlm_chrome(
     port_range: range = CDP_PORT_RANGE, profile_name: str = "default"
 ) -> tuple[int | None, str | None]:
@@ -544,13 +624,35 @@ def find_existing_nlm_chrome(
         if entry.get("profile") != profile_name:
             continue
         port = int(port_str)
-        debugger_url = get_debugger_url(port, timeout=1)
+        version_info = _fetch_cdp_version(port, timeout=1)
+        if not version_info:
+            # Mapped but not responding — stale entry, clean it up
+            _clear_port_map(port)
+            continue
+
+        ua = version_info.get("User-Agent", "")
+        if "Headless" in ua:
+            _logger.debug("Skipping headless mapped browser on port %d", port)
+            _clear_port_map(port)
+            continue
+
+        pid = entry.get("pid")
+        if not _mapped_chrome_owns_profile(pid, profile_name, port):
+            _logger.debug(
+                "Mapped Chrome on port %d (pid=%s) does not own profile '%s'; clearing",
+                port,
+                pid,
+                profile_name,
+            )
+            _clear_port_map(port)
+            continue
+
+        debugger_url = _normalize_ws_url(version_info.get("webSocketDebuggerUrl"))
         if debugger_url:
             _logger.debug(f"Reusing mapped Chrome on port {port} for profile '{profile_name}'")
             return port, debugger_url
-        else:
-            # Mapped but not responding — stale entry, clean it up
-            _clear_port_map(port)
+
+        _clear_port_map(port)
 
     # No mapped instance found for this profile
     return None, None

--- a/tests/test_cdp_port_map.py
+++ b/tests/test_cdp_port_map.py
@@ -1,0 +1,195 @@
+"""Regression tests for CDP port-map profile isolation (Issue #244)."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from notebooklm_tools.utils import cdp
+
+
+@pytest.fixture
+def storage_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr("notebooklm_tools.utils.config.get_storage_dir", lambda: tmp_path)
+    # Keep port-map PIDs alive during tests (pytest PIDs are synthetic).
+    monkeypatch.setattr("os.kill", lambda pid, sig: None)
+    return tmp_path
+
+
+def _write_port_map(storage_dir: Path, data: dict) -> None:
+    map_file = storage_dir / "chrome-port-map.json"
+    map_file.write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_find_existing_nlm_chrome_reuses_only_matching_profile(storage_dir):
+    _write_port_map(
+        storage_dir,
+        {
+            "9222": {"profile": "work", "pid": 111},
+            "9223": {"profile": "default", "pid": 222},
+        },
+    )
+    version = {
+        "webSocketDebuggerUrl": "ws://127.0.0.1:9223/devtools/browser/abc",
+        "User-Agent": "Mozilla/5.0 Chrome/124",
+    }
+
+    with (
+        patch.object(cdp, "_fetch_cdp_version", return_value=version),
+        patch.object(cdp, "_mapped_chrome_owns_profile", return_value=True),
+    ):
+        port, url = cdp.find_existing_nlm_chrome(profile_name="default")
+
+    assert port == 9223
+    assert url == "ws://127.0.0.1:9223/devtools/browser/abc"
+
+
+def test_find_existing_nlm_chrome_ignores_foreign_profile_entries(storage_dir):
+    _write_port_map(storage_dir, {"9222": {"profile": "work", "pid": 111}})
+
+    with patch.object(cdp, "_fetch_cdp_version") as mock_fetch:
+        port, url = cdp.find_existing_nlm_chrome(profile_name="default")
+
+    assert (port, url) == (None, None)
+    mock_fetch.assert_not_called()
+
+
+def test_find_existing_nlm_chrome_clears_stale_unresponsive_port(storage_dir):
+    _write_port_map(storage_dir, {"9222": {"profile": "default", "pid": 111}})
+
+    with patch.object(cdp, "_fetch_cdp_version", return_value=None):
+        port, url = cdp.find_existing_nlm_chrome(profile_name="default")
+
+    assert (port, url) == (None, None)
+    assert json.loads((storage_dir / "chrome-port-map.json").read_text(encoding="utf-8")) == {}
+
+
+def test_find_existing_nlm_chrome_skips_headless_mapped_browser(storage_dir):
+    _write_port_map(storage_dir, {"9222": {"profile": "default", "pid": 111}})
+    version = {
+        "webSocketDebuggerUrl": "ws://127.0.0.1:9222/devtools/browser/abc",
+        "User-Agent": "Mozilla/5.0 HeadlessChrome/124",
+    }
+
+    with patch.object(cdp, "_fetch_cdp_version", return_value=version):
+        port, url = cdp.find_existing_nlm_chrome(profile_name="default")
+
+    assert (port, url) == (None, None)
+    assert json.loads((storage_dir / "chrome-port-map.json").read_text(encoding="utf-8")) == {}
+
+
+def test_find_existing_nlm_chrome_clears_port_when_pid_uses_foreign_profile(storage_dir):
+    _write_port_map(storage_dir, {"9222": {"profile": "default", "pid": 999}})
+    version = {
+        "webSocketDebuggerUrl": "ws://127.0.0.1:9222/devtools/browser/abc",
+        "User-Agent": "Mozilla/5.0 Chrome/124",
+    }
+    profile_dir = storage_dir / "nlm-profile"
+    profile_dir.mkdir()
+    foreign_cmdline = (
+        '"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe" '
+        '--remote-debugging-port=9222 --user-data-dir="C:\\agent-browser-profile"'
+    )
+
+    with (
+        patch.object(cdp, "_fetch_cdp_version", return_value=version),
+        patch.object(cdp, "_get_profile_dir_for_launch", return_value=profile_dir),
+        patch.object(cdp, "get_chrome_path", return_value="chrome.exe"),
+        patch.object(cdp, "_get_process_cmdline", return_value=foreign_cmdline),
+    ):
+        port, url = cdp.find_existing_nlm_chrome(profile_name="default")
+
+    assert (port, url) == (None, None)
+    assert json.loads((storage_dir / "chrome-port-map.json").read_text(encoding="utf-8")) == {}
+
+
+def test_mapped_chrome_owns_profile_matches_user_data_dir_flag(tmp_path, monkeypatch):
+    profile_dir = tmp_path / "chrome-profile"
+    profile_dir.mkdir()
+    monkeypatch.setattr(
+        cdp,
+        "_get_profile_dir_for_launch",
+        lambda _chrome_path, _profile_name: profile_dir,
+    )
+    monkeypatch.setattr(cdp, "get_chrome_path", lambda: "/usr/bin/google-chrome")
+
+    cmdline = f"/usr/bin/google-chrome --remote-debugging-port=9222 --user-data-dir={profile_dir}"
+    with patch.object(cdp, "_get_process_cmdline", return_value=cmdline):
+        assert cdp._mapped_chrome_owns_profile(1234, "default", 9222) is True
+
+
+def test_mapped_chrome_owns_profile_matches_quoted_windows_path(tmp_path, monkeypatch):
+    profile_dir = tmp_path / "John Doe" / "nlm-profile"
+    profile_dir.mkdir(parents=True)
+    monkeypatch.setattr(
+        cdp,
+        "_get_profile_dir_for_launch",
+        lambda _chrome_path, _profile_name: profile_dir,
+    )
+    monkeypatch.setattr(cdp, "get_chrome_path", lambda: "chrome.exe")
+
+    win_path = str(profile_dir).replace("/", "\\")
+    cmdline = (
+        f'"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe" '
+        f'--remote-debugging-port=9222 --user-data-dir="{win_path}"'
+    )
+    with patch.object(cdp, "_get_process_cmdline", return_value=cmdline):
+        assert cdp._mapped_chrome_owns_profile(1234, "default", 9222) is True
+
+
+def test_mapped_chrome_owns_profile_rejects_foreign_user_data_dir(tmp_path, monkeypatch):
+    profile_dir = tmp_path / "nlm-profile"
+    profile_dir.mkdir()
+    monkeypatch.setattr(
+        cdp,
+        "_get_profile_dir_for_launch",
+        lambda _chrome_path, _profile_name: profile_dir,
+    )
+    monkeypatch.setattr(cdp, "get_chrome_path", lambda: "/usr/bin/google-chrome")
+
+    cmdline = (
+        "/usr/bin/google-chrome --remote-debugging-port=9222 "
+        "--user-data-dir=/tmp/agent-browser-profile"
+    )
+    with patch.object(cdp, "_get_process_cmdline", return_value=cmdline):
+        assert cdp._mapped_chrome_owns_profile(1234, "default", 9222) is False
+
+
+def test_mapped_chrome_owns_profile_fails_closed_when_cmdline_unavailable(tmp_path, monkeypatch):
+    profile_dir = tmp_path / "nlm-profile"
+    profile_dir.mkdir()
+    monkeypatch.setattr(
+        cdp,
+        "_get_profile_dir_for_launch",
+        lambda _chrome_path, _profile_name: profile_dir,
+    )
+    monkeypatch.setattr(cdp, "get_chrome_path", lambda: "/usr/bin/google-chrome")
+
+    with patch.object(cdp, "_get_process_cmdline", return_value=None):
+        assert cdp._mapped_chrome_owns_profile(1234, "default", 9222) is False
+
+
+def test_mapped_chrome_owns_profile_rejects_pid_on_wrong_debug_port(tmp_path, monkeypatch):
+    profile_dir = tmp_path / "nlm-profile"
+    profile_dir.mkdir()
+    monkeypatch.setattr(
+        cdp,
+        "_get_profile_dir_for_launch",
+        lambda _chrome_path, _profile_name: profile_dir,
+    )
+    monkeypatch.setattr(cdp, "get_chrome_path", lambda: "/usr/bin/google-chrome")
+
+    cmdline = f"/usr/bin/google-chrome --remote-debugging-port=9223 --user-data-dir={profile_dir}"
+    with patch.object(cdp, "_get_process_cmdline", return_value=cmdline):
+        assert cdp._mapped_chrome_owns_profile(1234, "default", 9222) is False
+
+
+@pytest.mark.skipif(not Path(f"/proc/{os.getpid()}/cmdline").exists(), reason="Linux /proc only")
+def test_get_process_cmdline_reads_linux_proc():
+    cmdline = cdp._get_process_cmdline(os.getpid())
+    assert cmdline is not None
+    assert "python" in cmdline.lower()


### PR DESCRIPTION
## Summary

`find_existing_nlm_chrome()` now validates that a mapped Chrome PID still owns the expected NLM `--user-data-dir` and `--remote-debugging-port` before reconnecting. Headless automation browsers are skipped and stale port-map entries are cleared instead of attaching to unrelated CDP listeners.

Fixes #244

## Motivation

When another tool (agent-browser, Playwright, Puppeteer) runs Chrome with CDP on port 9222, `nlm login` could previously reconnect to that foreign browser and fail with a 403 WebSocket origin error. The port-map fast path needed stronger ownership checks beyond PID liveness.

## Changes

- Add `_get_process_cmdline()` (Linux `/proc`, macOS `ps`, Windows PowerShell CIM)
- Add `_mapped_chrome_owns_profile()` with fail-closed behavior when cmdline is unavailable
- Require matching `--remote-debugging-port` and `--user-data-dir` (supports quoted Windows paths)
- Skip headless mapped browsers and clear stale/unverified port-map entries
- Add 11 regression tests in `tests/test_cdp_port_map.py`
- CHANGELOG entry under Unreleased → Fixed

## Tests

```bash
pytest tests/test_cdp_port_map.py -q
# 11 passed
ruff check src/notebooklm_tools/utils/cdp.py tests/test_cdp_port_map.py
ruff format --check src/notebooklm_tools/utils/cdp.py tests/test_cdp_port_map.py
```

## Notes

- When cmdline inspection fails for a mapped PID, reuse is denied (fail-closed) so we never silently attach to a foreign CDP listener.
- `extract_cookies_via_cdp()` already avoids blind port scanning; this hardens the port-map reuse path.