### PR TITLE
fix: confirm login --check expiry against the API before failing

### DIFF
--- a/src/notebooklm_tools/core/auth.py
+++ b/src/notebooklm_tools/core/auth.py
@@ -720,17 +720,28 @@ def check_auth(
         resp = _fetch_notebooklm_homepage(cookie_dict, timeout=timeout)
 
         final_url = str(resp.url)
+        redirected_to_login = "accounts.google.com" in final_url
 
-        if "accounts.google.com" in final_url:
+        if not redirected_to_login and resp.status_code == 200:
+            # Clean authenticated homepage: fast positive. Extract fresh CSRF
+            # while we're here (nice side-effect) and record last_validated.
+            csrf = extract_csrf_from_page_source(resp.text) or ""
+            manager.save_profile(
+                cookies=p.cookies,
+                csrf_token=csrf or p.csrf_token,
+                session_id=p.session_id,
+                email=p.email,
+                build_label=p.build_label,
+            )
             return AuthCheckResult(
-                valid=False,
-                reason="expired",
+                valid=True,
+                reason=None,
                 live=True,
                 profile=profile,
-                details={"final_url": final_url},
+                details={"csrf_token": csrf} if csrf else None,
             )
 
-        if resp.status_code != 200:
+        if not redirected_to_login:
             return AuthCheckResult(
                 valid=False,
                 reason=f"http_{resp.status_code}",
@@ -738,25 +749,10 @@ def check_auth(
                 profile=profile,
             )
 
-        # Try to extract fresh CSRF while we're here (nice side-effect)
-        csrf = extract_csrf_from_page_source(resp.text) or ""
-
-        # Update last_validated so that future non-live checks are accurate
-        manager.save_profile(
-            cookies=p.cookies,
-            csrf_token=csrf or p.csrf_token,
-            session_id=p.session_id,
-            email=p.email,
-            build_label=p.build_label,
-        )
-
-        return AuthCheckResult(
-            valid=True,
-            reason=None,
-            live=True,
-            profile=profile,
-            details={"csrf_token": csrf} if csrf else None,
-        )
+        # Redirected to Google login. This is NOT reliable proof of expiry:
+        # Google bounces some live sessions here while the batchexecute API
+        # still accepts the very same cookies. Confirm with the authoritative
+        # RPC before declaring the session dead. Falls through to the probe.
 
     except Exception as exc:
         # Network / timeout / etc. — be conservative but do not lie.
@@ -768,6 +764,59 @@ def check_auth(
             profile=profile,
             details={"exception": str(exc)},
         )
+
+    # Homepage bounced to login. Confirm against the same batchexecute RPC that
+    # real operations use — the source of truth for whether cookies still work.
+    try:
+        from notebooklm_tools.core.client import NotebookLMClient
+        from notebooklm_tools.core.exceptions import AuthenticationError
+
+        client = NotebookLMClient(
+            cookies=p.cookies,
+            csrf_token=p.csrf_token or "",
+            session_id=p.session_id or "",
+            build_label=p.build_label or "",
+        )
+        try:
+            client.list_notebooks()  # raises AuthenticationError on dead cookies
+            refreshed_csrf = client.csrf_token
+            refreshed_session = client._session_id
+            refreshed_bl = client._bl
+        finally:
+            client.close()
+    except AuthenticationError:
+        return AuthCheckResult(
+            valid=False,
+            reason="expired",
+            live=True,
+            profile=profile,
+            details={"final_url": final_url},
+        )
+    except Exception as exc:
+        return AuthCheckResult(
+            valid=False,
+            reason=f"network_error: {type(exc).__name__}",
+            live=True,
+            profile=profile,
+            details={"exception": str(exc)},
+        )
+
+    # RPC succeeded: session is live despite the homepage redirect. Persist any
+    # tokens the client refreshed so future non-live checks stay accurate.
+    manager.save_profile(
+        cookies=p.cookies,
+        csrf_token=refreshed_csrf or p.csrf_token,
+        session_id=refreshed_session or p.session_id,
+        email=p.email,
+        build_label=refreshed_bl or p.build_label,
+    )
+    return AuthCheckResult(
+        valid=True,
+        reason=None,
+        live=True,
+        profile=profile,
+        details={"recovered_via": "rpc"},
+    )
 
 
 # Note: AuthHealthChecker, AuthProbeResult, AuthHealthReport live in

--- a/tests/core/test_auth_check.py
+++ b/tests/core/test_auth_check.py
@@ -84,7 +84,13 @@ class TestCheckAuthAPI:
             assert result.details.get("csrf_token") == "csrf123abc"
 
     def test_check_auth_live_true_detects_expired_redirect(self, tmp_path, monkeypatch):
-        """The only reliable way to know cookies are dead is seeing the redirect."""
+        """Dead cookies: homepage redirects AND the authoritative RPC rejects them.
+
+        A homepage redirect alone is no longer trusted (Google bounces live
+        sessions there too); "expired" requires the RPC probe to also fail.
+        """
+        from notebooklm_tools.core.exceptions import AuthenticationError
+
         monkeypatch.setattr("notebooklm_tools.utils.config.get_storage_dir", lambda: tmp_path)
 
         mgr = AuthManager("default")
@@ -96,13 +102,21 @@ class TestCheckAuthAPI:
                 "APISID": "dead",
                 "SAPISID": "dead",
             },
+            csrf_token="stale123",  # present on disk, but rejected by the API
+            session_id="sess123",
             email="test@example.com",
         )
 
