### PR TITLE
fix: harden CDP auth and Windows tests

### DIFF
--- a/src/notebooklm_tools/mcp/tools/_utils.py
+++ b/src/notebooklm_tools/mcp/tools/_utils.py
@@ -17,7 +17,7 @@ from notebooklm_tools.services.auth import load_cached_tokens
 mcp_logger = logging.getLogger("notebooklm_tools.mcp")
 
 # Parameters that must never appear in log output
-_SENSITIVE_PARAMS = frozenset({"cookies", "csrf_token", "session_id", "request_body"})
+_SENSITIVE_PARAMS = frozenset({"cookies", "csrf_token", "session_id", "request_body", "request_url"})
 P = ParamSpec("P")
 R = TypeVar("R")
 T = TypeVar("T")

--- a/src/notebooklm_tools/mcp/tools/_utils.py
+++ b/src/notebooklm_tools/mcp/tools/_utils.py
@@ -17,7 +17,9 @@ from notebooklm_tools.services.auth import load_cached_tokens
 mcp_logger = logging.getLogger("notebooklm_tools.mcp")
 
 # Parameters that must never appear in log output
-_SENSITIVE_PARAMS = frozenset({"cookies", "csrf_token", "session_id", "request_body", "request_url"})
+_SENSITIVE_PARAMS = frozenset(
+    {"cookies", "csrf_token", "session_id", "request_body", "request_url"}
+)
 P = ParamSpec("P")
 R = TypeVar("R")
 T = TypeVar("T")

--- a/src/notebooklm_tools/mcp/tools/auth.py
+++ b/src/notebooklm_tools/mcp/tools/auth.py
@@ -3,6 +3,7 @@
 import os
 import time
 import urllib.parse
