### PR TITLE
feat(downloads): 'nlm download all' bulk export with --all-notebooks sweep (+ mind map fixes)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,7 @@ src/notebooklm_tools/
 | `research_import` | Import discovered sources into notebook (manual, if `auto_import` not used) |
 | `studio_create` | Generate unified content (audio, video, infographic, slides, etc.) |
 | `download_artifact` | Download any artifact (audio, video, pdf, markdown, json). Supports `wait`, `wait_timeout`, `poll_interval` params and returns `download_url` when MCP HTTP transport is active. |
-| `download_all_artifacts` | Download every completed artifact of a notebook into a per-notebook directory (named after the notebook title). Optional `artifact_types` filter; failures on one artifact don't stop the rest. CLI: `nlm download all` |
+| `download_all_artifacts` | Download every completed artifact of a notebook — or every notebook with `all_notebooks=True` — into per-notebook directories (named after notebook titles). Optional `artifact_types` filter and `skip_existing` for incremental re-runs; failures on one artifact/notebook don't stop the rest. CLI: `nlm download all [--all-notebooks] [--skip-existing]` |
 | `export_artifact` | Export Data Tables to Google Sheets or Reports to Google Docs |
 | `studio_status` | Check studio artifact generation status |
 | `studio_delete` | Delete studio artifacts (REQUIRES confirmation) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,7 @@ src/notebooklm_tools/
 | `research_import` | Import discovered sources into notebook (manual, if `auto_import` not used) |
 | `studio_create` | Generate unified content (audio, video, infographic, slides, etc.) |
 | `download_artifact` | Download any artifact (audio, video, pdf, markdown, json). Supports `wait`, `wait_timeout`, `poll_interval` params and returns `download_url` when MCP HTTP transport is active. |