-        with patch("httpx.Client") as MockClient:
+        with (
+            patch("httpx.Client") as MockClient,
+            patch(
+                "notebooklm_tools.core.client.NotebookLMClient.list_notebooks",
+                side_effect=AuthenticationError("dead"),
+            ),
+        ):
             client = MockClient.return_value.__enter__.return_value
 
-            # Simulate Google login redirect (the authoritative failure mode)
+            # Simulate Google login redirect
             req = httpx.Request("GET", "https://accounts.google.com/ServiceLogin")
             resp = httpx.Response(200, request=req, text="login page here")
             client.get.return_value = resp
@@ -112,6 +126,65 @@ class TestCheckAuthAPI:
             assert result.valid is False
             assert result.reason == "expired"
             assert result.live is True
+
+    def test_check_auth_live_true_redirect_but_rpc_alive_is_valid(self, tmp_path, monkeypatch):
+        """Regression: homepage redirects to login, but the batchexecute RPC
+        accepts the same cookies. This is the false-negative that made
+        `nlm login --check` wrongly report "expired" for a working account.
+        The RPC is authoritative, so the verdict must be valid.
+        """
+        monkeypatch.setattr("notebooklm_tools.utils.config.get_storage_dir", lambda: tmp_path)
+
+        mgr = AuthManager("default")
+        mgr.save_profile(
+            cookies={"SID": "x", "HSID": "x", "SSID": "x", "APISID": "x", "SAPISID": "x"},
+            csrf_token="csrf123",
+            session_id="sess123",
+            email="test@example.com",
+        )
+
+        with (
+            patch("httpx.Client") as MockClient,
+            patch(
+                "notebooklm_tools.core.client.NotebookLMClient.list_notebooks",
+                return_value=[],
+            ),
+        ):
+            client = MockClient.return_value.__enter__.return_value
+            req = httpx.Request("GET", "https://accounts.google.com/ServiceLogin")
+            client.get.return_value = httpx.Response(200, request=req, text="login page")
+
+            result = check_auth(live=True)
+
+            assert result.valid is True
+            assert result.reason is None
+            assert result.live is True
+
+    def test_check_auth_live_true_non_redirect_non_200_reports_http_error(
+        self, tmp_path, monkeypatch
+    ):
+        """Homepage answers with a non-200 that is NOT a login redirect (e.g. a
+        500 from Google) -> report http_<status> without an RPC probe. Pins the
+        branch split introduced when redirect stopped implying expiry.
+        """
+        monkeypatch.setattr("notebooklm_tools.utils.config.get_storage_dir", lambda: tmp_path)
+
+        mgr = AuthManager("default")
+        mgr.save_profile(
+            cookies={"SID": "x", "HSID": "x", "SSID": "x", "APISID": "x", "SAPISID": "x"},
+            email="test@example.com",
+        )
+
+        with patch("httpx.Client") as MockClient:
+            client = MockClient.return_value.__enter__.return_value
+            req = httpx.Request("GET", "https://notebooklm.google.com/")
+            client.get.return_value = httpx.Response(500, request=req, text="oops")
+
+            result = check_auth(live=True)
+
+        assert result.valid is False
+        assert result.reason == "http_500"
+        assert result.live is True
 
     def test_check_auth_live_true_degrades_on_read_timeout(self, tmp_path, monkeypatch):
         """Regression for #243: a real httpx.ReadTimeout from the homepage probe


### PR DESCRIPTION
## Problem

`nlm login --check` reported cookies as **expired** while they were perfectly
live — a direct API call returned all notebooks fine.

Since v0.8.1 (#243), `check_auth` decided validity solely from a homepage probe:
a redirect to the login page was treated as "cookies dead". But Google bounces
*even live sessions* to the login page, so the redirect is inconclusive on its
own — producing false "expired" results.

## Fix

Treat the homepage redirect as a *signal*, not a verdict:

- **Clean 200 homepage** → fast path unchanged (extract CSRF, save, valid). No
  extra RPC.
- **Redirect to login** → confirm with a real `list_notebooks()` call before
  declaring the profile dead. On success, refresh CSRF / session / build-label
  from that call and return valid.
- **Network / timeout during the probe** → degrade to `network_error`
  ("credentials may still be valid"), never a false `expired` and never a crash —
  preserving the slow-account contract from #243.

## Tests

- redirect + dead RPC → `expired`
- redirect + live RPC → valid (recovered via RPC)
- non-redirect non-200 → `http_<status>`
- probe read-timeout → `network_error`, not `expired`

Full suite green, ruff clean.
