### PR TITLE
fix: support WSL mirrored networking

### DIFF
--- a/docs/MCP_CLI_TEST_PLAN.md
+++ b/docs/MCP_CLI_TEST_PLAN.md
@@ -59,13 +59,15 @@ Refresh authentication tokens for NotebookLM.
 ### Test 1.2 - Interactive Login (Primary)
 **Tool:** `save_auth_tokens` (Fallback)
 **CLI:** `nlm login` (Launches Chrome for automated extraction)
+**WSL2 CLI:** `nlm login --wsl` (Supports NAT and mirrored networking modes)
 
 **Prompt:**
 ```
 I need to authenticate with NotebookLM.
 ```
 
-**Expected:** Chrome opens, logs in, and tokens are saved.
+**Expected:** Chrome opens, logs in, and tokens are saved. On WSL2, Windows Chrome opens and
+the CDP connection succeeds in both NAT and mirrored networking modes.
 
 ---
 

--- a/docs/WSL_SETUP.md
+++ b/docs/WSL_SETUP.md
@@ -86,7 +86,7 @@ nlm login --wsl
 ```
 
 This will:
-- Detect your Windows IP address from WSL
+- Detect the WSL networking mode and Windows host address
 - **Check Windows Firewall setup** (prompts with instructions)
 - Launch Chrome on Windows on port 9223 with remote debugging
 - Connect via the port proxy on port 9222
@@ -109,14 +109,15 @@ When you run `nlm login --wsl`:
 
 ```
 WSL Terminal
-    ↓  detects Windows host IP (from default gateway)
+    ↓  detects networking mode with wslinfo
+    ↓  uses the default gateway (NAT) or 127.0.0.1 (mirrored)
     ↓  launches /mnt/c/Program Files/Google/Chrome/Application/chrome.exe
 Windows Chrome
     ↓  starts on 127.0.0.1:9223 (Windows side, localhost only)
 netsh portproxy
     ↓  forwards 0.0.0.0:9222 → 127.0.0.1:9223
 WSL Auth Script
-    ↓  connects to http://172.x.x.x:9222 (via port proxy)
+    ↓  connects to the Windows host on port 9222 (via port proxy)
     ↓  opens notebook.google.com tab
     ↓  waits for login
     ↓  extracts cookies via CDP
@@ -180,13 +181,18 @@ cat /etc/resolv.conf
 grep nameserver /etc/resolv.conf
 ```
 
-You should see an IP like `172.20.x.x`. If not, your WSL2 networking may be in a different mode.
+In NAT mode, you should see an IP like `172.20.x.x`. In mirrored mode, the Windows host is
+available at `127.0.0.1`.
 
 **Workaround:**
 ```bash
-# Find Windows IP manually
-WINDOWS_IP=$(ip route show | grep default | awk '{print $3}')
-nlm login --cdp-url http://$WINDOWS_IP:9222
+# Find the Windows host address manually
+if [ "$(wslinfo --networking-mode 2>/dev/null)" = "mirrored" ]; then
+    WINDOWS_IP=127.0.0.1
+else
+    WINDOWS_IP=$(ip route show default | awk '{print $3; exit}')
+fi
+nlm login --cdp-url "http://${WINDOWS_IP}:9222"
 ```
 
 ### "Chrome did not start within 30 seconds"
@@ -202,7 +208,12 @@ Sometimes Windows firewall or antivirus blocks the connection.
    ```
    ```bash
    # In WSL (wait a few seconds first)
-   nlm login --cdp-url http://$(grep nameserver /etc/resolv.conf | awk '{print $2}'):9222
+   if [ "$(wslinfo --networking-mode 2>/dev/null)" = "mirrored" ]; then
+       WINDOWS_IP=127.0.0.1
+   else
+       WINDOWS_IP=$(ip route show default | awk '{print $3; exit}')
+   fi
+   nlm login --cdp-url "http://${WINDOWS_IP}:9222"
    ```
 
 ### Terminal still goes black
@@ -245,11 +256,15 @@ CHROME_PID=$!
 # Wait for startup
 sleep 3
 
-# Get Windows IP
-WINDOWS_IP=$(grep nameserver /etc/resolv.conf | awk '{print $2}')
+# Get the Windows host address
+if [ "$(wslinfo --networking-mode 2>/dev/null)" = "mirrored" ]; then
+    WINDOWS_IP=127.0.0.1
+else
+    WINDOWS_IP=$(ip route show default | awk '{print $3; exit}')
+fi
 
 # Login via CDP
