### PR TITLE
Docs, tests, and v0.9.0 for the download_all feature (#264, #258)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-07-20
+
+### Added
+- **Bulk artifact download (#264)** — New MCP tool `download_all_artifacts` and CLI command `nlm download all` download every completed Studio artifact of a notebook — or every notebook in the account with `--all-notebooks`/`all_notebooks=True` — into per-notebook directories named after each notebook's title. Supports an `--types`/`artifact_types` filter, `--skip-existing`/`skip_existing` for incremental re-runs, and safe cross-platform filenames (invalid characters replaced, Windows reserved names escaped, collisions deduped case-insensitively for both notebook directories and artifact filenames). A failure on one artifact or notebook is recorded and does not stop the rest; the CLI exits non-zero only when nothing was downloaded and failures occurred. Thanks to **@runthangs** for the contribution (PR #264, addressing review feedback from #258)!
+
+### Documentation
+- Reconciled the MCP tool count (39 → 40) and added `download_all_artifacts`/`nlm download all` across the README, MCP Guide, CLI Guide, packaged skill, and command reference.
+
 ## [0.8.9] - 2026-07-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ nlm notebook create "Research Project"         # Create a notebook
 nlm source add <notebook> --url "https://..."  # Add sources
 nlm audio create <notebook> --confirm          # Generate podcast
 nlm download audio <notebook> <artifact-id>    # Download audio file
+nlm download all <notebook> -d ./exports       # Download every artifact
 nlm share public <notebook>                    # Enable public link
 ```
 
@@ -85,6 +86,7 @@ Then use natural language: *"Create a notebook about quantum computing and gener
 | Create Studio Content (Audio, Video, etc.) | `nlm studio create` | `studio_create` |
 | Revise slide decks | `nlm slides revise` | `studio_revise` |
 | Download artifacts | `nlm download <type>` | `download_artifact` |
+| Download all artifacts (one or all notebooks) | `nlm download all` | `download_all_artifacts` |
 | Web/Drive research | `nlm research start` | `research_start` |
 | Share notebook | `nlm share public/invite` | `notebook_share_*` |
 | Sync Drive sources | `nlm source sync` | `source_sync_drive` |
@@ -99,7 +101,7 @@ Then use natural language: *"Create a notebook about quantum computing and gener
 📚 **More Documentation:**
 - **[Getting Started](docs/GETTING_STARTED.md)** — Install, login, agent setup, and migration from another NotebookLM MCP
 - **[CLI Guide](docs/CLI_GUIDE.md)** — Complete command reference
-- **[MCP Guide](docs/MCP_GUIDE.md)** — All 35 MCP tools with examples
+- **[MCP Guide](docs/MCP_GUIDE.md)** — All 40 MCP tools with examples
 - **[Authentication](docs/AUTHENTICATION.md)** — Setup and troubleshooting
 - **[Remote MCP](docs/REMOTE_MCP.md)** — Web/mobile connector feasibility, security, and authentication limitations
 - **[API Reference](docs/API_REFERENCE.md)** — Internal API docs for contributors
@@ -320,7 +322,7 @@ For detailed instructions and troubleshooting, see **[docs/AUTHENTICATION.md](do
 
 ## MCP Configuration
 
-> **⚠️ Context Window Warning:** This MCP provides **39 tools**. Disable it when not using NotebookLM to preserve context. In Claude Code: `@notebooklm-mcp` to toggle. To keep it on but expose only a subset, see [Selective tool exposure](docs/MCP_GUIDE.md#selective-tool-exposure).
+> **⚠️ Context Window Warning:** This MCP provides **40 tools**. Disable it when not using NotebookLM to preserve context. In Claude Code: `@notebooklm-mcp` to toggle. To keep it on but expose only a subset, see [Selective tool exposure](docs/MCP_GUIDE.md#selective-tool-exposure).
 
 ### Automatic Setup (Recommended)
 

--- a/desktop-extension/manifest.json
+++ b/desktop-extension/manifest.json
@@ -2,9 +2,9 @@
   "manifest_version": "0.2",
   "name": "notebooklm-mcp",
   "display_name": "NotebookLM MCP Server",
-  "version": "0.8.9",
+  "version": "0.9.0",
   "description": "Connect Claude to Google NotebookLM. Create podcasts, research topics, generate quizzes, flashcards, mind maps, and more from your notebooks.",
-  "long_description": "This extension connects Claude Desktop to Google NotebookLM via the Model Context Protocol. It provides 39 tools for managing notebooks, sources, labels, research, sharing, and generated content.\n\n**Prerequisites:**\n1. Install the package: `pip install notebooklm-mcp-cli` or `uv tool install notebooklm-mcp-cli`\n2. Authenticate: Run `nlm login` to set up your Google account\n\n**Features:**\n- Create and manage notebooks\n- Add sources (URLs, YouTube, Google Drive, text, files)\n- Generate podcasts (Audio Overview)\n- Create quizzes, flashcards, mind maps, reports\n- Research topics with web or Drive search",
+  "long_description": "This extension connects Claude Desktop to Google NotebookLM via the Model Context Protocol. It provides 40 tools for managing notebooks, sources, labels, research, sharing, and generated content.\n\n**Prerequisites:**\n1. Install the package: `pip install notebooklm-mcp-cli` or `uv tool install notebooklm-mcp-cli`\n2. Authenticate: Run `nlm login` to set up your Google account\n\n**Features:**\n- Create and manage notebooks\n- Add sources (URLs, YouTube, Google Drive, text, files)\n- Generate podcasts (Audio Overview)\n- Create quizzes, flashcards, mind maps, reports\n- Research topics with web or Drive search",
   "author": {
     "name": "Jacob Ben-David",
     "email": "mail4j@duck.com",

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -139,6 +139,10 @@ nlm download data-table <notebook> <artifact-id> --output data.csv
 # Interactive formats (quiz/flashcards)
 nlm download quiz <notebook> <artifact-id> --format html --output quiz.html
 nlm download flashcards <notebook> <artifact-id> --format markdown --output cards.md
+
+# Download every completed artifact into a per-notebook folder
+nlm download all <notebook> --output-dir ./exports
+nlm download all --all-notebooks --output-dir ./exports --skip-existing
 ```
 
 ### Research

--- a/docs/MCP_CLI_TEST_PLAN.md
+++ b/docs/MCP_CLI_TEST_PLAN.md
@@ -960,7 +960,7 @@ Get NotebookLM MCP server version and check for updates.
 
 ---
 
-## Summary: 30 Consolidated Tools
+## Summary: 31 Consolidated Tools
 
 | Category | Tools | Count |
 |----------|-------|-------|

--- a/docs/MCP_GUIDE.md
+++ b/docs/MCP_GUIDE.md
@@ -1,6 +1,6 @@
 # MCP Guide
 
-Complete reference for the NotebookLM MCP server — **39 tools** for AI assistants.
+Complete reference for the NotebookLM MCP server — **40 tools** for AI assistants.
 
 ## Installation
 
@@ -115,11 +115,12 @@ source_add(
 - `infographic` - Visual infographic
 - `data_table` - Structured data table
 
-### Downloads (1 tool)
+### Downloads (2 tools)
 
 | Tool | Description |
 |------|-------------|
 | `download_artifact` | **Unified** - Download any artifact type |
+| `download_all_artifacts` | Download every completed artifact of a notebook — or every notebook with `all_notebooks=True` — into per-notebook folders |
 
 **`download_artifact` types:**
 `audio`, `video`, `report`, `mind_map`, `slide_deck`, `infographic`, `data_table`, `quiz`, `flashcards`
@@ -332,11 +333,11 @@ pipeline(action="run", notebook_id="abc", pipeline_name="ingest-and-podcast", in
 
 ## Context Window Tips
 
-This MCP has **39 tools** which consume context. Best practices:
+This MCP has **40 tools** which consume context. Best practices:
 
 - **Disable when not using**: In Claude Code, use `@notebooklm-mcp` to toggle
 - **Hide tools you don't need**: See [Selective tool exposure](#selective-tool-exposure) below to expose only a subset
-- **Use unified tools**: `source_add`, `studio_create`, `download_artifact` handle multiple operations each
+- **Use unified tools**: `source_add`, `studio_create`, `download_artifact`, `download_all_artifacts` handle multiple operations each
 - **Poll wisely**: Use `studio_status` sparingly - artifacts take 1-5 minutes
 
 ### Selective tool exposure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "notebooklm-mcp-cli"
-version = "0.8.9"
+version = "0.9.0"
 description = "Unified CLI and MCP server for Google NotebookLM"
 readme = "README.md"
 license = "MIT"

--- a/src/notebooklm_tools/__init__.py
+++ b/src/notebooklm_tools/__init__.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import notebooklm_tools.utils.env_sanitize as _env_sanitize  # noqa: F401
 
-__version__ = "0.8.9"
+__version__ = "0.9.0"
 
 __all__ = ["NotebookLMClient", "__version__"]
 

--- a/src/notebooklm_tools/data/AGENTS_SECTION.md
+++ b/src/notebooklm_tools/data/AGENTS_SECTION.md
@@ -1,5 +1,5 @@
 <!-- nlm-skill-start -->
-<!-- nlm-version: 0.8.9 -->
+<!-- nlm-version: 0.9.0 -->
 ## NLM - NotebookLM CLI Expert
 
 **Triggers:** "nlm", "notebooklm", "notebook lm", "podcast", "audio overview", "research"

--- a/src/notebooklm_tools/data/SKILL.md
+++ b/src/notebooklm_tools/data/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nlm-skill
-version: "0.8.9"
+version: "0.9.0"
 description: "Expert guide for the NotebookLM CLI (`nlm`) and MCP server - interfaces for Google NotebookLM. Use this skill when users want to interact with NotebookLM programmatically, including: creating/managing notebooks, adding sources (URLs, YouTube, text, Google Drive), generating content (podcasts, reports, quizzes, flashcards, mind maps, slides, infographics, videos, data tables), conducting research, chatting with sources, or automating NotebookLM workflows. Triggers on mentions of \"nlm\", \"notebooklm\", \"notebook lm\", \"podcast generation\", \"audio overview\", \"refactor document\", \"critique draft\", or any NotebookLM-related automation task."
 ---
 
@@ -65,7 +65,7 @@ nlm --version           # Check installed version
 12. **Use `--help` when unsure**: Run `nlm <command> --help` to see available options and flags for any command.
 13. **Studio: fast track by default**: Infer format/style/prompt silently—one compact line, then `studio_create(confirm=True)`. No intake questionnaires. Fast track reduces clarifying questions, not the confirm gate. **Cinematic video is always guided** (quota-limited). Full preview only when vague, high-stakes, cinematic, or user asks. See **[references/studio-prompting-guide.md](references/studio-prompting-guide.md)**.
 
-**Current MCP surface:** 39 tools. Consolidated action tools include `note`,
+**Current MCP surface:** 40 tools. Consolidated action tools include `note`,
 `label`, `studio_status`, `batch`, `pipeline`, and `tag`. Consolidated type
 tools include `source_add`, `studio_create`, and `download_artifact`.
 
@@ -440,7 +440,9 @@ supported types with `action="list_types"`. Failed artifacts include
 `error_reason`. Detailed mode also includes `source_ids`; an empty list means
 the upstream payload did not expose provenance, not necessarily that no
 sources were used. Use `download_artifact` with `artifact_type` and
-`output_path`, `export_artifact` with `export_type` (`docs`/`sheets`), and
+`output_path`, `download_all_artifacts` to fetch every completed artifact of a
+notebook (or every notebook with `all_notebooks=True`) into per-notebook
+folders, `export_artifact` with `export_type` (`docs`/`sheets`), and
 `studio_delete` with `confirm=True`.
 
 #### CLI Commands
@@ -461,6 +463,8 @@ nlm download report <nb-id> --output report.md
 nlm download slide-deck <nb-id> --output slides.pdf           # PDF (default)
 nlm download slide-deck <nb-id> --output slides.pptx --format pptx  # PPTX
 nlm download quiz <nb-id> --output quiz.html --format html    # Also: json, markdown
+nlm download all <nb-id> -d ./exports                          # Every completed artifact
+nlm download all --all-notebooks -d ./exports --skip-existing  # Sweep every notebook
 
 # Export to Google Docs/Sheets
 nlm export sheets <nb-id> <artifact-id> --title "My Data Table"

--- a/src/notebooklm_tools/data/references/command_reference.md
+++ b/src/notebooklm_tools/data/references/command_reference.md
@@ -632,6 +632,29 @@ nlm download quiz <nb-id> --output quiz.html --format html
 nlm download flashcards <nb-id> --output cards.json --format json
 ```
 
+### nlm download all
+
+Download every completed artifact of a notebook — or every notebook — into
+per-notebook directories named after each notebook's title.
+
+```bash
+nlm download all <notebook-id> [OPTIONS]
+nlm download all --all-notebooks [OPTIONS]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--output-dir`, `-d` | Base directory; a subdirectory per notebook is created inside |
+| `--types`, `-t` | Comma-separated artifact types to include (default: all) |
+| `--all-notebooks`, `-a` | Sweep every notebook in the account |
+| `--skip-existing` | Skip artifacts whose file already exists (incremental re-runs) |
+
+**Examples:**
+```bash
+nlm download all <nb-id> --output-dir ./exports
+nlm download all --all-notebooks --output-dir ./exports --skip-existing
+```
+
 ---
 
 ## Export Commands

--- a/tests/cli/test_download_all.py
+++ b/tests/cli/test_download_all.py
@@ -1,0 +1,215 @@
+"""Tests for the `nlm download all` CLI command."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from notebooklm_tools.cli.commands.download import app
+from notebooklm_tools.services.errors import ServiceError
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _single_result(**overrides):
+    result = {
+        "notebook_id": "nb-1",
+        "notebook_title": "My Notebook",
+        "output_dir": "/tmp/exports/My Notebook",
+        "items": [
+            {
+                "artifact_id": "art-1",
+                "artifact_type": "report",
+                "title": "Report",
+                "path": "/tmp/exports/My Notebook/Report.md",
+                "success": True,
+                "error": None,
+            }
+        ],
+        "skipped": [],
+        "total_artifacts": 1,
+        "downloaded": 1,
+        "failed": 0,
+    }
+    result.update(overrides)
+    return result
+
+
+def _sweep_result(**overrides):
+    result = {
+        "output_dir": "/tmp/exports",
+        "notebooks": [
+            {
+                "notebook_id": "nb-1",
+                "notebook_title": "My Notebook",
+                "output_dir": "/tmp/exports/My Notebook",
+                "downloaded": 1,
+                "failed": 0,
+                "skipped": 0,
+                "error": None,
+            }
+        ],
+        "total_notebooks": 1,
+        "downloaded": 1,
+        "failed": 0,
+        "errored_notebooks": 0,
+    }
+    result.update(overrides)
+    return result
+
+
+def _alias_manager():
+    alias_mgr = MagicMock()
+    alias_mgr.resolve.side_effect = lambda x: x
+    return alias_mgr
+
+
+def test_requires_notebook_id_or_all_notebooks_flag(runner):
+    result = runner.invoke(app, ["all"])
+
+    assert result.exit_code == 1
+    assert "Provide either a notebook ID or --all-notebooks" in result.output
+
+
+def test_rejects_both_notebook_id_and_all_notebooks(runner):
+    result = runner.invoke(app, ["all", "nb-1", "--all-notebooks"])
+
+    assert result.exit_code == 1
+    assert "not both" in result.output
+
+
+def test_single_notebook_human_output(runner):
+    with (
+        patch("notebooklm_tools.cli.commands.download.get_client", return_value=MagicMock()),
+        patch(
+            "notebooklm_tools.cli.commands.download.get_alias_manager",
+            return_value=_alias_manager(),
+        ),
+        patch(
+            "notebooklm_tools.services.downloads.download_all",
+            return_value=_single_result(),
+        ),
+    ):
+        result = runner.invoke(app, ["all", "nb-1", "--no-progress"])
+
+    assert result.exit_code == 0
+    assert "My Notebook" in result.output
+    assert "1" in result.output
+    assert "downloaded" in result.output
+
+
+def test_single_notebook_json_output(runner):
+    service_result = _single_result()
+
+    with (
+        patch("notebooklm_tools.cli.commands.download.get_client", return_value=MagicMock()),
+        patch(
+            "notebooklm_tools.cli.commands.download.get_alias_manager",
+            return_value=_alias_manager(),
+        ),
+        patch(
+            "notebooklm_tools.services.downloads.download_all",
+            return_value=service_result,
+        ),
+    ):
+        result = runner.invoke(app, ["all", "nb-1", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["downloaded"] == 1
+    assert payload["notebook_title"] == "My Notebook"
+
+
+def test_all_notebooks_sweep_routes_to_service(runner):
+    with (
+        patch("notebooklm_tools.cli.commands.download.get_client", return_value=MagicMock()),
+        patch(
+            "notebooklm_tools.services.downloads.download_all_notebooks",
+            return_value=_sweep_result(),
+        ) as mock_sweep,
+    ):
+        result = runner.invoke(
+            app, ["all", "--all-notebooks", "--skip-existing", "--no-progress"]
+        )
+
+    assert result.exit_code == 0
+    assert mock_sweep.call_args.kwargs["skip_existing"] is True
+    assert "My Notebook" in result.output
+    assert "notebooks" in result.output
+
+
+def test_exit_code_1_when_nothing_downloaded_and_failures_occurred(runner):
+    service_result = _single_result(downloaded=0, failed=2, items=[])
+
+    with (
+        patch("notebooklm_tools.cli.commands.download.get_client", return_value=MagicMock()),
+        patch(
+            "notebooklm_tools.cli.commands.download.get_alias_manager",
+            return_value=_alias_manager(),
+        ),
+        patch(
+            "notebooklm_tools.services.downloads.download_all",
+            return_value=service_result,
+        ),
+    ):
+        result = runner.invoke(app, ["all", "nb-1", "--no-progress"])
+
+    assert result.exit_code == 1
+
+
+def test_exit_code_0_on_partial_success(runner):
+    service_result = _single_result(downloaded=1, failed=1)
+
+    with (
+        patch("notebooklm_tools.cli.commands.download.get_client", return_value=MagicMock()),
+        patch(
+            "notebooklm_tools.cli.commands.download.get_alias_manager",
+            return_value=_alias_manager(),
+        ),
+        patch(
+            "notebooklm_tools.services.downloads.download_all",
+            return_value=service_result,
+        ),
+    ):
+        result = runner.invoke(app, ["all", "nb-1", "--no-progress"])
+
+    assert result.exit_code == 0
+
+
+def test_service_error_reports_hint_and_exits_1(runner):
+    with (
+        patch("notebooklm_tools.cli.commands.download.get_client", return_value=MagicMock()),
+        patch(
+            "notebooklm_tools.cli.commands.download.get_alias_manager",
+            return_value=_alias_manager(),
+        ),
+        patch(
+            "notebooklm_tools.services.downloads.download_all",
+            side_effect=ServiceError("boom", user_message="Notebook not found.", hint="Check the ID."),
+        ),
+    ):
+        result = runner.invoke(app, ["all", "nb-1", "--no-progress"])
+
+    assert result.exit_code == 1
+    assert "Notebook not found." in result.output
+
+
+def test_types_filter_is_parsed_and_passed_through(runner):
+    with (
+        patch("notebooklm_tools.cli.commands.download.get_client", return_value=MagicMock()),
+        patch(
+            "notebooklm_tools.cli.commands.download.get_alias_manager",
+            return_value=_alias_manager(),
+        ),
+        patch(
+            "notebooklm_tools.services.downloads.download_all",
+            return_value=_single_result(),
+        ) as mock_download_all,
+    ):
+        runner.invoke(app, ["all", "nb-1", "--types", "video, report", "--no-progress"])
+
+    assert mock_download_all.call_args.kwargs["artifact_types"] == ["video", "report"]

--- a/tests/test_mcp_downloads.py
+++ b/tests/test_mcp_downloads.py
@@ -1,0 +1,185 @@
+"""Unit tests for the download_all_artifacts MCP tool."""
+
+from unittest.mock import MagicMock, patch
+
+from notebooklm_tools.mcp.tools import downloads
+from notebooklm_tools.services.errors import ServiceError, ValidationError
+
+
+def _single_result(**overrides):
+    result = {
+        "notebook_id": "nb-1",
+        "notebook_title": "My Notebook",
+        "output_dir": "/tmp/exports/My Notebook",
+        "items": [],
+        "skipped": [],
+        "total_artifacts": 0,
+        "downloaded": 0,
+        "failed": 0,
+    }
+    result.update(overrides)
+    return result
+
+
+def _sweep_result(**overrides):
+    result = {
+        "output_dir": "/tmp/exports",
+        "notebooks": [],
+        "total_notebooks": 0,
+        "downloaded": 0,
+        "failed": 0,
+        "errored_notebooks": 0,
+    }
+    result.update(overrides)
+    return result
+
+
+def test_requires_either_notebook_id_or_all_notebooks():
+    result = downloads.download_all_artifacts()
+
+    assert result["status"] == "error"
+    assert "Provide either notebook_id or all_notebooks" in result["error"]
+
+
+def test_rejects_both_notebook_id_and_all_notebooks():
+    result = downloads.download_all_artifacts(notebook_id="nb-1", all_notebooks=True)
+
+    assert result["status"] == "error"
+    assert "not both" in result["error"]
+
+
+def test_single_notebook_success_routes_to_download_all():
+    mock_client = MagicMock()
+    service_result = _single_result(downloaded=2, failed=0)
+
+    with (
+        patch("notebooklm_tools.mcp.tools.downloads.get_client", return_value=mock_client),
+        patch(
+            "notebooklm_tools.mcp.tools.downloads.downloads_service.download_all",
+            return_value=service_result,
+        ) as mock_download_all,
+    ):
+        result = downloads.download_all_artifacts(notebook_id="nb-1", output_dir="exports")
+
+    mock_download_all.assert_called_once_with(
+        mock_client,
+        "nb-1",
+        "exports",
+        artifact_types=None,
+        output_format="json",
+        slide_deck_format="pdf",
+        skip_existing=False,
+    )
+    assert result["status"] == "success"
+    assert result["downloaded"] == 2
+
+
+def test_single_notebook_partial_status_when_some_downloads_fail():
+    mock_client = MagicMock()
+    service_result = _single_result(downloaded=1, failed=1)
+
+    with (
+        patch("notebooklm_tools.mcp.tools.downloads.get_client", return_value=mock_client),
+        patch(
+            "notebooklm_tools.mcp.tools.downloads.downloads_service.download_all",
+            return_value=service_result,
+        ),
+    ):
+        result = downloads.download_all_artifacts(notebook_id="nb-1")
+
+    assert result["status"] == "partial"
+
+
+def test_single_notebook_error_status_when_nothing_downloaded():
+    mock_client = MagicMock()
+    service_result = _single_result(downloaded=0, failed=3)
+
+    with (
+        patch("notebooklm_tools.mcp.tools.downloads.get_client", return_value=mock_client),
+        patch(
+            "notebooklm_tools.mcp.tools.downloads.downloads_service.download_all",
+            return_value=service_result,
+        ),
+    ):
+        result = downloads.download_all_artifacts(notebook_id="nb-1")
+
+    assert result["status"] == "error"
+
+
+def test_all_notebooks_routes_to_sweep_and_coerces_types():
+    mock_client = MagicMock()
+    service_result = _sweep_result(total_notebooks=3, downloaded=5)
+
+    with (
+        patch("notebooklm_tools.mcp.tools.downloads.get_client", return_value=mock_client),
+        patch(
+            "notebooklm_tools.mcp.tools.downloads.downloads_service.download_all_notebooks",
+            return_value=service_result,
+        ) as mock_sweep,
+    ):
+        result = downloads.download_all_artifacts(
+            all_notebooks=True,
+            output_dir="exports",
+            artifact_types="video,report",
+            skip_existing=True,
+        )
+
+    mock_sweep.assert_called_once_with(
+        mock_client,
+        "exports",
+        artifact_types=["video", "report"],
+        output_format="json",
+        slide_deck_format="pdf",
+        skip_existing=True,
+    )
+    assert result["status"] == "success"
+    assert result["total_notebooks"] == 3
+
+
+def test_all_notebooks_partial_status_when_a_notebook_errors():
+    mock_client = MagicMock()
+    service_result = _sweep_result(downloaded=2, errored_notebooks=1)
+
+    with (
+        patch("notebooklm_tools.mcp.tools.downloads.get_client", return_value=mock_client),
+        patch(
+            "notebooklm_tools.mcp.tools.downloads.downloads_service.download_all_notebooks",
+            return_value=service_result,
+        ),
+    ):
+        result = downloads.download_all_artifacts(all_notebooks=True)
+
+    assert result["status"] == "partial"
+
+
+def test_validation_error_is_reported_without_hint():
+    mock_client = MagicMock()
+
+    with (
+        patch("notebooklm_tools.mcp.tools.downloads.get_client", return_value=mock_client),
+        patch(
+            "notebooklm_tools.mcp.tools.downloads.downloads_service.download_all",
+            side_effect=ValidationError("Unknown artifact type 'bogus'."),
+        ),
+    ):
+        result = downloads.download_all_artifacts(notebook_id="nb-1")
+
+    assert result["status"] == "error"
+    assert "Unknown artifact type" in result["error"]
+
+
+def test_service_error_surfaces_user_message_and_hint():
+    mock_client = MagicMock()
+
+    with (
+        patch("notebooklm_tools.mcp.tools.downloads.get_client", return_value=mock_client),
+        patch(
+            "notebooklm_tools.mcp.tools.downloads.downloads_service.download_all",
+            side_effect=ServiceError("boom", user_message="Notebook not found.", hint="Check the ID."),
+        ),
+    ):
+        result = downloads.download_all_artifacts(notebook_id="nb-1")
+
+    assert result["status"] == "error"
+    assert result["error"] == "Notebook not found."
+    assert result["hint"] == "Check the ID."

--- a/uv.lock
+++ b/uv.lock
@@ -759,7 +759,7 @@ wheels = [
 
 [[package]]
 name = "notebooklm-mcp-cli"
-version = "0.8.9"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

#264 and #258 (bulk `download_all_artifacts` / `nlm download all` + mind-map fixes) have been merged into `main` directly, crediting @runthangs and @hansschenker. This PR is just my follow-up work on top of that merge:

- **Docs reconciled:** every stale "39 tools" / "35 MCP tools" reference (README, MCP Guide, CLI Guide, packaged skill, command reference, desktop extension manifest) updated to the true count of 40, and the new command documented everywhere the download surface is listed.
- **Test coverage added:** the original PR only tested the service layer (well covered — 331 lines). This adds direct tests for the previously-uncovered layers:
  - `tests/test_mcp_downloads.py` — the `download_all_artifacts` MCP tool (mutual-exclusion guard, success/partial/error status mapping, error propagation).
  - `tests/cli/test_download_all.py` — the `nlm download all` CLI command (output formatting, flag routing, exit codes).
- **Version bump:** 0.8.9 → 0.9.0 across all 5 aligned files, with a CHANGELOG entry crediting @runthangs (@hansschenker was already credited in the 0.8.8 entry for the mind-map fixes).

## Test plan

- [x] `uv run pytest` — 1203 passed, 39 skipped
- [x] `uv cache clean && uv tool install --force .` — reinstalled cleanly, `nlm --version` reports 0.9.0
- [x] Live smoke test against a real notebook (`[TEST] Commercial AI Platform 2025 Financial Results`):
  - `nlm download all <id> -d /tmp/nlm-smoke-test --no-progress` → 18 downloaded, 0 failed, 0 skipped
  - Re-run with `--skip-existing` → 0 downloaded, 0 failed, 18 skipped, exit code 0
- [x] Grepped for stale tool counts across docs — none remain
- [x] Verified all 5 version files + CHANGELOG are aligned at 0.9.0