### PR TITLE
fix: prefer .google.com when flattening duplicate Chrome cookies

### DIFF
--- a/src/notebooklm_tools/core/auth.py
+++ b/src/notebooklm_tools/core/auth.py
@@ -29,7 +29,7 @@ class AuthTokens:
     they can be auto-extracted from the NotebookLM page when needed.
     """
 
-    cookies: dict[str, str]
+    cookies: "dict[str, str] | list[dict]"  # list[dict] preserves per-domain values
     csrf_token: str = ""  # Optional - auto-extracted from page
     session_id: str = ""  # Optional - auto-extracted from page
     build_label: str = ""  # Optional - auto-extracted from page (cfb2h key)
@@ -66,7 +66,9 @@ class AuthTokens:
     @property
     def cookie_header(self) -> str:
         """Get cookies as a header string."""
-        return "; ".join(f"{k}={v}" for k, v in self.cookies.items())
+        from notebooklm_tools.utils.browser import cookies_to_header, flatten_cookies
+
+        return cookies_to_header(flatten_cookies(self.cookies))
 
 
 def get_cache_path() -> Path:
@@ -272,9 +274,12 @@ def parse_cookies_from_chrome_format(cookies_list: list[dict]) -> dict[str, str]
 REQUIRED_COOKIES = ["SID", "HSID", "SSID", "APISID", "SAPISID"]
 
 
-def validate_cookies(cookies: dict[str, str]) -> bool:
-    """Check if required cookies are present."""
-    return all(required in cookies for required in REQUIRED_COOKIES)
+def validate_cookies(cookies: "dict[str, str] | list[dict]") -> bool:
+    """Check if required cookies are present (accepts flat dict or Chrome list)."""
+    from notebooklm_tools.utils.browser import flatten_cookies
+
+    flat = flatten_cookies(cookies)
+    return all(required in flat for required in REQUIRED_COOKIES)
 
 
 # =============================================================================
@@ -500,11 +505,9 @@ class AuthManager:
 
     def get_cookies(self) -> dict[str, str]:
         """Get cookies for the current profile as simple dict."""
-        profile = self.load_profile()
-        if isinstance(profile.cookies, list):
-            # Convert list[dict] to dict[str, str]
-            return {c["name"]: c["value"] for c in profile.cookies if "name" in c and "value" in c}
-        return profile.cookies
+        from notebooklm_tools.utils.browser import flatten_cookies
+
+        return flatten_cookies(self.load_profile().cookies)
 
     def get_raw_cookies(self) -> list[dict] | dict[str, str]:
         """Get raw cookies (list or dict)."""
@@ -519,11 +522,11 @@ class AuthManager:
 
     def get_headers(self) -> dict[str, str]:
         """Get headers for NotebookLM API requests."""
-        from notebooklm_tools.utils.browser import cookies_to_header
+        from notebooklm_tools.utils.browser import cookies_to_header, flatten_cookies
 
         profile = self.load_profile()
         headers = {
-            "Cookie": cookies_to_header(profile.cookies),
+            "Cookie": cookies_to_header(flatten_cookies(profile.cookies)),
             "Content-Type": "application/x-www-form-urlencoded",
             "Origin": get_base_url(),
             "Referer": f"{get_base_url()}/",
@@ -627,12 +630,9 @@ def _fetch_notebooklm_homepage(
     """
     import httpx
 
-    from notebooklm_tools.utils.browser import cookies_to_header
+    from notebooklm_tools.utils.browser import cookies_to_header, flatten_cookies
 
-    if isinstance(cookies, list):
-        cookie_dict = {c["name"]: c["value"] for c in cookies if "name" in c and "value" in c}
-    else:
-        cookie_dict = cookies
+    cookie_dict = flatten_cookies(cookies)
 
     headers = _PAGE_FETCH_HEADERS.copy()
 