+from http.cookies import SimpleCookie
 
 from ._utils import (
     ESSENTIAL_COOKIES,
@@ -117,12 +118,20 @@ def save_auth_tokens(
             save_tokens_to_cache,
         )
 
-        # Parse cookie string to dict
-        all_cookies = {}
-        for part in cookies.split("; "):
-            if "=" in part:
-                key, value = part.split("=", 1)
-                all_cookies[key.strip()] = value
+        # Parse cookie string to dict. Cookie headers are valid with or
+        # without spaces after semicolons, so do not split only on '; '.
+        try:
+            parsed_cookie = SimpleCookie()
+            parsed_cookie.load(cookies)
+            all_cookies = {key: morsel.value for key, morsel in parsed_cookie.items()}
+        except Exception:
+            all_cookies = {}
+        if not all_cookies:
+            all_cookies = {}
+            for part in cookies.split(";"):
+                if "=" in part:
+                    key, value = part.split("=", 1)
+                    all_cookies[key.strip()] = value.strip()
 
         # Validate required cookies
         required = ["SID", "HSID", "SSID", "APISID", "SAPISID"]
@@ -137,20 +146,19 @@ def save_auth_tokens(
         cookie_dict = {k: v for k, v in all_cookies.items() if k in ESSENTIAL_COOKIES}
 
         # Try to extract CSRF token from request body if provided
-        if not csrf_token and request_body and "at=" in request_body:
-            at_part = request_body.split("at=")[1].split("&")[0]
-            csrf_token = urllib.parse.unquote(at_part)
+        if not csrf_token and request_body:
+            body_params = urllib.parse.parse_qs(request_body, keep_blank_values=True)
+            csrf_token = body_params.get("at", [""])[0]
 
-        # Try to extract session ID from request URL if provided
-        if not session_id and request_url and "f.sid=" in request_url:
-            sid_part = request_url.split("f.sid=")[1].split("&")[0]
-            session_id = urllib.parse.unquote(sid_part)
-
-        # Try to extract build label from request URL if provided
+        # Try to extract session ID and build label from request URL if provided
         build_label = ""
-        if request_url and "bl=" in request_url:
-            bl_part = request_url.split("bl=")[1].split("&")[0]
-            build_label = urllib.parse.unquote(bl_part)
+        if request_url:
+            parsed_url = urllib.parse.urlparse(request_url)
+            query = parsed_url.query or request_url
+            url_params = urllib.parse.parse_qs(query, keep_blank_values=True)
+            if not session_id:
+                session_id = url_params.get("f.sid", [""])[0]
+            build_label = url_params.get("bl", [""])[0]
 
         # Create and save tokens
         tokens = AuthTokens(

--- a/src/notebooklm_tools/utils/cdp.py
+++ b/src/notebooklm_tools/utils/cdp.py
@@ -9,12 +9,14 @@ Usage:
     3. No keychain access required!
 """
 
+import contextlib
 import json
 import os
 import platform
 import re
 import shutil
 import subprocess
+import threading
 import time
 from pathlib import Path
 from typing import Any
@@ -36,6 +38,25 @@ import websocket  # noqa: E402
 
 _cached_ws: websocket.WebSocket | None = None
 _cached_ws_url: str | None = None
+_cdp_ws_lock = threading.Lock()
+_cdp_next_command_id = 0
+
+
+def _next_cdp_command_id() -> int:
+    """Return a process-local monotonically increasing CDP command id."""
+    global _cdp_next_command_id
+    _cdp_next_command_id += 1
+    return _cdp_next_command_id
+
+
+def _reset_cached_ws_unlocked() -> None:
+    """Close and clear the cached CDP websocket. Caller must hold _cdp_ws_lock."""
+    global _cached_ws, _cached_ws_url
+    if _cached_ws is not None:
+        with contextlib.suppress(Exception):
+            _cached_ws.close()
+    _cached_ws = None
+    _cached_ws_url = None
 
 
 def _normalize_ws_url(url: str | None) -> str | None:
@@ -437,14 +458,17 @@ def _is_snap_browser(browser_path: str) -> bool:
     if not browser_path:
         return False
 
+    browser_text = str(browser_path).replace("\\", "/")
+
     # Direct snap path or snap binary wrapper
-    if "/snap/" in browser_path:
+    if "/snap/" in browser_text or browser_text.startswith("/snap/"):
         return True
 
-    # Check if it's a symlink pointing to a snap path
+    # Check if it's a symlink pointing to a snap path. Normalize the resolved
+    # path text because tests can simulate POSIX paths while running on Windows.
     try:
-        resolved = Path(browser_path).resolve()
-        if "/snap/" in str(resolved):
+        resolved_text = str(Path(browser_path).resolve()).replace("\\", "/")
+        if "/snap/" in resolved_text or resolved_text.startswith("/snap/"):
             return True
     except (OSError, RuntimeError):
         pass
@@ -462,10 +486,17 @@ def get_snap_common_dir(browser_path: str) -> Path | None:
     if not _is_snap_browser(browser_path):
         return None
 
-    # Extract snap name from path (e.g., /snap/chromium/3444/... -> chromium)
+    # Extract snap name from path (e.g., /snap/chromium/3444/... -> chromium).
+    # Normalize to POSIX separators so Linux-path simulations work on Windows.
     try:
-        resolved = Path(browser_path).resolve()
-        for part in resolved.parts:
+        resolved_text = str(Path(browser_path).resolve()).replace("\\", "/")
+        parts = [part for part in resolved_text.split("/") if part]
+        for index, part in enumerate(parts):
+            if part == "snap" and index + 1 < len(parts):
+                snap_name = parts[index + 1]
+                if snap_name in ("chromium", "google-chrome", "firefox"):
+                    return Path.home() / "snap" / snap_name / "common"
+        for part in parts:
             if part in ("chromium", "google-chrome", "firefox"):
                 return Path.home() / "snap" / part / "common"
     except (OSError, RuntimeError):
@@ -502,8 +533,6 @@ def get_supported_browsers() -> list[str]:
 
 
 # Import Chrome profile directory from unified config
-import contextlib  # noqa: E402
-
 from notebooklm_tools.utils.config import get_chrome_profile_dir  # noqa: E402
 
 
@@ -799,18 +828,17 @@ def terminate_chrome(process: subprocess.Popen | None = None, port: int | None =
         return False
 
     # Attempt graceful shutdown via CDP to prevent "Restore Pages" warnings on next launch
-    ws_to_close = _cached_ws
     try:
-        if port or _cached_ws_url:
-            execute_cdp_command(_cached_ws_url or get_debugger_url(_chrome_port), "Browser.close")
-            if ws_to_close:
-                ws_to_close.close()
+        debugger_url = _cached_ws_url or (get_debugger_url(port) if port else None)
+        if debugger_url:
+            execute_cdp_command(debugger_url, "Browser.close")
         else:
             process.terminate()
     except Exception:
         pass  # Ignore connection drops or failures during close
 
-    _cached_ws = _cached_ws_url = None
+    with _cdp_ws_lock:
+        _reset_cached_ws_unlocked()
 
     try:
         # Wait up to 5 seconds for the graceful shutdown to finish
@@ -901,9 +929,8 @@ def find_or_create_notebooklm_page_by_cdp_url(cdp_http_url: str) -> dict | None:
     except Exception as e:
         _logger.debug("Exception creating blank page via PUT /json/new: %s", e)
 
-    # All creation attempts failed — reuse an existing page
-    _logger.debug("Falling back to reusing an existing page.")
-    any_page: tuple[dict, str] | None = None
+    # All creation attempts failed — reuse only a safe blank/new-tab page.
+    _logger.debug("Falling back to reusing a blank existing page.")
     for page in pages:
         url = page.get("url", "")
         if url in ("about:blank", "chrome://newtab/"):
@@ -912,16 +939,6 @@ def find_or_create_notebooklm_page_by_cdp_url(cdp_http_url: str) -> dict | None:
                 _logger.debug("Reusing page with url %s", url)
                 navigate_to_url(ws_url, NOTEBOOKLM_URL)
                 return page
-        elif page.get("type") == "page" and any_page is None:
-            ws_url = _normalize_ws_url(page.get("webSocketDebuggerUrl"))
-            if ws_url:
-                any_page = (page, ws_url)
-
-    if any_page:
-        page, ws_url = any_page
-        _logger.debug("Reusing arbitrary page with url %s", page.get("url", ""))
-        navigate_to_url(ws_url, NOTEBOOKLM_URL)
-        return page
 
     return None
 
@@ -984,7 +1001,8 @@ def execute_cdp_command(
     global _cached_ws, _cached_ws_url
 
     if retry:
-        # Retry once in case of stale cached connection
+        # Retry once in case of stale cached connection. Close stale sockets so
+        # the second attempt cannot reuse a broken descriptor.
         try:
             return execute_cdp_command(
                 ws_url,
@@ -994,44 +1012,50 @@ def execute_cdp_command(
                 response_timeout=response_timeout,
             )
         except Exception:
-            # Try again without the cached connection
-            _cached_ws = _cached_ws_url = None
+            with _cdp_ws_lock:
+                _reset_cached_ws_unlocked()
 
-    if ws_url != _cached_ws_url or not _cached_ws:
-        if _cached_ws:
-            _cached_ws.close()
-            _cached_ws = None
+    with _cdp_ws_lock:
+        if ws_url != _cached_ws_url or not _cached_ws:
+            _reset_cached_ws_unlocked()
 
-        # suppress_origin=True is required for some managed Chrome/CDP endpoints
-        # (e.g. OpenClaw browser profile) that reject default Origin headers.
+            # suppress_origin=True is required for some managed Chrome/CDP endpoints
+            # (e.g. OpenClaw browser profile) that reject default Origin headers.
+            try:
+                with _cdp_websocket_without_proxy_env():
+                    ws = websocket.create_connection(ws_url, timeout=30, suppress_origin=True)
+            except TypeError:
+                # Older websocket-client versions may not support suppress_origin.
+                with _cdp_websocket_without_proxy_env():
+                    ws = websocket.create_connection(ws_url, timeout=30)
+            _cached_ws = ws
+            _cached_ws_url = ws_url
+        else:
+            ws = _cached_ws
+
+        command_id = _next_cdp_command_id()
+        command = {"id": command_id, "method": method, "params": params or {}}
+        ws.send(json.dumps(command))
+
+        # Wait for response with matching ID. Long-running in-page fetches, such as
+        # streamed notebook queries, can legitimately exceed the default 30s wait.
+        ws.settimeout(response_timeout)
         try:
-            with _cdp_websocket_without_proxy_env():
-                ws = websocket.create_connection(ws_url, timeout=30, suppress_origin=True)
-        except TypeError:
-            # Older websocket-client versions may not support suppress_origin.
-            with _cdp_websocket_without_proxy_env():
-                ws = websocket.create_connection(ws_url, timeout=30)
-        _cached_ws = ws
-        _cached_ws_url = ws_url
-    else:
-        ws = _cached_ws
-
-    command = {"id": 1, "method": method, "params": params or {}}
-    ws.send(json.dumps(command))
-
-    # Wait for response with matching ID. Long-running in-page fetches, such as
-    # streamed notebook queries, can legitimately exceed the default 30s wait.
-    ws.settimeout(response_timeout)
-    try:
-        while True:
-            response = json.loads(ws.recv())
-            if response.get("id") == 1:
+            while True:
+                response = json.loads(ws.recv())
+                if response.get("id") != command_id:
+                    continue
+                if "error" in response:
+                    raise RuntimeError(f"CDP command '{method}' failed: {response['error']}")
                 return response.get("result", {})
-    except websocket.WebSocketTimeoutException as err:
-        _cached_ws = _cached_ws_url = None
-        raise TimeoutError(
-            f"CDP command '{method}' timed out after {response_timeout:g}s waiting for response"
-        ) from err
+        except websocket.WebSocketTimeoutException as err:
+            _reset_cached_ws_unlocked()
+            raise TimeoutError(
+                f"CDP command '{method}' timed out after {response_timeout:g}s waiting for response"
+            ) from err
+        except Exception:
+            _reset_cached_ws_unlocked()
+            raise
 
 
 def get_page_cookies(ws_url: str) -> list[dict]:
@@ -1552,11 +1576,16 @@ def run_headless_auth(
     chrome_was_running = False
 
     try:
-        # Try to connect to existing Chrome first
-        debugger_url = get_debugger_url(port)
+        # Try to connect only to a profile-owned existing Chrome first.
+        existing_port, debugger_url = find_existing_nlm_chrome(
+            port_range=range(port, port + 1),
+            profile_name=profile_name,
+            include_headless=True,
+        )
 
-        if debugger_url:
-            # Chrome already running - use existing instance
+        if existing_port is not None and debugger_url:
+            # Chrome already running for this profile - use existing instance
+            port = existing_port
             chrome_was_running = True
         else:
             # No Chrome running - launch in headless mode

--- a/tests/test_auth_migration.py
+++ b/tests/test_auth_migration.py
@@ -325,14 +325,15 @@ class TestCDPStartupHandling:
         chrome_path = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 
         def fake_exists(self):
-            return str(self) == chrome_path
+            return self.as_posix() == chrome_path
 
         with (
             patch("notebooklm_tools.utils.cdp.platform.system", return_value="Darwin"),
             patch.object(Path, "exists", fake_exists),
         ):
             result = get_chrome_path()
-        assert result == chrome_path
+        assert result is not None
+        assert Path(result).as_posix() == chrome_path
 
     # ------------------------------------------------------------------
     # get_chrome_path — Linux

--- a/tests/test_file_upload.py
+++ b/tests/test_file_upload.py
@@ -344,6 +344,7 @@ def temp_notebook():
     """Create a temporary notebook for E2E tests."""
     from notebooklm_tools.core.auth import load_cached_tokens
     from notebooklm_tools.core.client import NotebookLMClient
+    from notebooklm_tools.core.errors import ClientAuthenticationError
 
     # Load real auth
     tokens = load_cached_tokens()
@@ -353,7 +354,10 @@ def temp_notebook():
     client = NotebookLMClient(
         cookies=tokens.cookies, csrf_token=tokens.csrf_token, session_id=tokens.session_id
     )
-    notebook = client.create_notebook(title="Test Upload Notebook")
+    try:
+        notebook = client.create_notebook(title="Test Upload Notebook")
+    except ClientAuthenticationError as exc:
+        pytest.skip(f"Authentication tokens are expired or invalid: {exc}")
 
     yield notebook
 


### PR DESCRIPTION
## Summary

This PR hardens the v0.8.3 CDP/auth paths and fixes Windows-only test failures found while reviewing the latest release branch.

Changes:

- Serialize cached CDP WebSocket command execution and use unique command ids instead of fixed id `1`.
- Close stale cached CDP sockets before retrying failed commands.
- Ensure headless auth only reuses profile-owned CDP browsers instead of blindly attaching to any listener on the requested port.
- Use the explicit port when gracefully terminating an externally supplied Chrome process.
- Avoid navigating arbitrary existing browser tabs when CDP new-tab creation fails; only reuse blank/new-tab pages.
- Redact `request_url` from MCP debug logs because it can contain session/build parameters.
- Make `save_auth_tokens()` parse cookie headers and URL/body params more robustly.
- Fix Windows/path-related tests and skip live upload E2E setup when cached auth is expired.

## Validation

Ran on Windows from a clean branch based on `upstream/main` / `v0.8.3`.

```text
uv run ruff check src/notebooklm_tools/utils/cdp.py src/notebooklm_tools/mcp/tools/_utils.py src/notebooklm_tools/mcp/tools/auth.py tests/test_auth_migration.py tests/test_file_upload.py
```

```text
All checks passed!
```

```text
uv run pytest
```

```text
1079 passed, 39 skipped, 30 warnings in 27.08s
```

Warnings are existing Typer deprecation warnings from `tests/cli/test_login.py`.
