### PR TITLE
fix(security): add confirmation gate to save_auth_tokens and remove cache_path disclosure

### DIFF
--- a/src/notebooklm_tools/mcp/tools/auth.py
+++ b/src/notebooklm_tools/mcp/tools/auth.py
@@ -97,12 +97,15 @@ def save_auth_tokens(
     session_id: str = "",
     request_body: str = "",
     request_url: str = "",
+    confirm: bool = False,
 ) -> ResultDict:
     """Save NotebookLM cookies (FALLBACK method - try `nlm login` first!).
 
     IMPORTANT FOR AI ASSISTANTS:
     - First, run `nlm login` via Bash/terminal (automated, preferred)
     - Only use this tool if the automated CLI fails
+    - This tool requires confirm=True to proceed — do not set confirm=True
+      unless the user has explicitly approved saving auth tokens
 
     Args:
         cookies: Cookie header from Chrome DevTools (only needed if CLI fails)
@@ -110,7 +113,17 @@ def save_auth_tokens(
         session_id: Deprecated - auto-extracted
         request_body: Optional - contains CSRF if extracting manually
         request_url: Optional - contains session ID if extracting manually
+        confirm: Must be True to proceed — prevents automatic cookie overwrites
+            by LLM agents without user approval
     """
+    if not confirm:
+        return error_result(
+            "Saving auth tokens requires user confirmation. "
+            "Set confirm=True to proceed. This protects against "
+            "unintended session hijacking via prompt injection.",
+            status="confirmation_required",
+        )
+
     try:
         from notebooklm_tools.services.auth import (
             AuthTokens,
@@ -186,7 +199,8 @@ def save_auth_tokens(
         return {
             "status": "success",
             "message": f"Saved {len(cookie_dict)} essential cookies (filtered from {len(all_cookies)}). {token_msg}",
-            "cache_path": str(get_cache_path()),
+            # Note: cache_path intentionally omitted from response to prevent
+            # path disclosure that could aid cookie exfiltration.
             "extracted_csrf": bool(csrf_token),
             "extracted_session_id": bool(session_id),
         }


### PR DESCRIPTION
## Summary

The `save_auth_tokens` MCP tool allowed the LLM agent to write arbitrary Google session cookies (SID, HSID, SSID, APISID, SAPISID) to the auth cache file with no confirmation gate. An attacker who achieves prompt injection can hijack the user's Google session or exfiltrate their cookies via the `cache_path` in the response.

### Impact
- **Confidentiality**: `cache_path` in response leaks cookie storage location
- **Integrity**: Attacker can overwrite victim's cookies with their own, hijacking the Google session
- **CVSS**: 8.1 (AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N)

### Attack Scenario
1. Attacker achieves prompt injection on the LLM agent
2. Instructs LLM to call `save_auth_tokens(cookies="SID=attacker_value; HSID=...; SSID=...; APISID=...; SAPISID=...")`
3. Victim's real cookies are overwritten with attacker's cookies
4. All subsequent NotebookLM operations use attacker's account

## Fix

Two changes:

1. **Add `confirm` parameter** (default `False`) — matching the confirmation pattern used by other tools in this codebase. LLM agents must not set `confirm=True` without explicit user approval. The tool description warns against automatic confirmation.

2. **Remove `cache_path` from response** — prevents path disclosure that could aid cookie exfiltration.

**Opt-in design**: `confirm=False` by default means the tool is safe — it returns an error unless the user explicitly approves.

## Testing
- `save_auth_tokens(cookies="...")` → ❌ "confirmation_required" error
- `save_auth_tokens(cookies="...", confirm=True)` → ✅ proceeds (user approved)
- Response no longer contains `cache_path`

## Checklist
- [x] Opt-in default (confirm=False = safe)
- [x] Follows existing confirmation pattern in the codebase
- [x] No breaking changes for interactive use (users always confirm manually)