@@ -691,11 +691,10 @@ def check_auth(
             profile=profile,
         )
 
-    # Convert to simple dict for the fetch helper
-    if isinstance(p.cookies, list):
-        cookie_dict = {c["name"]: c["value"] for c in p.cookies if "name" in c and "value" in c}
-    else:
-        cookie_dict = p.cookies
+    # Convert to simple dict for the fetch helper (domain-aware: prefer .google.com)
+    from notebooklm_tools.utils.browser import flatten_cookies
+
+    cookie_dict = flatten_cookies(p.cookies)
 
     if not cookie_dict:
         return AuthCheckResult(valid=False, reason="no_tokens", live=live, profile=profile)

--- a/src/notebooklm_tools/core/base.py
+++ b/src/notebooklm_tools/core/base.py
@@ -473,14 +473,12 @@ class BaseClient:
 
     def _get_cookie_header(self) -> str:
         """Get Cookie header string (backward compatibility)."""
-        if isinstance(self.cookies, list):
-            # Flatten to simple dict for header
-            simple_cookies = {
-                c["name"]: c["value"] for c in self.cookies if "name" in c and "value" in c
-            }
-            return "; ".join(f"{k}={v}" for k, v in simple_cookies.items())
-        else:
-            return "; ".join(f"{k}={v}" for k, v in self.cookies.items())
+        from notebooklm_tools.utils.browser import flatten_cookies
+
+        # Domain-aware flatten: prefer .google.com when Chrome exports the same
+        # cookie name across .youtube.com / .google.com.vn / etc.
+        simple_cookies = flatten_cookies(self.cookies)
+        return "; ".join(f"{k}={v}" for k, v in simple_cookies.items())
 
     # =========================================================================
     # HTTP Client Management

--- a/src/notebooklm_tools/core/utils.py
+++ b/src/notebooklm_tools/core/utils.py
@@ -117,14 +117,17 @@ def parse_timestamp(ts_array: list | None) -> str | None:
 
 def extract_cookies_from_chrome_export(cookie_data: str | list[dict]) -> dict[str, str]:
     """Extract cookies from Chrome export format (JSON) or header string."""
+    from notebooklm_tools.utils.browser import flatten_cookies
+
     if isinstance(cookie_data, list):
-        return {c.get("name"): c.get("value") for c in cookie_data if "name" in c and "value" in c}
+        # Chrome export carries domains; prefer .google.com on name collisions.
+        return flatten_cookies(cookie_data)
     if not isinstance(cookie_data, str):
         return {}
     try:
         data = json.loads(cookie_data)
         if isinstance(data, list):
-            return {c.get("name"): c.get("value") for c in data if "name" in c and "value" in c}
+            return flatten_cookies(data)
         if isinstance(data, dict):
             return {str(k): str(v) for k, v in data.items()}
     except json.JSONDecodeError:

--- a/src/notebooklm_tools/services/auth.py
+++ b/src/notebooklm_tools/services/auth.py
@@ -474,11 +474,11 @@ class AuthHealthChecker:
 
     @staticmethod
     def _cookies_to_dict(profile: Any) -> dict[str, str]:
-        """Convert profile cookies to a plain dict."""
-        if isinstance(profile.cookies, list):
-            return {c["name"]: c["value"] for c in profile.cookies if "name" in c and "value" in c}
-        if isinstance(profile.cookies, dict):
-            return profile.cookies
+        """Convert profile cookies to a plain dict (domain-aware: prefer .google.com)."""
+        from notebooklm_tools.utils.browser import flatten_cookies
+
+        if isinstance(profile.cookies, (list, dict)):
+            return flatten_cookies(profile.cookies)
         return {}
 
     @staticmethod

--- a/src/notebooklm_tools/utils/browser.py
+++ b/src/notebooklm_tools/utils/browser.py
@@ -134,17 +134,49 @@ def _try_parse_netscape_cookies(content: str) -> dict[str, str] | None:
     return cookies if valid_lines > 0 else None
 
 
