### PR TITLE
fix: auto-rotate cookies before RPC calls; stop tests corrupting real auth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ save_auth_tokens(cookies=<cookie_header>)
 | `NOTEBOOKLM_BL` | No | Override for build label / bl URL param (auto-extracted from page) |
 | `NOTEBOOKLM_HL` | No | Interface language and default artifact language (default: `en`) |
 | `NOTEBOOKLM_RPC_OVERRIDES` | No | Hot-patch rotated batchexecute RPC method IDs without a release. JSON object mapping `BaseClient` RPC attribute names to new IDs, e.g. `{"RPC_LIST_NOTEBOOKS": "abc123"}` |
+| `NOTEBOOKLM_CHROME_PROFILE_DIR` | No | Absolute path to a fixed Chrome user-data-dir to reuse for browser-based auth (interactive login and headless refresh), instead of the tool's self-managed `chrome-profile(s)/` directory. Useful when you already have a Chrome profile logged into NotebookLM elsewhere. |
 
 ### Resilience: rotated RPC IDs
 

--- a/src/notebooklm_tools/core/base.py
+++ b/src/notebooklm_tools/core/base.py
@@ -847,6 +847,8 @@ class BaseClient:
             )
 
         client = self._get_client()
+        if not _retry and _server_retry == 0:
+            self._maybe_rotate_cookies(client)
         body = self._build_request_body(rpc_id, params)
         url = self._build_url(rpc_id, path)
 
@@ -1154,6 +1156,34 @@ class BaseClient:
         except Exception as e:
             # Non-critical: caching is an optimization, but log at debug level
             logger.debug(f"Failed to update auth token cache: {e}")
+
+    def _maybe_rotate_cookies(self, client: httpx.Client) -> None:
+        """Best-effort cookie rotation before RPC calls.
+
+        Calls Google's RotateCookies endpoint to keep *PSIDTS cookies fresh.
+        Rate-limited to once per 60s by the cookie_rotation module.
+        Non-fatal: failures are logged at debug level and the RPC proceeds.
+        """
+        if not self.cookies:
+            return
+
+        from .cookie_rotation import rotate_google_cookies, snapshot_cookie_input
+
+        result = rotate_google_cookies(client, timeout=3.0)
+        if not result.success:
+            return
+
+        with self._state_lock:
+            self.cookies = snapshot_cookie_input(self.cookies, client.cookies)
+        try:
+            from .auth import load_cached_tokens, save_tokens_to_cache
+
+            cached = load_cached_tokens()
+            if cached:
+                cached.cookies = self.cookies
+                save_tokens_to_cache(cached, silent=True)
+        except Exception as e:
+            logger.debug("Failed to persist rotated cookies: %s", e)
 
     def _try_reload_or_headless_auth(self) -> bool:
         """Try to recover authentication by reloading from disk or running headless auth.

--- a/src/notebooklm_tools/mcp/server.py
+++ b/src/notebooklm_tools/mcp/server.py
@@ -43,7 +43,7 @@ mcp = FastMCP(
     name="notebooklm",
     instructions="""NotebookLM MCP - Access NotebookLM (notebooklm.google.com).
 
-**Auth:** If you get authentication errors, run `nlm login` via your Bash/terminal tool. This is the automated authentication method that handles everything. Only use save_auth_tokens as a fallback if the CLI fails.
+**Auth:** If auth expires, call `refresh_auth` first. If that fails, run `nlm login` in terminal.
 **Account Switching:** To switch Google Accounts for the MCP server, run `nlm login switch <profile>` in Bash. The MCP server instantly uses the active default profile.
 **Confirmation:** Tools with confirm param require user approval before setting confirm=True.
 **Studio:** After creating audio/video/infographic/slides, poll studio_status for completion.

--- a/src/notebooklm_tools/utils/config.py
+++ b/src/notebooklm_tools/utils/config.py
@@ -121,10 +121,20 @@ def get_chrome_profile_dir(profile_name: str = "default") -> Path:
     Each NLM profile gets its own Chrome user-data-dir so different
     Google accounts can be used for different profiles.
 