+| `download_all_artifacts` | Download every completed artifact of a notebook into a per-notebook directory (named after the notebook title). Optional `artifact_types` filter; failures on one artifact don't stop the rest. CLI: `nlm download all` |
 | `export_artifact` | Export Data Tables to Google Sheets or Reports to Google Docs |
 | `studio_status` | Check studio artifact generation status |
 | `studio_delete` | Delete studio artifacts (REQUIRES confirmation) |

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1076,6 +1076,8 @@ params = [
 
 **Key Difference from Flashcards:** Quiz uses format code `2` at the first position of the options array, while Flashcards use `1`.
 
+**Mind maps share type code 4 too:** newer mind maps are stored as type-4 studio artifacts with format code `4` at `artifact[9][1][0]` (older mind maps live in the notes store via the `cFji9` RPC). The status parser classifies format code 4 as `mind_map`, and downloading one fetches the artifact's interactive HTML (`v9rmvd`) and extracts the mind map JSON (`{"name": ..., "children": [...]}`) from the `data-app-data` attribute — the same mechanism quiz/flashcards use.
+
 ---
 
 ## Data Table RPCs

--- a/docs/MCP_CLI_TEST_PLAN.md
+++ b/docs/MCP_CLI_TEST_PLAN.md
@@ -702,6 +702,24 @@ downloaded/failed/skipped counts. Also test `--types video,report` filtering.
 
 ---
 
+### Test 6.7 - Sweep All Notebooks (Incremental)
+**Tool:** `download_all_artifacts` with `all_notebooks=True, skip_existing=True`
+**CLI:** `nlm download all --all-notebooks --skip-existing --output-dir /tmp/exports`
+
+**Prompt:**
+```
+Download all artifacts from every notebook into /tmp/exports, skipping
+files that already exist.
+```
+
+**Expected:** One subdirectory per notebook. On a second run with
+`skip_existing`, previously downloaded artifacts are reported as skipped
+("already downloaded") and only new artifacts are fetched. A failure on one
+notebook doesn't stop the sweep; result includes per-notebook counts and
+`errored_notebooks`.
+
+---
+
 ## Test Group 7: Sharing
 
 ### Test 7.1 - Get Share Status

--- a/docs/MCP_CLI_TEST_PLAN.md
+++ b/docs/MCP_CLI_TEST_PLAN.md
@@ -684,6 +684,24 @@ Download slide deck from notebook [notebook_id]:
 
 ---
 
+### Test 6.6 - Download All Artifacts
+**Tool:** `download_all_artifacts`
+**CLI:** `nlm download all [notebook_id] --output-dir /tmp/exports`
+
+**Prompt:**
+```
+Download all completed artifacts from notebook [notebook_id]:
+- output_dir: /tmp/exports
+```
+
+**Expected:** A subdirectory named after the notebook title created under the
+output dir, containing every completed artifact named after its title
+(report → .md, mind_map → .json, video → .mp4, slide_deck → .pdf, ...).
+In-progress/failed artifacts are listed as skipped; result reports
+downloaded/failed/skipped counts. Also test `--types video,report` filtering.
+
+---
+
 ## Test Group 7: Sharing
 
 ### Test 7.1 - Get Share Status
@@ -917,7 +935,7 @@ Get NotebookLM MCP server version and check for updates.
 
 ---
 
-## Summary: 29 Consolidated Tools
+## Summary: 30 Consolidated Tools
 
 | Category | Tools | Count |
 |----------|-------|-------|
@@ -927,12 +945,12 @@ Get NotebookLM MCP server version and check for updates.
 | **Sharing** | `notebook_share_status`, `notebook_share_public`, `notebook_share_invite` | 3 |
 | **Research** | `research_start`, `research_status`, `research_import` | 3 |
 | **Studio** | `studio_create`, `studio_status`, `studio_delete`, `studio_revise` | 4 |
-| **Downloads** | `download_artifact` | 1 |
+| **Downloads** | `download_artifact`, `download_all_artifacts` | 2 |
 | **Exports** | `export_artifact` | 1 |
 | **Chat** | `notebook_query`, `chat_configure` | 2 |
 | **Notes** | `note` (unified: list, create, update, delete) | 1 |
 | **Server** | `server_info` | 1 |
-| **Total** | | **30** |
+| **Total** | | **31** |
 
 ---
 

--- a/src/notebooklm_tools/cli/commands/download.py
+++ b/src/notebooklm_tools/cli/commands/download.py
@@ -186,14 +186,60 @@ def _interactive_download(
 # --- Bulk download ---
 
 
+def _print_download_all_result(result: dict) -> None:
+    """Human-readable output for a single-notebook download_all result."""
+    console.print(f"Notebook: [bold]{result['notebook_title']}[/bold]")
+    console.print(f"Directory: {result['output_dir']}")
+    for item in result["items"]:
+        label = item["artifact_type"].replace("_", " ")
+        if item["success"]:
+            console.print(f"[green]✓[/green] {label}: {item['path']}")
+        else:
+            console.print(f"[red]✗[/red] {label} ({item['title']}): {item['error']}")
+    for skipped in result["skipped"]:
+        if skipped["reason"] == "type not requested":
+            continue
+        label = skipped["artifact_type"].replace("_", " ")
+        console.print(
+            f"[yellow]-[/yellow] skipped {label} ({skipped['title']}): {skipped['reason']}"
+        )
+    if result["total_artifacts"] == 0:
+        console.print("No studio artifacts found in this notebook.")
+    console.print(
+        f"\n[bold]{result['downloaded']}[/bold] downloaded, "
+        f"{result['failed']} failed, {len(result['skipped'])} skipped"
+    )
+
+
+def _print_sweep_result(result: dict) -> None:
+    """Human-readable output for an all-notebooks sweep result."""
+    console.print(f"Directory: {result['output_dir']}")
+    for nb in result["notebooks"]:
+        if nb["error"]:
+            console.print(f"[red]✗[/red] {nb['notebook_title']}: {nb['error']}")
+        else:
+            console.print(
+                f"[green]✓[/green] {nb['notebook_title']}: "
+                f"{nb['downloaded']} downloaded, {nb['failed']} failed, "
+                f"{nb['skipped']} skipped"
+            )
+    console.print(
+        f"\n[bold]{result['downloaded']}[/bold] downloaded, {result['failed']} failed "
+        f"across {result['total_notebooks']} notebooks "
+        f"({result['errored_notebooks']} notebooks errored)"
+    )
+
+
 @app.command("all")
 def download_all_cmd(
-    notebook_id: str = typer.Argument(..., help="Notebook ID or alias"),
+    notebook_id: str | None = typer.Argument(
+        None, help="Notebook ID or alias (omit with --all-notebooks)"
+    ),
     output_dir: str = typer.Option(
         ".",
         "--output-dir",
         "-d",
-        help="Base directory; a subdirectory named after the notebook is created inside",
+        help="Base directory; a subdirectory named after each notebook is created inside",
     ),
     types: str | None = typer.Option(
         None,
@@ -207,26 +253,54 @@ def download_all_cmd(
     interactive_format: str = typer.Option(
         "json", "--interactive-format", help="Quiz/flashcards format: json, markdown, or html"
     ),
+    all_notebooks: bool = typer.Option(
+        False, "--all-notebooks", "-a", help="Sweep every notebook in the account"
+    ),
+    skip_existing: bool = typer.Option(
+        False,
+        "--skip-existing",
+        help="Skip artifacts whose file already exists (incremental re-runs)",
+    ),
     no_progress: bool = typer.Option(False, "--no-progress", help="Disable download progress bars"),
     json_output: bool = typer.Option(False, "--json", "-j", help="Output result as JSON"),
 ):
-    """Download all completed artifacts of a notebook into a per-notebook directory."""
-    notebook_id = get_alias_manager().resolve(notebook_id)
+    """Download all completed artifacts into per-notebook directories.
+
+    With a notebook ID, downloads that notebook's artifacts. With
+    --all-notebooks, sweeps every notebook in the account.
+    """
+    if all_notebooks == (notebook_id is not None):
+        err_console.print(
+            "[red]Error:[/red] Provide either a notebook ID or --all-notebooks (not both)."
+        )
+        raise typer.Exit(1)
+
     artifact_types = [t.strip() for t in types.split(",") if t.strip()] if types else None
     client = get_client()
 
-    try:
-        if no_progress or json_output:
-            result = asyncio.run(
-                downloads_service.download_all(
-                    client,
-                    notebook_id,
-                    output_dir,
-                    artifact_types=artifact_types,
-                    output_format=interactive_format,
-                    slide_deck_format=slide_format.lower(),
+    def _run(
+        progress_factory: Callable[[str, str], Callable[[int, int], None]] | None,
+        on_notebook: Callable[[int, int, str], None] | None,
+    ) -> dict:
+        common = {
+            "artifact_types": artifact_types,
+            "output_format": interactive_format,
+            "slide_deck_format": slide_format.lower(),
+            "skip_existing": skip_existing,
+            "progress_factory": progress_factory,
+        }
+        if all_notebooks:
+            return asyncio.run(
+                downloads_service.download_all_notebooks(
+                    client, output_dir, on_notebook=on_notebook, **common
                 )
             )
+        resolved = get_alias_manager().resolve(notebook_id)
+        return asyncio.run(downloads_service.download_all(client, resolved, output_dir, **common))
+
+    try:
+        if no_progress or json_output:
+            result = _run(None, None)
         else:
             with Progress(
                 TextColumn("[bold blue]{task.description}"),
@@ -252,17 +326,10 @@ def download_all_cmd(
 
                     return update_progress
 
-                result = asyncio.run(
-                    downloads_service.download_all(
-                        client,
-                        notebook_id,
-                        output_dir,
-                        artifact_types=artifact_types,
-                        output_format=interactive_format,
-                        slide_deck_format=slide_format.lower(),
-                        progress_factory=_progress_factory,
-                    )
-                )
+                def _on_notebook(index: int, total: int, title: str) -> None:
+                    progress.console.print(f"[dim][{index}/{total}][/dim] {title}")
+
+                result = _run(_progress_factory, _on_notebook)
     except ServiceError as e:
         err_console.print(f"[red]Error:[/red] {e.user_message}")
         raise typer.Exit(1) from e
@@ -272,28 +339,10 @@ def download_all_cmd(
 
     if json_output:
         console.print_json(data=result)
+    elif all_notebooks:
+        _print_sweep_result(result)
     else:
-        console.print(f"Notebook: [bold]{result['notebook_title']}[/bold]")
-        console.print(f"Directory: {result['output_dir']}")
-        for item in result["items"]:
-            label = item["artifact_type"].replace("_", " ")
-            if item["success"]:
-                console.print(f"[green]✓[/green] {label}: {item['path']}")
-            else:
-                console.print(f"[red]✗[/red] {label} ({item['title']}): {item['error']}")
-        for skipped in result["skipped"]:
-            if skipped["reason"] == "type not requested":
-                continue
-            label = skipped["artifact_type"].replace("_", " ")
-            console.print(
-                f"[yellow]-[/yellow] skipped {label} ({skipped['title']}): {skipped['reason']}"
-            )
-        if result["total_artifacts"] == 0:
-            console.print("No studio artifacts found in this notebook.")
-        console.print(
-            f"\n[bold]{result['downloaded']}[/bold] downloaded, "
-            f"{result['failed']} failed, {len(result['skipped'])} skipped"
-        )
+        _print_download_all_result(result)
 
     if result["downloaded"] == 0 and result["failed"] > 0:
         raise typer.Exit(1)

--- a/src/notebooklm_tools/cli/commands/download.py
+++ b/src/notebooklm_tools/cli/commands/download.py
@@ -183,6 +183,122 @@ def _interactive_download(
         handle_error(e)
 
 
+# --- Bulk download ---
+
+
+@app.command("all")
+def download_all_cmd(
+    notebook_id: str = typer.Argument(..., help="Notebook ID or alias"),
+    output_dir: str = typer.Option(
+        ".",
+        "--output-dir",
+        "-d",
+        help="Base directory; a subdirectory named after the notebook is created inside",
+    ),
+    types: str | None = typer.Option(
+        None,
+        "--types",
+        "-t",
+        help="Comma-separated artifact types (default: all). Example: video,slide_deck,mind_map,report",
+    ),
+    slide_format: str = typer.Option(
+        "pdf", "--slide-format", help="Slide deck format: pdf (default) or pptx"
+    ),
+    interactive_format: str = typer.Option(
+        "json", "--interactive-format", help="Quiz/flashcards format: json, markdown, or html"
+    ),
+    no_progress: bool = typer.Option(False, "--no-progress", help="Disable download progress bars"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output result as JSON"),
+):
+    """Download all completed artifacts of a notebook into a per-notebook directory."""
+    notebook_id = get_alias_manager().resolve(notebook_id)
+    artifact_types = [t.strip() for t in types.split(",") if t.strip()] if types else None
+    client = get_client()
+
+    try:
+        if no_progress or json_output:
+            result = asyncio.run(
+                downloads_service.download_all(
+                    client,
+                    notebook_id,
+                    output_dir,
+                    artifact_types=artifact_types,
+                    output_format=interactive_format,
+                    slide_deck_format=slide_format.lower(),
+                )
+            )
+        else:
+            with Progress(
+                TextColumn("[bold blue]{task.description}"),
+                BarColumn(bar_width=None),
+                "[progress.percentage]{task.percentage:>3.0f}%",
+                DownloadColumn(),
+                TransferSpeedColumn(),
+                TimeRemainingColumn(),
+                console=console,
+                transient=True,
+            ) as progress:
+
+                def _progress_factory(
+                    artifact_type: str, filename: str
+                ) -> Callable[[int, int], None]:
+                    task_id = progress.add_task(f"Downloading {filename}", total=None)
+
+                    def update_progress(current: int, total: int | None):
+                        if total:
+                            progress.update(task_id, completed=current, total=total)
+                        else:
+                            progress.update(task_id, completed=current)
+
+                    return update_progress
+
+                result = asyncio.run(
+                    downloads_service.download_all(
+                        client,
+                        notebook_id,
+                        output_dir,
+                        artifact_types=artifact_types,
+                        output_format=interactive_format,
+                        slide_deck_format=slide_format.lower(),
+                        progress_factory=_progress_factory,
+                    )
+                )
+    except ServiceError as e:
+        err_console.print(f"[red]Error:[/red] {e.user_message}")
+        raise typer.Exit(1) from e
+    except Exception as e:
+        handle_error(e)
+        return
+
+    if json_output:
+        console.print_json(data=result)
+    else:
+        console.print(f"Notebook: [bold]{result['notebook_title']}[/bold]")
+        console.print(f"Directory: {result['output_dir']}")
+        for item in result["items"]:
+            label = item["artifact_type"].replace("_", " ")
+            if item["success"]:
+                console.print(f"[green]✓[/green] {label}: {item['path']}")
+            else:
+                console.print(f"[red]✗[/red] {label} ({item['title']}): {item['error']}")
+        for skipped in result["skipped"]:
+            if skipped["reason"] == "type not requested":
+                continue
+            label = skipped["artifact_type"].replace("_", " ")
+            console.print(
+                f"[yellow]-[/yellow] skipped {label} ({skipped['title']}): {skipped['reason']}"
+            )
+        if result["total_artifacts"] == 0:
+            console.print("No studio artifacts found in this notebook.")
+        console.print(
+            f"\n[bold]{result['downloaded']}[/bold] downloaded, "
+            f"{result['failed']} failed, {len(result['skipped'])} skipped"
+        )
+
+    if result["downloaded"] == 0 and result["failed"] > 0:
+        raise typer.Exit(1)
+
+
 # --- Streaming downloads (with progress bars) ---
 
 

--- a/src/notebooklm_tools/cli/commands/verbs.py
+++ b/src/notebooklm_tools/cli/commands/verbs.py
@@ -926,12 +926,14 @@ download_app = typer.Typer(help="Download studio artifacts")
 
 @download_app.command("all")
 def download_all_verb(
-    notebook: str = typer.Argument(..., help="Notebook ID or alias"),
+    notebook: str | None = typer.Argument(
+        None, help="Notebook ID or alias (omit with --all-notebooks)"
+    ),
     output_dir: str = typer.Option(
         ".",
         "--output-dir",
         "-d",
-        help="Base directory; a subdirectory named after the notebook is created inside",
+        help="Base directory; a subdirectory named after each notebook is created inside",
     ),
     types: str | None = typer.Option(
         None, "--types", "-t", help="Comma-separated artifact types (default: all)"
@@ -942,16 +944,26 @@ def download_all_verb(
     interactive_format: str = typer.Option(
         "json", "--interactive-format", help="Quiz/flashcards format: json, markdown, or html"
     ),
+    all_notebooks: bool = typer.Option(
+        False, "--all-notebooks", "-a", help="Sweep every notebook in the account"
+    ),
+    skip_existing: bool = typer.Option(
+        False,
+        "--skip-existing",
+        help="Skip artifacts whose file already exists (incremental re-runs)",
+    ),
     no_progress: bool = typer.Option(False, "--no-progress", help="Disable download progress bars"),
     json_output: bool = typer.Option(False, "--json", "-j", help="Output result as JSON"),
 ) -> None:
-    """Download all completed artifacts of a notebook into a per-notebook directory."""
+    """Download all completed artifacts into per-notebook directories."""
     download_all_cmd(
         notebook_id=notebook,
         output_dir=output_dir,
         types=types,
         slide_format=slide_format,
         interactive_format=interactive_format,
+        all_notebooks=all_notebooks,
+        skip_existing=skip_existing,
         no_progress=no_progress,
         json_output=json_output,
     )

--- a/src/notebooklm_tools/cli/commands/verbs.py
+++ b/src/notebooklm_tools/cli/commands/verbs.py
@@ -25,6 +25,7 @@ from notebooklm_tools.cli.commands.config import (
     show_config,
 )
 from notebooklm_tools.cli.commands.download import (
+    download_all_cmd,
     download_audio,
     download_data_table,
     download_infographic,
@@ -921,6 +922,39 @@ def configure_chat_verb(
 # =============================================================================
 
 download_app = typer.Typer(help="Download studio artifacts")
+
+
+@download_app.command("all")
+def download_all_verb(
+    notebook: str = typer.Argument(..., help="Notebook ID or alias"),
+    output_dir: str = typer.Option(
+        ".",
+        "--output-dir",
+        "-d",
+        help="Base directory; a subdirectory named after the notebook is created inside",
+    ),
+    types: str | None = typer.Option(
+        None, "--types", "-t", help="Comma-separated artifact types (default: all)"
+    ),
+    slide_format: str = typer.Option(
+        "pdf", "--slide-format", help="Slide deck format: pdf (default) or pptx"
+    ),
+    interactive_format: str = typer.Option(
+        "json", "--interactive-format", help="Quiz/flashcards format: json, markdown, or html"
+    ),
+    no_progress: bool = typer.Option(False, "--no-progress", help="Disable download progress bars"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output result as JSON"),
+) -> None:
+    """Download all completed artifacts of a notebook into a per-notebook directory."""
+    download_all_cmd(
+        notebook_id=notebook,
+        output_dir=output_dir,
+        types=types,
+        slide_format=slide_format,
+        interactive_format=interactive_format,
+        no_progress=no_progress,
+        json_output=json_output,
+    )
 
 
 @download_app.command("audio")

--- a/src/notebooklm_tools/core/download.py
+++ b/src/notebooklm_tools/core/download.py
@@ -23,6 +23,7 @@ from .errors import (
 from .errors import (
     ClientAuthenticationError as AuthenticationError,
 )
+from .utils import is_mind_map_json
 
 
 class DownloadMixin(BaseClient):
@@ -669,6 +670,19 @@ class DownloadMixin(BaseClient):
         if result and isinstance(result, list) and len(result) > 0:  # noqa: SIM102
             if isinstance(result[0], list):
                 mind_maps = result[0]
+
+        # The notes store holds both regular notes (prose content) and mind
+        # maps (JSON content) — keep only real mind maps so an unqualified
+        # download can't pick a note and a note ID reports "not found".
+        mind_maps = [
+            mm
+            for mm in mind_maps
+            if isinstance(mm, list)
+            and len(mm) > 1
+            and isinstance(mm[1], list)
+            and len(mm[1]) > 1
+            and is_mind_map_json(mm[1][1])
+        ]
 
         if not mind_maps:
             raise ArtifactNotReadyError("mind_map")

--- a/src/notebooklm_tools/core/download.py
+++ b/src/notebooklm_tools/core/download.py
@@ -684,18 +684,18 @@ class DownloadMixin(BaseClient):
             and is_mind_map_json(mm[1][1])
         ]
 
-        if not mind_maps:
-            raise ArtifactNotReadyError("mind_map")
-
         target = None
         if artifact_id:
             target = next(
                 (mm for mm in mind_maps if isinstance(mm, list) and mm[0] == artifact_id), None
             )
-            if not target:
-                raise ArtifactNotFoundError(artifact_id, artifact_type="mind_map")
-        else:
+        elif mind_maps:
             target = mind_maps[0]
+
+        if target is None:
+            # Newer mind maps are stored as type-4 studio artifacts (format
+            # code 4) rather than in the notes store — fall back to those.
+            return self._download_studio_mind_map(notebook_id, output_path, artifact_id)
 
         try:
             # Mind map JSON is stringified in target[1][1]
@@ -715,6 +715,55 @@ class DownloadMixin(BaseClient):
 
         except (IndexError, TypeError, json.JSONDecodeError, AttributeError) as e:
             raise ArtifactParseError("mind_map", details=str(e)) from e
+
+    def _download_studio_mind_map(
+        self,
+        notebook_id: str,
+        output_path: str,
+        artifact_id: str | None = None,
+    ) -> str:
+        """Download a studio-side mind map (type-4 artifact, format code 4).
+
+        The mind map JSON ({"name": ..., "children": [...]}) is embedded in
+        the artifact's interactive HTML as data-app-data.
+        """
+        artifacts = self._list_raw(notebook_id)
+        candidates = [
+            a
+            for a in artifacts
+            if isinstance(a, list)
+            and len(a) > 4
+            and a[2] == self.STUDIO_TYPE_FLASHCARDS
+            and a[4] == 3
+            and self._interactive_format_code(a) == 4
+        ]
+
+        if artifact_id:
+            target = next((a for a in candidates if a[0] == artifact_id), None)
+            if target is None:
+                raise ArtifactNotFoundError(artifact_id, artifact_type="mind_map")
+        else:
+            if not candidates:
+                raise ArtifactNotReadyError("mind_map")
+            target = candidates[0]
+
+        html_content = self._get_artifact_content(notebook_id, target[0])
+        if not html_content:
+            raise ArtifactDownloadError("mind_map", details="Failed to fetch HTML content from API")
+
+        try:
+            app_data = self._extract_app_data(html_content)
+        except ArtifactParseError:
+            raise
+        except (ValueError, json.JSONDecodeError) as e:
+            raise ArtifactParseError("mind_map", details=str(e)) from e
+
+        output = Path(output_path)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(app_data, indent=2, ensure_ascii=False), encoding="utf-8")
+
+        logger.info(f"Downloaded mind map to {output}")
+        return str(output)
 
     @staticmethod
     def _extract_cell_text(cell: Any, _depth: int = 0) -> str:
@@ -972,6 +1021,19 @@ class DownloadMixin(BaseClient):
     # =========================================================================
     # Interactive Artifact Downloads (Quiz, Flashcards)
     # =========================================================================
+
+    @staticmethod
+    def _interactive_format_code(artifact: Any) -> int | None:
+        """Read the interactive subtype of a type-4 studio artifact.
+
+        Type 4 (STUDIO_TYPE_FLASHCARDS) covers flashcards (1), quizzes (2),
+        and mind maps (4); the code lives at artifact[9][1][0].
+        """
+        try:
+            code = artifact[9][1][0]
+        except (IndexError, TypeError):
+            return None
+        return code if isinstance(code, int) else None
 
     def _get_artifact_content(self, notebook_id: str, artifact_id: str) -> str | None:
         """Fetch artifact HTML content for quiz/flashcard types.
@@ -1241,8 +1303,17 @@ class DownloadMixin(BaseClient):
         # Get all artifacts and filter for completed interactive artifacts
         artifacts = self._list_raw(notebook_id)
 
-        # Type 4 (STUDIO_TYPE_FLASHCARDS) covers both quizzes and flashcards
-        # Status 3 = completed
+        # Type 4 (STUDIO_TYPE_FLASHCARDS) covers quizzes, flashcards, AND mind
+        # maps — distinguished by the format code at [9][1][0] (1=flashcards,
+        # 2=quiz, 4=mind map). Status 3 = completed.
+        def _matches_subtype(a: Any) -> bool:
+            code = self._interactive_format_code(a)
+            if is_quiz:
+                return code == 2
+            # Flashcards: accept legacy entries without a readable code, but
+            # never quizzes or mind maps.
+            return code not in (2, 4)
+
         candidates = [
             a
             for a in artifacts
@@ -1250,6 +1321,7 @@ class DownloadMixin(BaseClient):
             and len(a) > 4
             and a[2] == self.STUDIO_TYPE_FLASHCARDS
             and a[4] == 3
+            and _matches_subtype(a)
         ]
 
         if not candidates:

--- a/src/notebooklm_tools/core/notes.py
+++ b/src/notebooklm_tools/core/notes.py
@@ -8,9 +8,8 @@ This mixin provides note-related operations:
 - get_note: Get a single note's details
 """
 
-import json
-
 from .base import BaseClient
+from .utils import is_mind_map_json
 
 
 class NotesMixin(BaseClient):
@@ -108,21 +107,8 @@ class NotesMixin(BaseClient):
                     content = note_data[1] if len(note_data) > 1 else ""
                     title = note_data[4] if len(note_data) > 4 else "Untitled"
 
-                    # Distinguish notes from mind maps by checking if content is JSON
-                    # Mind maps have JSON with "children" or "nodes" keys
-                    is_mind_map = False
-                    if content:
-                        try:
-                            parsed = json.loads(content)
-                            if isinstance(parsed, dict) and (
-                                "children" in parsed or "nodes" in parsed
-                            ):
-                                is_mind_map = True
-                        except (json.JSONDecodeError, TypeError):
-                            pass
-
                     # Only include notes, not mind maps
-                    if not is_mind_map:
+                    if not is_mind_map_json(content):
                         notes.append(
                             {
                                 "id": note_id,

--- a/src/notebooklm_tools/core/studio.py
+++ b/src/notebooklm_tools/core/studio.py
@@ -6,7 +6,7 @@ from typing import Any, Protocol, cast
 
 from . import constants
 from .base import BaseClient
-from .utils import parse_timestamp
+from .utils import is_mind_map_json, parse_timestamp
 
 
 class _SourceLookupProtocol(Protocol):
@@ -1337,6 +1337,12 @@ class StudioMixin(BaseClient):
                     mind_map_json = details[1] if len(details) > 1 else None
                     title = details[4] if len(details) > 4 else "Mind Map"
                     metadata = details[2] if len(details) > 2 else []
+
+                    # The notes store holds both regular notes (prose content)
+                    # and mind maps (JSON content) — keep only real mind maps,
+                    # mirroring the inverse filter in NotesMixin.list_notes.
+                    if not is_mind_map_json(mind_map_json):
+                        continue
 
                     created_at = None
                     if isinstance(metadata, list) and len(metadata) > 2:

--- a/src/notebooklm_tools/core/studio.py
+++ b/src/notebooklm_tools/core/studio.py
@@ -439,17 +439,22 @@ class StudioMixin(BaseClient):
                 # Quiz and Flashcards share type code 4, distinguished by options[1][0]:
                 #   - Flashcards: options[1][0] == 1
                 #   - Quiz: options[1][0] == 2
+                #   - Mind map: options[1][0] == 4 (mind maps are stored as
+                #     type-4 studio artifacts too, not only in the notes store)
                 flashcard_count = None
                 is_quiz = False
+                is_mind_map = False
                 if type_code == self.STUDIO_TYPE_FLASHCARDS and len(artifact_data) > 9:
                     flashcard_options = artifact_data[9]
                     if isinstance(flashcard_options, list) and len(flashcard_options) > 1:
                         inner_options = flashcard_options[1]
                         if isinstance(inner_options, list) and len(inner_options) > 0:
-                            # Check format code: 1=flashcards, 2=quiz
+                            # Check format code: 1=flashcards, 2=quiz, 4=mind map
                             format_code = inner_options[0]
                             if format_code == 2:
                                 is_quiz = True
+                            elif format_code == 4:
+                                is_mind_map = True
                         # Count cards in the data
                         cards_data = (
                             flashcard_options[1] if isinstance(flashcard_options[1], list) else None
@@ -485,7 +490,12 @@ class StudioMixin(BaseClient):
                     self.STUDIO_TYPE_SLIDE_DECK: "slide_deck",
                     self.STUDIO_TYPE_DATA_TABLE: "data_table",
                 }
-                artifact_type = "quiz" if is_quiz else type_map.get(cast(int, type_code), "unknown")
+                if is_quiz:
+                    artifact_type = "quiz"
+                elif is_mind_map:
+                    artifact_type = "mind_map"
+                else:
+                    artifact_type = type_map.get(cast(int, type_code), "unknown")
                 status = self._normalize_studio_status(artifact_data)
 
                 # Extract custom_instructions (focus prompt) if present

--- a/src/notebooklm_tools/core/utils.py
+++ b/src/notebooklm_tools/core/utils.py
@@ -115,6 +115,22 @@ def parse_timestamp(ts_array: list | None) -> str | None:
         return None
 
 
+def is_mind_map_json(content: Any) -> bool:
+    """Return True if a note-store content string holds mind map JSON.
+
+    The notes RPC returns both regular notes (prose content) and mind maps
+    (stringified JSON with "children"/"nodes" keys) in the same list. This is
+    the single discriminator used by both the notes and mind map listers.
+    """
+    if not content or not isinstance(content, str):
+        return False
+    try:
+        parsed = json.loads(content)
+    except (json.JSONDecodeError, TypeError):
+        return False
+    return isinstance(parsed, dict) and ("children" in parsed or "nodes" in parsed)
+
+
 def extract_cookies_from_chrome_export(cookie_data: str | list[dict]) -> dict[str, str]:
     """Extract cookies from Chrome export format (JSON) or header string."""
     from notebooklm_tools.utils.browser import flatten_cookies

--- a/src/notebooklm_tools/mcp/server.py
+++ b/src/notebooklm_tools/mcp/server.py
@@ -53,6 +53,7 @@ Consolidated tools:
 - studio_create(artifact_type=audio|video|...): Create any artifact type
 - studio_revise: Revise individual slides in an existing slide deck
 - download_artifact(artifact_type=audio|video|...): Download any artifact type
+- download_all_artifacts: Download every completed artifact of a notebook into a per-notebook folder
 - note(action=create|list|update|delete): Manage notes in notebooks
 - label(action=auto|list|reorganize|create|rename|set_emoji|move_source|delete): Manage source labels""",
 )

--- a/src/notebooklm_tools/mcp/tool_groups.py
+++ b/src/notebooklm_tools/mcp/tool_groups.py
@@ -1,6 +1,6 @@
 """Optional group-based gating of MCP tools.
 
-The server registers a large tool set (39 tools). Clients that only need a
+The server registers a large tool set (40 tools). Clients that only need a
 subset can hide the rest to save context, without editing code, by toggling
 named groups or individual tools through environment variables.
 
@@ -94,6 +94,7 @@ TOOL_GROUPS: dict[str, set[str]] = {
         "studio_delete",
         "studio_revise",
         "download_artifact",
+        "download_all_artifacts",
         "export_artifact",
     },
 }

--- a/src/notebooklm_tools/mcp/tools/__init__.py
+++ b/src/notebooklm_tools/mcp/tools/__init__.py
@@ -8,7 +8,7 @@ from .chat import (
     notebook_query,
 )
 from .cross_notebook import cross_notebook_query
-from .downloads import download_artifact
+from .downloads import download_all_artifacts, download_artifact
 from .exports import (
     export_artifact,
 )
@@ -52,8 +52,9 @@ from .studio import (
 )
 
 __all__ = [
-    # Downloads (1 consolidated)
+    # Downloads (1 consolidated + 1 bulk)
     "download_artifact",
+    "download_all_artifacts",
     # Auth (2)
     "refresh_auth",
     "save_auth_tokens",

--- a/src/notebooklm_tools/mcp/tools/downloads.py
+++ b/src/notebooklm_tools/mcp/tools/downloads.py
@@ -74,50 +74,71 @@ def download_artifact(
 
 @logged_tool()
 def download_all_artifacts(
-    notebook_id: str,
+    notebook_id: str | None = None,
     output_dir: str = ".",
     artifact_types: list[str] | str | None = None,
     output_format: str = "json",
     slide_deck_format: str = "pdf",
+    all_notebooks: bool = False,
+    skip_existing: bool = False,
 ) -> ResultDict:
-    """Download all completed studio artifacts of a notebook in one call.
+    """Download all completed studio artifacts of one notebook — or every notebook.
 
-    Creates a subdirectory of output_dir named after the notebook title and
+    Creates a subdirectory of output_dir named after each notebook title and
     saves every completed artifact there, named after its title with the
     type's default extension (report → .md, mind_map → .json, video → .mp4,
     slide_deck → .pdf/.pptx, ...). Artifacts that are still generating or
     failed are skipped and listed in the result. A failure on one artifact
-    does not stop the others.
+    (or one notebook in a sweep) does not stop the others.
 
     Args:
-        notebook_id: Notebook UUID
-        output_dir: Base directory for the per-notebook folder (default: cwd)
+        notebook_id: Notebook UUID (omit when all_notebooks=True)
+        output_dir: Base directory for the per-notebook folders (default: cwd)
         artifact_types: Restrict to these types, e.g. ["video", "slide_deck",
             "mind_map", "report"]. Default: all types.
         output_format: For quiz/flashcards only: json|markdown|html
         slide_deck_format: For slide decks only: pdf (default) or pptx
+        all_notebooks: Sweep every notebook in the account instead of one
+        skip_existing: Skip artifacts whose target file already exists —
+            makes repeated runs incremental
 
     Returns:
-        dict with status, output_dir, per-artifact items, skipped artifacts,
-        and downloaded/failed counts
+        dict with status, output_dir, and per-artifact items (single notebook)
+        or per-notebook outcomes (sweep), plus downloaded/failed counts
 
     Example:
         download_all_artifacts(notebook_id="abc123", output_dir="exports")
-        download_all_artifacts(notebook_id="abc123", artifact_types=["video", "report"])
+        download_all_artifacts(all_notebooks=True, output_dir="exports", skip_existing=True)
     """
+    if all_notebooks == (notebook_id is not None):
+        return error_result("Provide either notebook_id or all_notebooks=True (not both).")
     try:
         client = get_client()
-        result = asyncio.run(
-            downloads_service.download_all(
-                client,
-                notebook_id,
-                output_dir,
-                artifact_types=coerce_list(artifact_types),
-                output_format=output_format,
-                slide_deck_format=slide_deck_format,
+        if all_notebooks:
+            result = asyncio.run(
+                downloads_service.download_all_notebooks(
+                    client,
+                    output_dir,
+                    artifact_types=coerce_list(artifact_types),
+                    output_format=output_format,
+                    slide_deck_format=slide_deck_format,
+                    skip_existing=skip_existing,
+                )
             )
-        )
-        if result["failed"] == 0:
+        else:
+            result = asyncio.run(
+                downloads_service.download_all(
+                    client,
+                    notebook_id,
+                    output_dir,
+                    artifact_types=coerce_list(artifact_types),
+                    output_format=output_format,
+                    slide_deck_format=slide_deck_format,
+                    skip_existing=skip_existing,
+                )
+            )
+        problems = result["failed"] + result.get("errored_notebooks", 0)
+        if problems == 0:
             status = "success"
         elif result["downloaded"] > 0:
             status = "partial"

--- a/src/notebooklm_tools/mcp/tools/downloads.py
+++ b/src/notebooklm_tools/mcp/tools/downloads.py
@@ -4,7 +4,7 @@ import asyncio
 
 from ...services import ServiceError, ValidationError
 from ...services import downloads as downloads_service
-from ._utils import ResultDict, error_result, get_client, logged_tool
+from ._utils import ResultDict, coerce_list, error_result, get_client, logged_tool
 
 
 @logged_tool()
@@ -66,6 +66,66 @@ def download_artifact(
         if message.startswith("Unknown artifact type "):
             message = message.replace("Unknown artifact type", "Unknown artifact_type", 1)
         return error_result(message)
+    except ServiceError as e:
+        return error_result(e.user_message, hint=e.hint)
+    except Exception as e:
+        return error_result(str(e))
+
+
+@logged_tool()
+def download_all_artifacts(
+    notebook_id: str,
+    output_dir: str = ".",
+    artifact_types: list[str] | str | None = None,
+    output_format: str = "json",
+    slide_deck_format: str = "pdf",
+) -> ResultDict:
+    """Download all completed studio artifacts of a notebook in one call.
+
+    Creates a subdirectory of output_dir named after the notebook title and
+    saves every completed artifact there, named after its title with the
+    type's default extension (report → .md, mind_map → .json, video → .mp4,
+    slide_deck → .pdf/.pptx, ...). Artifacts that are still generating or
+    failed are skipped and listed in the result. A failure on one artifact
+    does not stop the others.
+
+    Args:
+        notebook_id: Notebook UUID
+        output_dir: Base directory for the per-notebook folder (default: cwd)
+        artifact_types: Restrict to these types, e.g. ["video", "slide_deck",
+            "mind_map", "report"]. Default: all types.
+        output_format: For quiz/flashcards only: json|markdown|html
+        slide_deck_format: For slide decks only: pdf (default) or pptx
+
+    Returns:
+        dict with status, output_dir, per-artifact items, skipped artifacts,
+        and downloaded/failed counts
+
+    Example:
+        download_all_artifacts(notebook_id="abc123", output_dir="exports")
+        download_all_artifacts(notebook_id="abc123", artifact_types=["video", "report"])
+    """
+    try:
+        client = get_client()
+        result = asyncio.run(
+            downloads_service.download_all(
+                client,
+                notebook_id,
+                output_dir,
+                artifact_types=coerce_list(artifact_types),
+                output_format=output_format,
+                slide_deck_format=slide_deck_format,
+            )
+        )
+        if result["failed"] == 0:
+            status = "success"
+        elif result["downloaded"] > 0:
+            status = "partial"
+        else:
+            status = "error"
+        return {"status": status, **result}
+    except ValidationError as e:
+        return error_result(str(e))
     except ServiceError as e:
         return error_result(e.user_message, hint=e.hint)
     except Exception as e:

--- a/src/notebooklm_tools/services/downloads.py
+++ b/src/notebooklm_tools/services/downloads.py
@@ -10,7 +10,7 @@ from ..core.client import NotebookLMClient
 from ..core.errors import ArtifactDownloadError
 from ._compat import TypedDict
 from .errors import ServiceError, ValidationError
-from .notebooks import get_notebook
+from .notebooks import get_notebook, list_notebooks
 from .studio import get_studio_status
 
 VALID_ARTIFACT_TYPES = (
@@ -92,6 +92,29 @@ class DownloadAllResult(TypedDict):
     total_artifacts: int
     downloaded: int
     failed: int
+
+
+class NotebookSweepItem(TypedDict):
+    """Per-notebook outcome of a download_all_notebooks() sweep."""
+
+    notebook_id: str
+    notebook_title: str
+    output_dir: str | None
+    downloaded: int
+    failed: int
+    skipped: int
+    error: str | None
+
+
+class DownloadAllNotebooksResult(TypedDict):
+    """Result of sweeping every notebook with download_all()."""
+
+    output_dir: str
+    notebooks: list[NotebookSweepItem]
+    total_notebooks: int
+    downloaded: int
+    failed: int
+    errored_notebooks: int
 
 
 # Directories that are always blocked as download targets, regardless of platform.
@@ -375,6 +398,7 @@ async def download_all(
     artifact_types: Sequence[str] | None = None,
     output_format: str = "json",
     slide_deck_format: str = "pdf",
+    skip_existing: bool = False,
     progress_factory: Callable[[str, str], Callable[[int, int], None] | None] | None = None,
 ) -> DownloadAllResult:
     """Download every completed studio artifact of a notebook.
@@ -391,6 +415,8 @@ async def download_all(
         artifact_types: Restrict to these types (default: all valid types)
         output_format: For quiz/flashcards: json|markdown|html
         slide_deck_format: For slide decks: pdf (default) or pptx
+        skip_existing: Skip artifacts whose target file already exists,
+            making repeated runs incremental
         progress_factory: Called with (artifact_type, filename) before each
             streaming download; may return a (current, total) progress callback
 
@@ -473,6 +499,17 @@ async def download_all(
         used_names.add(filename)
         output_path = str(notebook_dir / filename)
 
+        if skip_existing and (notebook_dir / filename).exists():
+            skipped.append(
+                {
+                    "artifact_id": artifact_id,
+                    "artifact_type": artifact_type,
+                    "title": title,
+                    "reason": "already downloaded",
+                }
+            )
+            continue
+
         progress_callback = None
         if progress_factory is not None and artifact_type in STREAMING_TYPES:
             progress_callback = progress_factory(artifact_type, filename)
@@ -531,6 +568,117 @@ async def download_all(
         "total_artifacts": status["total"],
         "downloaded": downloaded,
         "failed": len(items) - downloaded,
+    }
+
+
+async def download_all_notebooks(
+    client: NotebookLMClient,
+    output_dir: str = ".",
+    artifact_types: Sequence[str] | None = None,
+    output_format: str = "json",
+    slide_deck_format: str = "pdf",
+    skip_existing: bool = False,
+    progress_factory: Callable[[str, str], Callable[[int, int], None] | None] | None = None,
+    on_notebook: Callable[[int, int, str], None] | None = None,
+) -> DownloadAllNotebooksResult:
+    """Run download_all() over every notebook in the account.
+
+    Each notebook gets its own subdirectory of ``output_dir``. A failure on
+    one notebook (or one artifact) is recorded and does not stop the sweep.
+    With ``skip_existing`` the sweep is incremental: artifacts whose target
+    file already exists are not re-downloaded.
+
+    Args:
+        client: Authenticated NotebookLM client
+        output_dir: Base directory for the per-notebook directories
+        artifact_types: Restrict to these types (default: all valid types)
+        output_format: For quiz/flashcards: json|markdown|html
+        slide_deck_format: For slide decks: pdf (default) or pptx
+        skip_existing: Skip artifacts whose target file already exists
+        progress_factory: Passed through to download_all() for each notebook
+        on_notebook: Called with (index, total, title) before each notebook —
+            a UX hook for progress narration
+
+    Returns:
+        DownloadAllNotebooksResult with per-notebook outcomes and totals
+
+    Raises:
+        ValidationError: If a requested type or format is invalid
+        ServiceError: If the notebook list cannot be retrieved
+    """
+    requested = tuple(artifact_types) if artifact_types else VALID_ARTIFACT_TYPES
+    for artifact_type in requested:
+        validate_artifact_type(artifact_type)
+    validate_output_format(output_format)
+    validate_slide_deck_format(slide_deck_format)
+
+    notebooks = list_notebooks(client)["notebooks"]
+
+    sweep: list[NotebookSweepItem] = []
+    total_downloaded = total_failed = 0
+    for index, notebook in enumerate(notebooks, 1):
+        title = notebook.get("title") or notebook["id"]
+        if on_notebook is not None:
+            on_notebook(index, len(notebooks), title)
+        try:
+            result = await download_all(
+                client,
+                notebook["id"],
+                output_dir,
+                artifact_types=artifact_types,
+                output_format=output_format,
+                slide_deck_format=slide_deck_format,
+                skip_existing=skip_existing,
+                progress_factory=progress_factory,
+            )
+        except ServiceError as e:
+            sweep.append(
+                {
+                    "notebook_id": notebook["id"],
+                    "notebook_title": title,
+                    "output_dir": None,
+                    "downloaded": 0,
+                    "failed": 0,
+                    "skipped": 0,
+                    "error": e.user_message or str(e),
+                }
+            )
+            continue
+        except Exception as e:
+            sweep.append(
+                {
+                    "notebook_id": notebook["id"],
+                    "notebook_title": title,
+                    "output_dir": None,
+                    "downloaded": 0,
+                    "failed": 0,
+                    "skipped": 0,
+                    "error": str(e),
+                }
+            )
+            continue
+
+        total_downloaded += result["downloaded"]
+        total_failed += result["failed"]
+        sweep.append(
+            {
+                "notebook_id": result["notebook_id"],
+                "notebook_title": result["notebook_title"],
+                "output_dir": result["output_dir"],
+                "downloaded": result["downloaded"],
+                "failed": result["failed"],
+                "skipped": len(result["skipped"]),
+                "error": None,
+            }
+        )
+
+    return {
+        "output_dir": str(Path(output_dir).expanduser()),
+        "notebooks": sweep,
+        "total_notebooks": len(notebooks),
+        "downloaded": total_downloaded,
+        "failed": total_failed,
+        "errored_notebooks": sum(1 for item in sweep if item["error"]),
     }
 
 

--- a/src/notebooklm_tools/services/downloads.py
+++ b/src/notebooklm_tools/services/downloads.py
@@ -1,7 +1,8 @@
 """Downloads service — shared validation and routing for artifact downloads."""
 
 import inspect
-from collections.abc import Awaitable, Callable
+import re
+from collections.abc import Awaitable, Callable, Sequence
 from pathlib import Path
 from typing import Any, cast
 
@@ -9,6 +10,8 @@ from ..core.client import NotebookLMClient
 from ..core.errors import ArtifactDownloadError
 from ._compat import TypedDict
 from .errors import ServiceError, ValidationError
+from .notebooks import get_notebook
+from .studio import get_studio_status
 
 VALID_ARTIFACT_TYPES = (
     "audio",
@@ -56,6 +59,39 @@ class DownloadResult(TypedDict):
 
     artifact_type: str
     path: str
+
+
+class DownloadAllItem(TypedDict):
+    """Outcome of one artifact download attempted by download_all()."""
+
+    artifact_id: str | None
+    artifact_type: str
+    title: str
+    path: str
+    success: bool
+    error: str | None
+
+
+class SkippedArtifact(TypedDict):
+    """An artifact download_all() saw but did not attempt to download."""
+
+    artifact_id: str | None
+    artifact_type: str
+    title: str
+    reason: str
+
+
+class DownloadAllResult(TypedDict):
+    """Result of downloading all artifacts of a notebook."""
+
+    notebook_id: str
+    notebook_title: str
+    output_dir: str
+    items: list[DownloadAllItem]
+    skipped: list[SkippedArtifact]
+    total_artifacts: int
+    downloaded: int
+    failed: int
 
 
 # Directories that are always blocked as download targets, regardless of platform.
@@ -295,6 +331,207 @@ async def download_async(
         )
 
     return {"artifact_type": artifact_type, "path": saved_path}
+
+
+_INVALID_FILENAME_CHARS = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+
+# Windows reserves these device names regardless of extension (CON.md is invalid).
+_RESERVED_FILENAMES = {
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    *(f"COM{i}" for i in range(1, 10)),
+    *(f"LPT{i}" for i in range(1, 10)),
+}
+
+
+def sanitize_filename(name: str, fallback: str = "untitled", max_length: int = 80) -> str:
+    """Turn an artifact/notebook title into a safe cross-platform file name.
+
+    Replaces characters invalid on Windows/POSIX, collapses whitespace, and
+    truncates. Returns ``fallback`` if nothing usable remains.
+    """
+    cleaned = re.sub(r"\s+", " ", name).strip()
+    cleaned = _INVALID_FILENAME_CHARS.sub("_", cleaned)
+    cleaned = cleaned[:max_length].rstrip(". ")
+    if cleaned.upper() in _RESERVED_FILENAMES:
+        cleaned = f"_{cleaned}"
+    return cleaned or fallback
+
+
+def validate_slide_deck_format(slide_deck_format: str) -> None:
+    """Validate slide deck file format. Raises ValidationError if invalid."""
+    if slide_deck_format not in ("pdf", "pptx"):
+        raise ValidationError(
+            f"Invalid slide deck format '{slide_deck_format}'. Valid formats: pdf, pptx",
+        )
+
+
+async def download_all(
+    client: NotebookLMClient,
+    notebook_id: str,
+    output_dir: str = ".",
+    artifact_types: Sequence[str] | None = None,
+    output_format: str = "json",
+    slide_deck_format: str = "pdf",
+    progress_factory: Callable[[str, str], Callable[[int, int], None] | None] | None = None,
+) -> DownloadAllResult:
+    """Download every completed studio artifact of a notebook.
+
+    Creates a subdirectory of ``output_dir`` named after the notebook title
+    and saves each artifact there, named after its title with the type's
+    default extension. Failures on individual artifacts are recorded and do
+    not stop the remaining downloads.
+
+    Args:
+        client: Authenticated NotebookLM client
+        notebook_id: Notebook UUID
+        output_dir: Base directory; the per-notebook directory is created inside
+        artifact_types: Restrict to these types (default: all valid types)
+        output_format: For quiz/flashcards: json|markdown|html
+        slide_deck_format: For slide decks: pdf (default) or pptx
+        progress_factory: Called with (artifact_type, filename) before each
+            streaming download; may return a (current, total) progress callback
+
+    Returns:
+        DownloadAllResult with per-artifact outcomes and summary counts
+
+    Raises:
+        ValidationError: If a requested type or format is invalid
+        ServiceError: If the artifact list cannot be retrieved
+    """
+    requested = tuple(artifact_types) if artifact_types else VALID_ARTIFACT_TYPES
+    for artifact_type in requested:
+        validate_artifact_type(artifact_type)
+    validate_output_format(output_format)
+    validate_slide_deck_format(slide_deck_format)
+
+    try:
+        notebook_title = get_notebook(client, notebook_id).get("title") or notebook_id
+    except Exception:
+        notebook_title = notebook_id
+
+    status = get_studio_status(client, notebook_id)
+
+    notebook_dir = Path(output_dir).expanduser() / sanitize_filename(
+        notebook_title, fallback=notebook_id
+    )
+    validate_output_path(str(notebook_dir))
+    notebook_dir.mkdir(parents=True, exist_ok=True)
+
+    items: list[DownloadAllItem] = []
+    skipped: list[SkippedArtifact] = []
+    used_names: set[str] = set()
+
+    for artifact in status["artifacts"]:
+        artifact_type = artifact.get("type") or "unknown"
+        title = artifact.get("title") or ""
+        artifact_id = artifact.get("artifact_id")
+
+        if artifact_type not in VALID_ARTIFACT_TYPES:
+            skipped.append(
+                {
+                    "artifact_id": artifact_id,
+                    "artifact_type": artifact_type,
+                    "title": title,
+                    "reason": f"unsupported artifact type '{artifact_type}'",
+                }
+            )
+            continue
+        if artifact_type not in requested:
+            skipped.append(
+                {
+                    "artifact_id": artifact_id,
+                    "artifact_type": artifact_type,
+                    "title": title,
+                    "reason": "type not requested",
+                }
+            )
+            continue
+        if artifact.get("status") != "completed":
+            skipped.append(
+                {
+                    "artifact_id": artifact_id,
+                    "artifact_type": artifact_type,
+                    "title": title,
+                    "reason": f"not completed (status: {artifact.get('status') or 'unknown'})",
+                }
+            )
+            continue
+
+        if artifact_type == "slide_deck":
+            ext = slide_deck_format
+        else:
+            ext = get_default_extension(artifact_type, output_format)
+        stem = sanitize_filename(title, fallback=artifact_type)
+        filename = f"{stem}.{ext}"
+        counter = 2
+        while filename in used_names:
+            filename = f"{stem}_{counter}.{ext}"
+            counter += 1
+        used_names.add(filename)
+        output_path = str(notebook_dir / filename)
+
+        progress_callback = None
+        if progress_factory is not None and artifact_type in STREAMING_TYPES:
+            progress_callback = progress_factory(artifact_type, filename)
+
+        try:
+            result = await download_async(
+                client,
+                notebook_id,
+                artifact_type,
+                output_path,
+                artifact_id=artifact_id,
+                output_format=output_format,
+                progress_callback=progress_callback,
+                slide_deck_format=slide_deck_format,
+            )
+            items.append(
+                {
+                    "artifact_id": artifact_id,
+                    "artifact_type": artifact_type,
+                    "title": title,
+                    "path": result["path"],
+                    "success": True,
+                    "error": None,
+                }
+            )
+        except ServiceError as e:
+            items.append(
+                {
+                    "artifact_id": artifact_id,
+                    "artifact_type": artifact_type,
+                    "title": title,
+                    "path": output_path,
+                    "success": False,
+                    "error": e.user_message or str(e),
+                }
+            )
+        except Exception as e:
+            items.append(
+                {
+                    "artifact_id": artifact_id,
+                    "artifact_type": artifact_type,
+                    "title": title,
+                    "path": output_path,
+                    "success": False,
+                    "error": str(e),
+                }
+            )
+
+    downloaded = sum(1 for item in items if item["success"])
+    return {
+        "notebook_id": notebook_id,
+        "notebook_title": notebook_title,
+        "output_dir": str(notebook_dir),
+        "items": items,
+        "skipped": skipped,
+        "total_artifacts": status["total"],
+        "downloaded": downloaded,
+        "failed": len(items) - downloaded,
+    }
 
 
 def _dispatch_sync(

--- a/tests/cli/test_verbs_parity.py
+++ b/tests/cli/test_verbs_parity.py
@@ -63,6 +63,7 @@ def _collect_pairs():
         ("query_notebook_verb", verbs.query_notebook_verb, notebook.query_notebook, set()),
         ("content_source_verb", verbs.content_source_verb, source.get_source_content, set()),
         ("download_slides_verb", verbs.download_slides_verb, download.download_slide_deck, set()),
+        ("download_all_verb", verbs.download_all_verb, download.download_all_cmd, set()),
         ("delete_alias_verb", verbs.delete_alias_verb, alias.delete_alias, set()),
         ("research_start_verb", verbs.research_start_verb, research.start_research, set()),
     ]

--- a/tests/core/test_download.py
+++ b/tests/core/test_download.py
@@ -348,3 +348,67 @@ class TestDownloadUrlCookies:
         headers = captured["headers"]
         assert headers.get("Sec-Fetch-Site") == "cross-site"
         assert headers.get("Referer") == f"{mixin._get_base_url()}/"
+
+
+class TestDownloadMindMapNoteFiltering:
+    """The notes store mixes notes and mind maps; download_mind_map must only
+    consider entries whose content is real mind map JSON."""
+
+    @staticmethod
+    def _mixin_with_entries(entries):
+        from unittest.mock import patch
+
+        from notebooklm_tools.core.download import DownloadMixin
+
+        with patch.object(DownloadMixin, "_refresh_auth_tokens"):
+            mixin = DownloadMixin(cookies={"test": "cookie"}, csrf_token="test")
+        patcher = patch.object(mixin, "_call_rpc", return_value=[entries])
+        patcher.start()
+        return mixin, patcher
+
+    _NOTE = [
+        "note-1",
+        ["note-1", "Prose note content, not JSON.", [None, None, None], None, "A Note"],
+        1,
+    ]
+    _MIND_MAP = [
+        "mm-1",
+        ["mm-1", '{"name": "Root", "children": []}', [None, None, None], None, "Real Map"],
+        1,
+    ]
+
+    def test_unqualified_download_skips_notes(self, tmp_path):
+        mixin, patcher = self._mixin_with_entries([self._NOTE, self._MIND_MAP])
+        try:
+            out = mixin.download_mind_map("nb-1", str(tmp_path / "mm.json"))
+        finally:
+            patcher.stop()
+        import json as _json
+
+        data = _json.loads((tmp_path / "mm.json").read_text(encoding="utf-8"))
+        assert data == {"name": "Root", "children": []}
+        assert out == str(tmp_path / "mm.json")
+
+    def test_note_id_reports_not_found(self, tmp_path):
+        import pytest as _pytest
+
+        from notebooklm_tools.core.errors import ArtifactNotFoundError
+
+        mixin, patcher = self._mixin_with_entries([self._NOTE, self._MIND_MAP])
+        try:
+            with _pytest.raises(ArtifactNotFoundError):
+                mixin.download_mind_map("nb-1", str(tmp_path / "mm.json"), "note-1")
+        finally:
+            patcher.stop()
+
+    def test_only_notes_reports_not_ready(self, tmp_path):
+        import pytest as _pytest
+
+        from notebooklm_tools.core.errors import ArtifactNotReadyError
+
+        mixin, patcher = self._mixin_with_entries([self._NOTE])
+        try:
+            with _pytest.raises(ArtifactNotReadyError):
+                mixin.download_mind_map("nb-1", str(tmp_path / "mm.json"))
+        finally:
+            patcher.stop()

--- a/tests/core/test_download.py
+++ b/tests/core/test_download.py
@@ -412,3 +412,102 @@ class TestDownloadMindMapNoteFiltering:
                 mixin.download_mind_map("nb-1", str(tmp_path / "mm.json"))
         finally:
             patcher.stop()
+
+
+class TestStudioMindMapDownload:
+    """Mind maps stored as type-4 studio artifacts (format code 4)."""
+
+    _MM_HTML = (
+        '<div data-app-data="{&quot;name&quot;: &quot;Root&quot;, &quot;children&quot;: []}"></div>'
+    )
+
+    @staticmethod
+    def _raw_type4(artifact_id, title, format_code):
+        return [
+            artifact_id,
+            title,
+            4,
+            None,
+            3,
+            None,
+            None,
+            None,
+            None,
+            ["", [format_code, None, None, "en", None, None, None, None, True]],
+        ]
+
+    @staticmethod
+    def _mixin():
+        from unittest.mock import patch
+
+        from notebooklm_tools.core.download import DownloadMixin
+
+        with patch.object(DownloadMixin, "_refresh_auth_tokens"):
+            return DownloadMixin(cookies={"test": "cookie"}, csrf_token="test")
+
+    def test_download_mind_map_falls_back_to_studio_artifact(self, tmp_path):
+        import json as _json
+        from unittest.mock import patch
+
+        mixin = self._mixin()
+        raw = self._raw_type4("mm-9", "Studio Map", 4)
+        with (
+            patch.object(mixin, "_call_rpc", return_value=[[]]),  # notes store empty
+            patch.object(mixin, "_list_raw", return_value=[raw]),
+            patch.object(mixin, "_get_artifact_content", return_value=self._MM_HTML),
+        ):
+            out = mixin.download_mind_map("nb-1", str(tmp_path / "mm.json"), "mm-9")
+
+        assert out == str(tmp_path / "mm.json")
+        data = _json.loads((tmp_path / "mm.json").read_text(encoding="utf-8"))
+        assert data == {"name": "Root", "children": []}
+
+    def test_unqualified_download_uses_studio_when_notes_store_empty(self, tmp_path):
+        import json as _json
+        from unittest.mock import patch
+
+        mixin = self._mixin()
+        raw = self._raw_type4("mm-9", "Studio Map", 4)
+        with (
+            patch.object(mixin, "_call_rpc", return_value=[[]]),
+            patch.object(mixin, "_list_raw", return_value=[raw]),
+            patch.object(mixin, "_get_artifact_content", return_value=self._MM_HTML),
+        ):
+            out = mixin.download_mind_map("nb-1", str(tmp_path / "mm.json"))
+
+        data = _json.loads((tmp_path / "mm.json").read_text(encoding="utf-8"))
+        assert data["name"] == "Root"
+        assert out == str(tmp_path / "mm.json")
+
+    @pytest.mark.asyncio
+    async def test_flashcards_download_excludes_mind_maps(self, tmp_path):
+        from unittest.mock import patch
+
+        from notebooklm_tools.core.errors import ArtifactNotReadyError
+
+        mixin = self._mixin()
+        raw = self._raw_type4("mm-9", "Studio Map", 4)
+        with (
+            patch.object(mixin, "_list_raw", return_value=[raw]),
+            pytest.raises(ArtifactNotReadyError),
+        ):
+            await mixin.download_flashcards("nb-1", str(tmp_path / "cards.json"))
+
+    @pytest.mark.asyncio
+    async def test_quiz_download_still_finds_quiz(self, tmp_path):
+        from unittest.mock import patch
+
+        quiz_html = '<div data-app-data="{&quot;quiz&quot;: [{&quot;question&quot;: &quot;Q1&quot;}]}"></div>'
+        mixin = self._mixin()
+        raws = [
+            self._raw_type4("mm-9", "Studio Map", 4),
+            self._raw_type4("q-1", "The Quiz", 2),
+        ]
+        with (
+            patch.object(mixin, "_list_raw", return_value=raws),
+            patch.object(mixin, "_get_artifact_content", return_value=quiz_html) as mock_content,
+        ):
+            out = await mixin.download_quiz("nb-1", str(tmp_path / "quiz.json"))
+
+        assert out == str(tmp_path / "quiz.json")
+        assert mock_content.call_args[0][1] == "q-1"

--- a/tests/core/test_studio.py
+++ b/tests/core/test_studio.py
@@ -429,3 +429,47 @@ class TestShortVideoFormat:
         assert result["format"] == "short"
         assert result["visual_style"] is None
         assert result["language"] == "en"
+
+
+def test_list_mind_maps_excludes_prose_notes():
+    """Issue: the notes store mixes notes and mind maps; only real mind maps
+    (JSON content with children/nodes) may be returned as mind maps."""
+    from unittest.mock import patch
+
+    from notebooklm_tools.core.studio import StudioMixin
+
+    mind_map_entry = [
+        "mm-1",
+        [
+            "mm-1",
+            '{"name": "Root", "children": []}',
+            [None, None, [1700000000, 0]],
+            None,
+            "Real Map",
+        ],
+        1,
+    ]
+    note_entry = [
+        "note-1",
+        [
+            "note-1",
+            "To run Docling locally, follow these steps...",
+            [None, None, None],
+            None,
+            "A Note",
+        ],
+        1,
+    ]
+    tombstone_entry = ["gone-1", None, 2]
+
+    with (
+        patch.object(StudioMixin, "_refresh_auth_tokens"),
+        patch.object(StudioMixin, "_call_rpc") as mock_rpc,
+    ):
+        mock_rpc.return_value = [[note_entry, mind_map_entry, tombstone_entry]]
+        mixin = StudioMixin(cookies={"test": "cookie"}, csrf_token="test")
+        result = mixin.list_mind_maps("nb-1")
+
+    assert len(result) == 1
+    assert result[0]["mind_map_id"] == "mm-1"
+    assert result[0]["title"] == "Real Map"

--- a/tests/core/test_studio.py
+++ b/tests/core/test_studio.py
@@ -473,3 +473,42 @@ def test_list_mind_maps_excludes_prose_notes():
     assert len(result) == 1
     assert result[0]["mind_map_id"] == "mm-1"
     assert result[0]["title"] == "Real Map"
+
+
+def _raw_type4_artifact(artifact_id, title, format_code):
+    """Raw poll entry for a type-4 (interactive) studio artifact."""
+    return [
+        artifact_id,
+        title,
+        4,  # STUDIO_TYPE_FLASHCARDS — shared by flashcards/quiz/mind map
+        None,
+        3,  # completed
+        None,
+        None,
+        None,
+        None,
+        ["", [format_code, None, None, "en", None, None, None, None, True]],
+    ]
+
+
+def test_poll_studio_status_classifies_type4_subtypes():
+    """Type-4 artifacts split by format code: 1=flashcards, 2=quiz, 4=mind map."""
+    from unittest.mock import patch
+
+    from notebooklm_tools.core.studio import StudioMixin
+
+    raw = [
+        _raw_type4_artifact("f-1", "Cards", 1),
+        _raw_type4_artifact("q-1", "Quiz", 2),
+        _raw_type4_artifact("mm-1", "Map", 4),
+    ]
+    with (
+        patch.object(StudioMixin, "_refresh_auth_tokens"),
+        patch.object(StudioMixin, "_call_rpc") as mock_rpc,
+    ):
+        mock_rpc.return_value = [raw]
+        mixin = StudioMixin(cookies={"test": "cookie"}, csrf_token="test")
+        artifacts = mixin.poll_studio_status("nb-1")
+
+    types = {a["artifact_id"]: a["type"] for a in artifacts}
+    assert types == {"f-1": "flashcards", "q-1": "quiz", "mm-1": "mind_map"}

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -1,6 +1,7 @@
 from notebooklm_tools.core.utils import (
     RPC_NAMES,
     extract_cookies_from_chrome_export,
+    is_mind_map_json,
     parse_timestamp,
 )
 
@@ -44,3 +45,24 @@ def test_extract_cookies_from_chrome_export_json_list_prefers_google_com():
 
 def test_rpc_names_exists():
     assert "wXbhsf" in RPC_NAMES
+
+
+class TestIsMindMapJson:
+    def test_children_key_is_mind_map(self):
+        assert is_mind_map_json('{"name": "Root", "children": []}') is True
+
+    def test_nodes_key_is_mind_map(self):
+        assert is_mind_map_json('{"nodes": []}') is True
+
+    def test_prose_note_is_not_mind_map(self):
+        assert is_mind_map_json("To run Docling locally, follow these steps...") is False
+
+    def test_json_without_mind_map_keys_is_not_mind_map(self):
+        assert is_mind_map_json('{"name": "just a dict"}') is False
+
+    def test_json_list_is_not_mind_map(self):
+        assert is_mind_map_json('[{"children": []}]') is False
+
+    def test_empty_and_none_are_not_mind_maps(self):
+        assert is_mind_map_json("") is False
+        assert is_mind_map_json(None) is False

--- a/tests/services/test_downloads.py
+++ b/tests/services/test_downloads.py
@@ -9,6 +9,7 @@ from notebooklm_tools.services.downloads import (
     VALID_ARTIFACT_TYPES,
     VALID_OUTPUT_FORMATS,
     download_all,
+    download_all_notebooks,
     download_async,
     download_sync,
     get_default_extension,
@@ -491,3 +492,117 @@ class TestDownloadAll:
         args = bulk_client.download_mind_map.call_args
         assert args[0][0] == "nb-1"
         assert args[0][2] == "mm-7"
+
+    @pytest.mark.asyncio
+    async def test_skip_existing_skips_present_files(self, bulk_client, monkeypatch, tmp_path):
+        _patch_lookups(
+            monkeypatch,
+            [
+                _artifact(artifact_id="a1", type="report", title="Existing"),
+                _artifact(artifact_id="a2", type="report", title="Fresh"),
+            ],
+        )
+        nb_dir = tmp_path / "My Notebook"
+        nb_dir.mkdir()
+        (nb_dir / "Existing.md").write_text("old content", encoding="utf-8")
+
+        result = await download_all(bulk_client, "nb-1", str(tmp_path), skip_existing=True)
+
+        assert result["downloaded"] == 1
+        assert result["items"][0]["title"] == "Fresh"
+        assert result["skipped"][0]["reason"] == "already downloaded"
+        assert (nb_dir / "Existing.md").read_text(encoding="utf-8") == "old content"
+
+    @pytest.mark.asyncio
+    async def test_without_skip_existing_overwrites(self, bulk_client, monkeypatch, tmp_path):
+        _patch_lookups(monkeypatch, [_artifact(artifact_id="a1", type="report", title="Existing")])
+        nb_dir = tmp_path / "My Notebook"
+        nb_dir.mkdir()
+        (nb_dir / "Existing.md").write_text("old content", encoding="utf-8")
+
+        result = await download_all(bulk_client, "nb-1", str(tmp_path))
+
+        assert result["downloaded"] == 1
+        assert result["skipped"] == []
+
+
+def _patch_notebook_list(monkeypatch, notebooks):
+    monkeypatch.setattr(
+        "notebooklm_tools.services.downloads.list_notebooks",
+        lambda client: {"notebooks": notebooks},
+    )
+
+
+class TestDownloadAllNotebooks:
+    """Test download_all_notebooks — the account-wide sweep."""
+
+    @pytest.mark.asyncio
+    async def test_sweeps_every_notebook(self, bulk_client, monkeypatch, tmp_path):
+        _patch_notebook_list(
+            monkeypatch,
+            [{"id": "nb-1", "title": "First"}, {"id": "nb-2", "title": "Second"}],
+        )
+        monkeypatch.setattr(
+            "notebooklm_tools.services.downloads.get_notebook",
+            lambda client, nb: {
+                "notebook_id": nb,
+                "title": {"nb-1": "First", "nb-2": "Second"}[nb],
+            },
+        )
+        monkeypatch.setattr(
+            "notebooklm_tools.services.downloads.get_studio_status",
+            lambda client, nb: {
+                "artifacts": [_artifact(artifact_id=f"{nb}-a1", type="report", title="Report")],
+                "total": 1,
+                "completed": 1,
+                "in_progress": 0,
+            },
+        )
+
+        seen: list[tuple[int, int, str]] = []
+        result = await download_all_notebooks(
+            bulk_client, str(tmp_path), on_notebook=lambda i, n, t: seen.append((i, n, t))
+        )
+
+        assert result["total_notebooks"] == 2
+        assert result["downloaded"] == 2
+        assert result["failed"] == 0
+        assert result["errored_notebooks"] == 0
+        assert seen == [(1, 2, "First"), (2, 2, "Second")]
+        assert (tmp_path / "First" / "Report.md").name == "Report.md"
+        assert [nb["notebook_title"] for nb in result["notebooks"]] == ["First", "Second"]
+
+    @pytest.mark.asyncio
+    async def test_notebook_error_does_not_stop_sweep(self, bulk_client, monkeypatch, tmp_path):
+        _patch_notebook_list(
+            monkeypatch,
+            [{"id": "nb-bad", "title": "Broken"}, {"id": "nb-ok", "title": "Fine"}],
+        )
+        monkeypatch.setattr(
+            "notebooklm_tools.services.downloads.get_notebook",
+            lambda client, nb: {"notebook_id": nb, "title": "Fine" if nb == "nb-ok" else "Broken"},
+        )
+
+        def _status(client, nb):
+            if nb == "nb-bad":
+                raise ServiceError("poll failed", user_message="Could not retrieve studio status.")
+            return {
+                "artifacts": [_artifact(artifact_id="a1", type="report", title="Report")],
+                "total": 1,
+                "completed": 1,
+                "in_progress": 0,
+            }
+
+        monkeypatch.setattr("notebooklm_tools.services.downloads.get_studio_status", _status)
+
+        result = await download_all_notebooks(bulk_client, str(tmp_path))
+
+        assert result["errored_notebooks"] == 1
+        assert result["downloaded"] == 1
+        bad = next(nb for nb in result["notebooks"] if nb["notebook_id"] == "nb-bad")
+        assert bad["error"] == "Could not retrieve studio status."
+
+    @pytest.mark.asyncio
+    async def test_invalid_type_raises_before_listing(self, bulk_client, tmp_path):
+        with pytest.raises(ValidationError, match="Unknown artifact type"):
+            await download_all_notebooks(bulk_client, str(tmp_path), artifact_types=["podcast"])

--- a/tests/services/test_downloads.py
+++ b/tests/services/test_downloads.py
@@ -8,9 +8,11 @@ from notebooklm_tools.core.errors import ArtifactDownloadError
 from notebooklm_tools.services.downloads import (
     VALID_ARTIFACT_TYPES,
     VALID_OUTPUT_FORMATS,
+    download_all,
     download_async,
     download_sync,
     get_default_extension,
+    sanitize_filename,
     validate_artifact_type,
     validate_audio_extension,
     validate_output_format,
@@ -275,3 +277,217 @@ class TestValidateAudioExtension:
         """Issue #185: download_sync must also reject .mp3 for audio."""
         with pytest.raises(ValidationError, match="cannot honor"):
             download_sync(mock_client, "nb-1", "audio", "/tmp/out.mp3")
+
+
+class TestSanitizeFilename:
+    """Test sanitize_filename function."""
+
+    def test_invalid_chars_replaced(self):
+        assert sanitize_filename('a<b>c:d"e/f\\g|h?i*j') == "a_b_c_d_e_f_g_h_i_j"
+
+    def test_whitespace_collapsed(self):
+        assert sanitize_filename("  My   Report\ttitle ") == "My Report title"
+
+    def test_empty_returns_fallback(self):
+        assert sanitize_filename("", fallback="report") == "report"
+
+    def test_whitespace_only_returns_fallback(self):
+        assert sanitize_filename("   ", fallback="report") == "report"
+
+    def test_truncates_long_names(self):
+        assert len(sanitize_filename("x" * 500)) == 80
+
+    def test_trailing_dots_stripped(self):
+        assert sanitize_filename("notes...") == "notes"
+
+    def test_windows_reserved_names_prefixed(self):
+        assert sanitize_filename("CON") == "_CON"
+
+
+def _artifact(**overrides):
+    base = {
+        "artifact_id": "art-1",
+        "type": "report",
+        "title": "My Artifact",
+        "status": "completed",
+    }
+    base.update(overrides)
+    return base
+
+
+def _echo_path_sync(notebook_id, output_path, artifact_id=None, *args, **kwargs):
+    return output_path
+
+
+async def _echo_path_async(notebook_id, output_path, artifact_id=None, *args, **kwargs):
+    return output_path
+
+
+@pytest.fixture
+def bulk_client():
+    """Client whose download methods return the requested output path."""
+    client = MagicMock()
+    for name in (
+        "download_audio",
+        "download_video",
+        "download_slide_deck",
+        "download_infographic",
+        "download_quiz",
+        "download_flashcards",
+    ):
+        setattr(client, name, AsyncMock(side_effect=_echo_path_async))
+    for name in ("download_report", "download_mind_map", "download_data_table"):
+        getattr(client, name).side_effect = _echo_path_sync
+    return client
+
+
+def _patch_lookups(monkeypatch, artifacts, title="My Notebook"):
+    monkeypatch.setattr(
+        "notebooklm_tools.services.downloads.get_studio_status",
+        lambda client, nb: {
+            "artifacts": artifacts,
+            "total": len(artifacts),
+            "completed": sum(1 for a in artifacts if a.get("status") == "completed"),
+            "in_progress": sum(1 for a in artifacts if a.get("status") == "in_progress"),
+        },
+    )
+    monkeypatch.setattr(
+        "notebooklm_tools.services.downloads.get_notebook",
+        lambda client, nb: {"notebook_id": nb, "title": title},
+    )
+
+
+class TestDownloadAll:
+    """Test download_all — bulk download into a per-notebook directory."""
+
+    @pytest.mark.asyncio
+    async def test_downloads_all_completed_artifacts(self, bulk_client, monkeypatch, tmp_path):
+        _patch_lookups(
+            monkeypatch,
+            [
+                _artifact(artifact_id="a1", type="video", title="Overview Video"),
+                _artifact(artifact_id="a2", type="report", title="Briefing"),
+                _artifact(artifact_id="a3", type="mind_map", title="Map"),
+                _artifact(artifact_id="a4", type="slide_deck", title="Deck"),
+            ],
+        )
+        result = await download_all(bulk_client, "nb-1", str(tmp_path))
+
+        assert result["downloaded"] == 4
+        assert result["failed"] == 0
+        assert result["skipped"] == []
+        assert result["notebook_title"] == "My Notebook"
+        assert result["output_dir"] == str(tmp_path / "My Notebook")
+        paths = {item["artifact_type"]: item["path"] for item in result["items"]}
+        assert paths["video"].endswith("Overview Video.mp4")
+        assert paths["report"].endswith("Briefing.md")
+        assert paths["mind_map"].endswith("Map.json")
+        assert paths["slide_deck"].endswith("Deck.pdf")
+        assert (tmp_path / "My Notebook").is_dir()
+
+    @pytest.mark.asyncio
+    async def test_skips_non_completed_artifacts(self, bulk_client, monkeypatch, tmp_path):
+        _patch_lookups(
+            monkeypatch,
+            [
+                _artifact(type="video", status="in_progress"),
+                _artifact(type="audio", status="failed"),
+            ],
+        )
+        result = await download_all(bulk_client, "nb-1", str(tmp_path))
+
+        assert result["downloaded"] == 0
+        assert result["failed"] == 0
+        assert len(result["skipped"]) == 2
+        assert "not completed" in result["skipped"][0]["reason"]
+
+    @pytest.mark.asyncio
+    async def test_types_filter(self, bulk_client, monkeypatch, tmp_path):
+        _patch_lookups(
+            monkeypatch,
+            [
+                _artifact(artifact_id="a1", type="video"),
+                _artifact(artifact_id="a2", type="report"),
+            ],
+        )
+        result = await download_all(bulk_client, "nb-1", str(tmp_path), artifact_types=["report"])
+
+        assert result["downloaded"] == 1
+        assert result["items"][0]["artifact_type"] == "report"
+        assert result["skipped"][0]["reason"] == "type not requested"
+
+    @pytest.mark.asyncio
+    async def test_invalid_type_filter_raises(self, bulk_client, tmp_path):
+        with pytest.raises(ValidationError, match="Unknown artifact type"):
+            await download_all(bulk_client, "nb-1", str(tmp_path), artifact_types=["podcast"])
+
+    @pytest.mark.asyncio
+    async def test_one_failure_does_not_stop_others(self, bulk_client, monkeypatch, tmp_path):
+        bulk_client.download_video = AsyncMock(side_effect=RuntimeError("boom"))
+        _patch_lookups(
+            monkeypatch,
+            [
+                _artifact(artifact_id="a1", type="video", title="Video"),
+                _artifact(artifact_id="a2", type="report", title="Report"),
+            ],
+        )
+        result = await download_all(bulk_client, "nb-1", str(tmp_path))
+
+        assert result["downloaded"] == 1
+        assert result["failed"] == 1
+        failed = [item for item in result["items"] if not item["success"]]
+        assert failed[0]["artifact_type"] == "video"
+        assert failed[0]["error"]
+
+    @pytest.mark.asyncio
+    async def test_filename_collision_deduped(self, bulk_client, monkeypatch, tmp_path):
+        _patch_lookups(
+            monkeypatch,
+            [
+                _artifact(artifact_id="a1", type="report", title="Same"),
+                _artifact(artifact_id="a2", type="report", title="Same"),
+            ],
+        )
+        result = await download_all(bulk_client, "nb-1", str(tmp_path))
+
+        names = sorted(
+            item["path"].replace("\\", "/").rsplit("/", 1)[1] for item in result["items"]
+        )
+        assert names == ["Same.md", "Same_2.md"]
+
+    @pytest.mark.asyncio
+    async def test_directory_falls_back_to_notebook_id(self, bulk_client, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "notebooklm_tools.services.downloads.get_studio_status",
+            lambda client, nb: {"artifacts": [], "total": 0, "completed": 0, "in_progress": 0},
+        )
+
+        def _raise(client, nb):
+            raise ServiceError("nope")
+
+        monkeypatch.setattr("notebooklm_tools.services.downloads.get_notebook", _raise)
+        result = await download_all(bulk_client, "nb-1", str(tmp_path))
+
+        assert result["notebook_title"] == "nb-1"
+        assert result["output_dir"] == str(tmp_path / "nb-1")
+
+    @pytest.mark.asyncio
+    async def test_slide_format_pptx_extension(self, bulk_client, monkeypatch, tmp_path):
+        _patch_lookups(monkeypatch, [_artifact(artifact_id="a1", type="slide_deck", title="Deck")])
+        result = await download_all(bulk_client, "nb-1", str(tmp_path), slide_deck_format="pptx")
+
+        assert result["items"][0]["path"].endswith("Deck.pptx")
+
+    @pytest.mark.asyncio
+    async def test_invalid_slide_format_raises(self, bulk_client, tmp_path):
+        with pytest.raises(ValidationError, match="slide deck format"):
+            await download_all(bulk_client, "nb-1", str(tmp_path), slide_deck_format="keynote")
+
+    @pytest.mark.asyncio
+    async def test_artifact_ids_passed_through(self, bulk_client, monkeypatch, tmp_path):
+        _patch_lookups(monkeypatch, [_artifact(artifact_id="mm-7", type="mind_map", title="Map")])
+        await download_all(bulk_client, "nb-1", str(tmp_path))
+
+        args = bulk_client.download_mind_map.call_args
+        assert args[0][0] == "nb-1"
+        assert args[0][2] == "mm-7"


### PR DESCRIPTION
# Bulk artifact download: `nlm download all` + `--all-notebooks` sweep, and two mind map fixes

## What this adds

**`nlm download all <notebook>`** — downloads every completed studio artifact of a notebook into a directory named after the notebook title, with files named after artifact titles (report → `.md`, mind_map → `.json`, video → `.mp4`, slide_deck → `.pdf`/`.pptx`, ...). Failures on one artifact are recorded per-item and don't stop the rest; in-progress/failed artifacts are reported as skipped.

**`nlm download all --all-notebooks [--skip-existing]`** — sweeps every notebook in the account. `--skip-existing` works at the file level, so re-runs are incremental: a newly generated artifact in an already-exported notebook is still fetched, while existing files are never re-downloaded. One broken notebook doesn't stop the sweep.

**MCP:** a matching `download_all_artifacts` tool (with `all_notebooks` / `skip_existing` params), registered in the `studio` tool group.

Layering follows the repo rules: business logic in `services/downloads.py` (`download_all()`, `download_all_notebooks()`), thin wrappers in `cli/commands/download.py` (+ verb wrapper with parity-test entry) and `mcp/tools/downloads.py`.

## Two bugs found and fixed along the way

1. **Notes listed as mind maps** (`e3f285f`): the notes store holds both prose notes and mind maps, and `list_mind_maps()` returned everything — a notebook with 11 saved notes reported 11 phantom "mind maps" that all failed to download (prose isn't JSON). `list_notes()` already had the JSON-with-`children`/`nodes` discriminator; it's now shared via `core/utils.is_mind_map_json()` and applied on the mind-map side too.

2. **Type-4 mind maps classified as flashcards** (`3dee872`): newer mind maps are stored as **type-4 studio artifacts** — the type code shared with flashcards/quiz — distinguished by an undocumented format code at `artifact[9][1][0]` (1=flashcards, 2=quiz, **4=mind map**). They were parsed as flashcards and downloaded as empty `{"title", "cards": []}` stubs. The parser now classifies format code 4 as `mind_map`; `download_mind_map` falls back to the studio-side artifact (extracting the `{"name", "children"}` JSON from the interactive HTML `data-app-data`, same mechanism as quiz/flashcards); and quiz/flashcards downloads filter by format code so they can't pick up a mind map. Format codes documented in `docs/API_REFERENCE.md`.

## Verification against the live API

- **Full-account sweep**: 100 notebooks, 327 artifacts, 3.7 GB (95 mp4, 97 pdf, 103 json, 24 md, 7 m4a, 1 png), 0 failures.
- **Incremental re-run**: second sweep with `--skip-existing` → `0 downloaded, 0 failed across 100 notebooks`, all artifacts skipped as "already downloaded"; a transient Google 502 mid-run was absorbed by the existing retry logic.
- **New-artifact round trip**: created a mind map, re-ran the sweep → exactly 1 file downloaded, everything else skipped; verified the downloaded JSON is the real `{"name", "children"}` tree (4.4 KB), not the previous 78-byte flashcards stub.
- **Notes-vs-mindmap fix**: notebook with 11 saved notes went from "11 phantom mind maps, all failing" to "0 mind maps / 11 notes" (verified via `list_mind_maps`/`list_notes` against the live API).

## Testing

- 21 new unit tests (`tests/services/test_downloads.py`, `tests/core/test_studio.py`, `tests/core/test_download.py`, `tests/core/test_utils.py`, plus a verbs-parity entry); full suite: **1127 passed** with `pytest -m "not e2e"`, `ruff check` and `ruff format --check` clean.
- CLI verified live end-to-end (all commands above). The MCP tool is a thin wrapper over the same service functions; it's covered by the unit tests and registration checks (40 tools grouped) but was not exercised through a live MCP client session.

Docs updated: `docs/MCP_CLI_TEST_PLAN.md` (tests 6.6/6.7), `docs/API_REFERENCE.md` (type-4 format codes), `CLAUDE.md` (tools table). No version bump, per contribution guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