+def flatten_cookies(cookies: "list[dict] | dict[str, str]") -> dict[str, str]:
+    """Flatten a cookie list to {name: value}, preferring the .google.com value.
+
+    Chrome exports duplicate auth cookies (SID, HSID, SSID, APISID, ...) across
+    .google.com, .youtube.com, .google.com.vn, etc. — often with *different*
+    values per domain. A naive ``{c["name"]: c["value"] for c in cookies}`` lets
+    whichever domain happens to be last in the list win, which can silently
+    select another site's session token. NotebookLM lives on .google.com, so
+    that domain always wins here; a non-google duplicate only fills a name no
+    .google.com cookie has claimed.
+    """
+    if isinstance(cookies, dict):
+        return cookies
+
+    out: dict[str, str] = {}
+    google_locked: set[str] = set()
+    for c in cookies:
+        name = c.get("name")
+        value = c.get("value")
+        if not name or value is None:
+            continue
+        is_google = (c.get("domain") or "").lstrip(".") == "google.com"
+        if name in google_locked and not is_google:
+            continue  # keep the .google.com value already chosen
+        out[name] = value
+        if is_google:
+            google_locked.add(name)
+    return out
+
+
 def cookies_to_header(cookies: dict[str, str]) -> str:
     """Convert cookies dict to Cookie header value."""
     return "; ".join(f"{name}={value}" for name, value in cookies.items())
 
 
-def validate_notebooklm_cookies(cookies: dict[str, str]) -> bool:
+def validate_notebooklm_cookies(cookies: "dict[str, str] | list[dict]") -> bool:
     """
     Check if cookies appear to be valid for NotebookLM.
 
     This is a basic check - actual validation requires making an API call.
+    Accepts a flat dict or a Chrome-export list[dict].
     """
+    cookies = flatten_cookies(cookies)
     # Check for essential Google auth cookies
     essential_patterns = ["SID", "HSID", "SSID", "APISID", "SAPISID"]
     found = sum(1 for pattern in essential_patterns if any(pattern in name for name in cookies))

