### PR TITLE
fix(desktop-extension): find uvx installed via pip install --user on Windows

### DIFF
--- a/desktop-extension/run_server.py
+++ b/desktop-extension/run_server.py
@@ -9,6 +9,7 @@ Bundled inside the .mcpb extension and invoked via manifest.json:
     "command": "python3", "args": ["${__dirname}/run_server.py"]
 """
 
+import glob
 import os
 import platform
 import shutil
@@ -43,12 +44,20 @@ def _find_uvx() -> str | None:
         ]
     elif platform.system() == "Windows":
         appdata = os.environ.get("LOCALAPPDATA", os.path.join(home, "AppData", "Local"))
+        roaming = os.environ.get("APPDATA", os.path.join(home, "AppData", "Roaming"))
         candidates = [
             os.path.join(home, ".local", "bin", "uvx.exe"),
             os.path.join(home, ".cargo", "bin", "uvx.exe"),
             os.path.join(appdata, "uv", "uvx.exe"),
             os.path.join(home, "scoop", "shims", "uvx.exe"),
         ]
+        # `pip install --user uv` places uvx.exe in
+        # %APPDATA%\Python\Python3XX\Scripts, which Windows does not add to PATH
+        # automatically, so shutil.which() above misses it. Include the Scripts
+        # directory of every installed CPython version.
+        candidates += sorted(
+            glob.glob(os.path.join(roaming, "Python", "Python*", "Scripts", "uvx.exe"))
+        )
 
     for path in candidates:
         if os.path.isfile(path) and os.access(path, os.X_OK):


### PR DESCRIPTION
## Problem

On Windows, the `.mcpb` desktop extension can fail to start with `Error: Could not find 'uvx'` even when `uv` is installed — specifically when it was installed via `pip install --user uv`.

`_find_uvx()` tries `shutil.which("uvx")`, then a fixed candidate list. On Windows that list covers `~\.local\bin`, `~\.cargo\bin`, `%LOCALAPPDATA%\uv`, and scoop shims — but not `%APPDATA%\Python\Python3XX\Scripts\uvx.exe`, which is exactly where `pip install --user uv` installs it. Windows does not add that directory to `PATH` automatically, so `shutil.which()` misses it too, and the extension dies at launch even though `uv` is present.

## Fix

Add the pip user-site `Scripts` directory (globbed across installed CPython versions) to the Windows candidate list. No behavior change on macOS/Linux.

## Testing

- `ruff check` and `ruff format --check`: clean.
- Verified on Windows 11: with a `PATH` that omits `%APPDATA%\Python\Python314\Scripts` (the environment the child process actually receives), `shutil.which("uvx")` returns `None`, while `_find_uvx()` now resolves the real `uvx.exe` through the new fallback.