-nlm login --cdp-url http://$WINDOWS_IP:9222
+nlm login --cdp-url "http://${WINDOWS_IP}:9222"
 
 # Cleanup
 kill $CHROME_PID

--- a/src/notebooklm_tools/utils/wsl.py
+++ b/src/notebooklm_tools/utils/wsl.py
@@ -60,17 +60,36 @@ def is_wsl() -> bool:
     return False
 
 
+def _is_mirrored_networking() -> bool:
+    """Return whether WSL is using mirrored networking mode."""
+    try:
+        result = subprocess.run(
+            ["wslinfo", "--networking-mode"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return False
+
+    return result.stdout.strip().casefold() == "mirrored"
+
+
 def get_windows_host_ip() -> str | None:
     """Get the Windows host IP address from WSL.
 
-    WSL2 uses a virtual network where the Windows host is the default gateway.
-    We check multiple sources to find the correct IP.
+    In mirrored mode, Windows is reachable through the shared loopback
+    interface. In NAT mode, the Windows host is the default gateway.
 
     Returns:
         IP address string (e.g., "172.20.112.1") or None if not in WSL.
     """
     if not is_wsl():
         return None
+
+    if _is_mirrored_networking():
+        return "127.0.0.1"
 
     # Method 1: Get default gateway (most reliable for Chrome binding)
     try:

--- a/tests/test_wsl.py
+++ b/tests/test_wsl.py
@@ -1,0 +1,61 @@
+"""Tests for WSL networking utilities."""
+
+import subprocess
+from unittest.mock import Mock, call
+
+from notebooklm_tools.utils import wsl
+
+
+def _result(args: list[str], stdout: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args, returncode=0, stdout=stdout, stderr="")
+
+
+def test_get_windows_host_ip_uses_loopback_in_mirrored_mode(monkeypatch):
+    monkeypatch.setattr(wsl, "is_wsl", lambda: True)
+    run = Mock(return_value=_result(["wslinfo", "--networking-mode"], "mirrored\n"))
+    monkeypatch.setattr(wsl.subprocess, "run", run)
+
+    assert wsl.get_windows_host_ip() == "127.0.0.1"
+    run.assert_called_once_with(
+        ["wslinfo", "--networking-mode"],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=5,
+    )
+
+
+def test_get_windows_host_ip_uses_gateway_in_nat_mode(monkeypatch):
+    monkeypatch.setattr(wsl, "is_wsl", lambda: True)
+    run = Mock(
+        side_effect=[
+            _result(["wslinfo", "--networking-mode"], "nat\n"),
+            _result(["ip", "route"], "default via 172.20.112.1 dev eth0\n"),
+        ]
+    )
+    monkeypatch.setattr(wsl.subprocess, "run", run)
+
+    assert wsl.get_windows_host_ip() == "172.20.112.1"
+    assert run.call_args_list == [
+        call(
+            ["wslinfo", "--networking-mode"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=5,
+        ),
+        call(["ip", "route"], capture_output=True, text=True, check=True),
+    ]
+
+
+def test_get_windows_host_ip_uses_gateway_when_wslinfo_is_unavailable(monkeypatch):
+    monkeypatch.setattr(wsl, "is_wsl", lambda: True)
+
+    def run(args, **kwargs):
+        if args[0] == "wslinfo":
+            raise FileNotFoundError
+        return _result(args, "default via 172.20.112.1 dev eth0\n")
+
+    monkeypatch.setattr(wsl.subprocess, "run", run)
+
+    assert wsl.get_windows_host_ip() == "172.20.112.1"


### PR DESCRIPTION
## Summary

- detect the active WSL networking mode with `wslinfo --networking-mode`
- use the shared loopback address for mirrored networking
- preserve the existing gateway and resolver fallbacks for NAT mode and older WSL installations
- add unit coverage and update the WSL authentication documentation

## Root cause

`get_windows_host_ip()` assumed the default gateway was always the Windows host. That is true
for WSL2 NAT networking, but in mirrored mode the gateway can be the physical network router.
As a result, `nlm login --wsl` polled the wrong host for Chrome DevTools Protocol and timed out.

In mirrored mode, Windows and WSL share loopback, so the correct host address is `127.0.0.1`.
If the networking-mode probe is unavailable or does not report `mirrored`, the existing NAT
discovery path remains unchanged.

Closes #273.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run --dev --with pytest-github-actions-annotate-failures --with pytest-asyncio pytest -v --tb=short -m "not e2e"`: 1,247 passed, 37 skipped, 1 deselected
- manually verified `nlm login --wsl` on WSL2 mirrored networking