--- a/src/notebooklm_tools/utils/cdp.py
+++ b/src/notebooklm_tools/utils/cdp.py
@@ -1527,6 +1527,7 @@ def run_headless_auth(
     """
     # Import here to avoid circular imports
     from notebooklm_tools.core.auth import AuthTokens, save_tokens_to_cache, validate_cookies
+    from notebooklm_tools.utils.browser import flatten_cookies
 
     # Check if profile exists with saved login
     if not has_chrome_profile(profile_name):
@@ -1584,11 +1585,11 @@ def run_headless_auth(
         if not ready:
             return None
 
-        # Extract cookies
+        # Extract cookies. Keep the raw list[dict] (domain preserved) for storage
+        # so downstream domain-aware handling can pick the .google.com value —
+        # getAllCookies returns duplicate names across .youtube.com / .google.com.vn.
         cookies_list = get_page_cookies(ws_url)
-        cookies = {c["name"]: c["value"] for c in cookies_list}
-
-        if not validate_cookies(cookies):
+        if not validate_cookies(flatten_cookies(cookies_list)):
             return None
 
         # Get page HTML for CSRF extraction
@@ -1598,7 +1599,7 @@ def run_headless_auth(
 
         # Create and save tokens
         tokens = AuthTokens(
-            cookies=cookies,
+            cookies=cookies_list,
             csrf_token=csrf_token or "",
             session_id=session_id or "",
             extracted_at=time.time(),

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -19,5 +19,28 @@ def test_extract_cookies_header_string():
     assert result == {"name": "value", "other": "foo"}
 
 
+def test_extract_cookies_from_chrome_export_list_prefers_google_com():
+    """Bug 1: the NOTEBOOKLM_COOKIES env / Chrome-export path must pick the
+    .google.com value on cross-domain name collisions, not whichever is last."""
+    export = [
+        {"name": "SID", "value": "vn", "domain": ".google.com.vn"},
+        {"name": "SID", "value": "goog", "domain": ".google.com"},
+        {"name": "SID", "value": "yt", "domain": ".youtube.com"},  # last
+    ]
+    assert extract_cookies_from_chrome_export(export)["SID"] == "goog"
+
+
+def test_extract_cookies_from_chrome_export_json_list_prefers_google_com():
+    import json as _json
+
+    export = _json.dumps(
+        [
+            {"name": "HSID", "value": "yt", "domain": ".youtube.com"},
+            {"name": "HSID", "value": "goog", "domain": ".google.com"},
+        ]
+    )
+    assert extract_cookies_from_chrome_export(export)["HSID"] == "goog"
+
+
 def test_rpc_names_exists():
     assert "wXbhsf" in RPC_NAMES

--- a/tests/test_auth_browser.py
+++ b/tests/test_auth_browser.py
@@ -69,3 +69,110 @@ def test_saved_legacy_browser_backend_is_read_from_metadata(tmp_path, monkeypatc
     auth.metadata_file.write_text(json.dumps(metadata), encoding="utf-8")
 
     assert _get_saved_browser_backend("default") == "firefox_playwright"
+
+
+def test_flatten_cookies_prefers_google_com_over_other_domains():
+    """Bug 1 regression: Chrome exports SID/HSID/... duplicated across
+    .youtube.com / .google.com / .google.com.vn with *different* values. A naive
+    {name: value} flatten lets the last domain win, selecting another site's
+    token. flatten_cookies must always pick the .google.com value regardless of
+    list order.
+    """
+    from notebooklm_tools.utils.browser import flatten_cookies
+
+    cookies = [
+        {"name": "SID", "value": "yt_sid", "domain": ".youtube.com"},
+        {"name": "SID", "value": "goog_sid", "domain": ".google.com"},
+        {"name": "SID", "value": "vn_sid", "domain": ".google.com.vn"},  # last in list
+        {"name": "HSID", "value": "yt_hsid", "domain": ".youtube.com"},
+        {"name": "HSID", "value": "goog_hsid", "domain": ".google.com"},
+        {"name": "ONLY_VN", "value": "vn_only", "domain": ".google.com.vn"},
+    ]
+
+    flat = flatten_cookies(cookies)
+
+    assert flat["SID"] == "goog_sid"  # not vn_sid (naive flatten's answer)
+    assert flat["HSID"] == "goog_hsid"
+    assert flat["ONLY_VN"] == "vn_only"  # non-google name still passes through
+
+
+def test_flatten_cookies_passthrough_dict_and_skips_malformed():
+    from notebooklm_tools.utils.browser import flatten_cookies
+
+    assert flatten_cookies({"SID": "x"}) == {"SID": "x"}
+    assert flatten_cookies([{"name": "SID"}, {"value": "no_name"}]) == {}
+
+
+def test_flatten_cookies_empty_list_and_empty_value():
+    """Empty list -> {}; a cookie with empty-string value is kept (not dropped)."""
+    from notebooklm_tools.utils.browser import flatten_cookies
+
+    assert flatten_cookies([]) == {}
+    assert flatten_cookies([{"name": "X", "value": ""}]) == {"X": ""}
+
+
+# --- Hardening: dict-only helpers must tolerate Chrome list[dict] --------------
+# The stored auth format switched to domain-preserving list[dict] (Bug 1 fix),
+# so every "is this a valid cookie set" helper must accept a list too.
+
+
+def test_validate_cookies_accepts_chrome_list():
+    from notebooklm_tools.core.auth import validate_cookies
+
+    chrome_list = [
+        {"name": n, "value": "v", "domain": ".google.com"}
+        for n in ("SID", "HSID", "SSID", "APISID", "SAPISID")
+    ]
+    assert validate_cookies(chrome_list) is True
+    assert validate_cookies(chrome_list[:2]) is False  # missing required names
+    assert validate_cookies({"SID": "v", "HSID": "v", "SSID": "v", "APISID": "v", "SAPISID": "v"})
+
+
+def test_validate_notebooklm_cookies_accepts_chrome_list():
+    from notebooklm_tools.utils.browser import validate_notebooklm_cookies
+
+    chrome_list = [
+        {"name": "SID", "value": "v", "domain": ".google.com"},
+        {"name": "HSID", "value": "v", "domain": ".google.com"},
+    ]
+    assert validate_notebooklm_cookies(chrome_list) is True
+    assert validate_notebooklm_cookies([]) is False
+
+
+def test_auth_tokens_cookie_header_flattens_list():
+    """AuthTokens now stores list[dict] (from headless auth); its cookie_header
+    property must flatten domain-aware instead of blowing up on .items()."""
+    from notebooklm_tools.core.auth import AuthTokens
+
+    tokens = AuthTokens(
+        cookies=[
+            {"name": "SID", "value": "vn", "domain": ".google.com.vn"},
+            {"name": "SID", "value": "goog", "domain": ".google.com"},
+        ]
+    )
+    header = tokens.cookie_header
+    assert "SID=goog" in header
+    assert "vn" not in header
+
+
+def test_get_headers_flattens_list_cookies(tmp_path, monkeypatch):
+    """A profile whose cookies are stored as list[dict] must still produce a
+    correct Cookie header (prefer .google.com), not crash on .items()."""
+    from notebooklm_tools.core.auth import AuthManager
+
+    monkeypatch.setattr("notebooklm_tools.utils.config.get_storage_dir", lambda: tmp_path)
+
+    auth = AuthManager("default")
+    auth.save_profile(
+        cookies=[
+            {"name": "SID", "value": "goog", "domain": ".google.com"},
+            {"name": "SID", "value": "yt", "domain": ".youtube.com"},
+        ],
+        csrf_token="csrf1",
+        email="u@example.com",
+    )
+
+    headers = auth.get_headers()
+    assert "SID=goog" in headers["Cookie"]
+    assert "yt" not in headers["Cookie"]
+    assert headers["X-Goog-Csrf-Token"] == "csrf1"


### PR DESCRIPTION
## Problem

Chrome exports cookies for every domain it holds. The Google auth cookies
(`SID`, `HSID`, `SSID`, `APISID`, `SAPISID`) therefore appear multiple times —
once for `.google.com`, again for `.youtube.com`, `.google.com.vn`, etc., each
with a *different* value.

When we flatten that `list[dict]` into a plain `{name: value}` dict, the last
domain in the list wins. If that isn't `.google.com`, we hand NotebookLM the
wrong token and auth fails intermittently — depending on the cookie ordering the
browser happened to export.

## Fix

Add `flatten_cookies()` which keeps the `.google.com` value whenever a name
collides across domains, and route every `list -> dict` conversion through it:

- `core/auth.py` — profile cookie handling
- `core/base.py` — outgoing request header
- `utils/cdp.py` — headless capture
- `core/utils.py` — `NOTEBOOKLM_COOKIES` env / Chrome-export parser
- `services/auth.py` — service-layer normalization

The domain-aware `httpx.Cookies` path (`BaseClient._get_httpx_cookies`) already
handled this correctly and is unchanged.

## Tests

- `flatten_cookies` prefers `.google.com` over other domains, plus passthrough
  (already-flat dict) and empty-list/empty-value edge cases
- `validate_cookies` / `validate_notebooklm_cookies` accept the raw Chrome
  `list[dict]` shape
- Chrome-export parser (`extract_cookies_from_chrome_export`) prefers
  `.google.com` for both the list and JSON-list inputs

Full suite green, ruff clean.