+    ``NOTEBOOKLM_CHROME_PROFILE_DIR`` overrides this with a fixed,
+    already-authenticated Chrome user-data-dir (e.g. one you set up and
+    logged into NotebookLM by hand), instead of the tool's self-managed
+    profile directory.
+
     For backward compatibility, the "default" profile uses the old
     chrome-profile/ directory if it exists, keeping single-profile
     users' experience unchanged.
     """
+    if env_dir := os.environ.get("NOTEBOOKLM_CHROME_PROFILE_DIR"):
+        chrome_dir = Path(env_dir)
+        safe_mkdir(chrome_dir, parents=True)
+        return chrome_dir
+
     storage = get_storage_dir()
 
     # Backward compatibility: use old location for default profile if it exists

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+"""Shared test fixtures."""
+
+import pytest
+
+from notebooklm_tools.core.cookie_rotation import DISABLE_ROTATE_COOKIES_ENV
+
+
+@pytest.fixture(autouse=True)
+def _isolate_storage(monkeypatch, tmp_path):
+    """Point all storage (~/.notebooklm-mcp-cli) at a per-test temp dir.
+
+    Several code paths (e.g. BaseClient._update_cached_tokens, headless auth)
+    write to the real auth cache and Chrome profile. Without this guard, tests
+    that exercise them corrupt the developer's real login (see
+    test_refresh_auth_tokens_success, which used to overwrite auth.json with
+    fake test tokens).
+    """
+    monkeypatch.setenv("NOTEBOOKLM_MCP_CLI_PATH", str(tmp_path / "storage"))
+
+
+@pytest.fixture(autouse=True)
+def _disable_cookie_rotation(monkeypatch):
+    """Keep tests from hitting accounts.google.com.
+
+    BaseClient._call_rpc rotates Google cookies before real RPC calls; a test
+    with a mocked HTTP client could otherwise "succeed" at rotation against
+    the mock. Tests that exercise rotation itself re-enable it with
+    monkeypatch.delenv.
+    """
+    monkeypatch.setenv(DISABLE_ROTATE_COOKIES_ENV, "1")

--- a/tests/core/test_cookie_rotation.py
+++ b/tests/core/test_cookie_rotation.py
@@ -12,6 +12,7 @@ from notebooklm_tools.core.cookie_rotation import (
 
 
 def test_rotate_google_cookies_posts_expected_request(monkeypatch):
+    monkeypatch.delenv(DISABLE_ROTATE_COOKIES_ENV, raising=False)
     seen: dict[str, object] = {}
 
     def handler(request: httpx.Request) -> httpx.Response:

--- a/tests/core/test_rpc_cookie_rotation.py
+++ b/tests/core/test_rpc_cookie_rotation.py
@@ -1,0 +1,117 @@
+"""Tests for automatic cookie rotation in BaseClient._call_rpc."""
+
+from unittest.mock import patch
+
+import httpx
+
+from notebooklm_tools.core.base import BaseClient
+from notebooklm_tools.core.cookie_rotation import CookieRotationResult
+
+
+def _client(cookies=None):
+    if cookies is None:
+        cookies = {"SID": "old"}
+    with patch.object(BaseClient, "_refresh_auth_tokens"):
+        return BaseClient(cookies=cookies, csrf_token="t")
+
+
+def _fake_resp():
+    return type("R", (), {"text": "", "status_code": 200, "raise_for_status": lambda self: None})()
+
+
+OK_CHUNK = [[["wrb.fr", "EXPECTED", "[1]", None, None, None, "generic"]]]
+
+
+def test_call_rpc_rotates_cookies_before_first_attempt():
+    client = _client()
+
+    with (
+        patch.object(client, "_get_client") as mock_get_client,
+        patch.object(client, "_maybe_rotate_cookies") as mock_rotate,
+        patch.object(client, "_parse_response", return_value=OK_CHUNK),
+    ):
+        mock_get_client.return_value.post.return_value = _fake_resp()
+        client._call_rpc("EXPECTED", [])
+
+    mock_rotate.assert_called_once_with(mock_get_client.return_value)
+
+
+def test_call_rpc_does_not_rotate_on_auth_retry():
+    client = _client()
+
+    with (
+        patch.object(client, "_get_client") as mock_get_client,
+        patch.object(client, "_maybe_rotate_cookies") as mock_rotate,
+        patch.object(client, "_parse_response", return_value=OK_CHUNK),
+    ):
+        mock_get_client.return_value.post.return_value = _fake_resp()
+        client._call_rpc("EXPECTED", [], _retry=True)
+
+    mock_rotate.assert_not_called()
+
+
+def test_call_rpc_rotates_once_across_connect_timeout_retries():
+    client = _client()
+
+    with (
+        patch.object(client, "_get_client") as mock_get_client,
+        patch.object(client, "_maybe_rotate_cookies") as mock_rotate,
+        patch.object(client, "_parse_response", return_value=OK_CHUNK),
+        patch("time.sleep"),
+    ):
+        mock_get_client.return_value.post.side_effect = [
+            httpx.ConnectTimeout("connect timed out"),
+            _fake_resp(),
+        ]
+        client._call_rpc("EXPECTED", [])
+
+    mock_rotate.assert_called_once()
+
+
+def test_maybe_rotate_cookies_success_updates_cookies_and_cache():
+    client = _client(cookies={"SID": "old"})
+    http_client = httpx.Client()
+    http_client.cookies.set("SID", "fresh", domain=".google.com")
+
+    cached = type("T", (), {"cookies": {"SID": "old"}})()
+
+    with (
+        patch(
+            "notebooklm_tools.core.cookie_rotation.rotate_google_cookies",
+            return_value=CookieRotationResult(attempted=True, success=True, status_code=200),
+        ),
+        patch("notebooklm_tools.core.auth.load_cached_tokens", return_value=cached),
+        patch("notebooklm_tools.core.auth.save_tokens_to_cache") as mock_save,
+    ):
+        client._maybe_rotate_cookies(http_client)
+
+    assert client.cookies["SID"] == "fresh"
+    assert cached.cookies == client.cookies
+    mock_save.assert_called_once_with(cached, silent=True)
+
+
+def test_maybe_rotate_cookies_failure_leaves_state_untouched():
+    client = _client(cookies={"SID": "old"})
+
+    with (
+        patch(
+            "notebooklm_tools.core.cookie_rotation.rotate_google_cookies",
+            return_value=CookieRotationResult(
+                attempted=False, success=False, skipped_reason="recent_process_attempt"
+            ),
+        ),
+        patch("notebooklm_tools.core.auth.save_tokens_to_cache") as mock_save,
+    ):
+        client._maybe_rotate_cookies(httpx.Client())
+
+    assert client.cookies == {"SID": "old"}
+    mock_save.assert_not_called()
+
+
+def test_maybe_rotate_cookies_skips_when_no_cookies():
+    client = _client(cookies={})
+
+    with patch("notebooklm_tools.core.cookie_rotation.rotate_google_cookies") as mock_rotate:
+        client._maybe_rotate_cookies(httpx.Client())
+
+    mock_rotate.assert_not_called()


### PR DESCRIPTION
## What changed

**1. Auto-rotate Google cookies before RPC calls** (`core/base.py`)

NotebookLM RPC traffic alone does not refresh Google's short-lived `*PSIDTS` cookies, so long-lived MCP sessions drift into auth failures and force frequent re-logins. `_call_rpc` now makes a best-effort call to the `RotateCookies` endpoint before the first attempt of each RPC:

- The existing process-level rate limit in `cookie_rotation.py` keeps this to at most one rotation per 60s — no extra load on Google.
- Retries (`_retry` / `_server_retry`) skip it, since auth recovery already rotates.
- Failures are non-fatal (logged at debug); the RPC proceeds regardless.
- On success the refreshed jar is snapshotted into the client and persisted to the auth cache, so the CLI and the MCP server share cookie freshness.
- Skipped entirely when the client has no cookies, and when the new CDP RPC transport is active (the browser manages its own cookies).

**2. Test-suite hygiene fix: pytest was corrupting the developer's real login** (`tests/conftest.py`, new)

`tests/test_api_client.py::test_refresh_auth_tokens_success` runs the real `_refresh_auth_tokens`, whose `_update_cached_tokens()` call wrote fake test tokens (`csrf: "new_csrf_token"`, empty cookies) into the real `~/.notebooklm-mcp-cli/auth.json` on **every full test run**. Anyone developing this repo while using it gets their login silently destroyed each time they run pytest — reproduced and verified on Windows.

A new `tests/conftest.py` adds two autouse fixtures:
- storage isolation: `NOTEBOOKLM_MCP_CLI_PATH` points at a per-test `tmp_path`, so no test can touch the real auth cache or Chrome profile;
- `NOTEBOOKLM_DISABLE_ROTATE_COOKIES=1`, so no test can hit `accounts.google.com` through a mocked client (tests that exercise rotation re-enable it with `monkeypatch.delenv`).

Verified before/after: with the fixture, a full suite run no longer modifies the real `auth.json` or `chrome-profile/` mtimes.

**3. `NOTEBOOKLM_CHROME_PROFILE_DIR` override** (`utils/config.py`, `CLAUDE.md`)

Optional env var pointing browser-based auth (interactive login and headless refresh) at a fixed, already-authenticated Chrome user-data-dir instead of the self-managed `chrome-profile(s)/` directory.

**4. MCP server instructions tweak** (`mcp/server.py`)

Advise clients to call `refresh_auth` (reload from disk, no browser round-trip) before falling back to `nlm login`.

## Tests

- 6 new tests in `tests/core/test_rpc_cookie_rotation.py` cover: rotation fires once before the first RPC attempt, is skipped on auth retries and connect-timeout retries, persists on success, leaves state untouched on failure/skip, and no-ops without cookies.
- Full suite on Windows: **1081 passed**, 38 skipped. The 4 remaining failures (`test_snap.py`, macOS chrome-path, cdp-port-map) and 1 E2E error are pre-existing platform-specific failures that also fail on `main`.

## Notes for reviewers

- Rebased on v0.8.3; the rotation hook deliberately sits after the CDP-transport early return, so it only applies to the httpx path.
- The conftest fixtures are intentionally autouse: the cache-write paths (`_update_cached_tokens`, headless auth) sit deep in production code, and per-test mocking has already proven leaky — env-level isolation is the only reliable guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)