### PR TITLE
Add Claude Desktop support to nlm setup

### DIFF
--- a/src/notebooklm_tools/cli/ai_docs.py
+++ b/src/notebooklm_tools/cli/ai_docs.py
@@ -787,6 +787,7 @@ Checks: installation, authentication, browser profile, AI tool configs. Shows su
 ```bash
 nlm setup list                          # Show all clients and their MCP status
 nlm setup add claude-code               # Add to Claude Code (via claude mcp add)
+nlm setup add claude-desktop            # Add to Claude Desktop config
 nlm setup add gemini                    # Add to Gemini CLI config
 nlm setup add cursor                    # Add to Cursor config
 nlm setup add windsurf                  # Add to Windsurf config
@@ -799,7 +800,7 @@ nlm setup remove <client>               # Remove MCP from client
 nlm setup remove all                    # Remove MCP from ALL configured tools (with confirmation)
 ```
 
-**Supported Clients:** claude-code, gemini, cursor, windsurf, cline, antigravity, codex
+**Supported Clients:** claude-code, claude-desktop, gemini, cursor, windsurf, cline, antigravity, codex
 
 **For other tools:** `nlm setup add json` launches an interactive wizard — choose uvx or regular mode, full path or command name, and existing or new config. The JSON is printed with syntax highlighting and can be copied to clipboard (macOS).
 

--- a/src/notebooklm_tools/cli/commands/doctor.py
+++ b/src/notebooklm_tools/cli/commands/doctor.py
@@ -361,6 +361,7 @@ def _check_clients(verbose: bool) -> bool:
 
     from notebooklm_tools.cli.commands.setup import (
         CLIENT_REGISTRY,
+        _claude_desktop_config_path,
         _cursor_config_path,
         _gemini_config_path,
         _is_configured,
@@ -398,6 +399,11 @@ def _check_clients(verbose: bool) -> bool:
                 if verbose:
                     console.print(f"  {info['name']}: [dim]not installed[/dim]")
                 continue
+
+        elif client_id == "claude-desktop":
+            path = _claude_desktop_config_path()
+            config = _read_json_config(path)
+            status = _is_configured(config)
 
         elif client_id == "gemini":
             path = _gemini_config_path()

--- a/src/notebooklm_tools/cli/commands/setup.py
+++ b/src/notebooklm_tools/cli/commands/setup.py
@@ -158,6 +158,18 @@ def _github_copilot_config_path() -> Path:
     return Path(".vscode") / "mcp.json"
 
 
+def _claude_desktop_config_path() -> Path:
+    """Get Claude Desktop MCP config path."""
+    system = platform.system()
+    if system == "Darwin":
+        return Path.home() / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
+    elif system == "Windows":
+        appdata = Path(os.environ.get("APPDATA", ""))
+        return appdata / "Claude" / "claude_desktop_config.json"
+    else:
+        return Path.home() / ".config" / "Claude" / "claude_desktop_config.json"
+
+
 # =============================================================================
 # Client definitions
 # =============================================================================
@@ -166,6 +178,11 @@ CLIENT_REGISTRY = {
     "claude-code": {
         "name": "Claude Code",
         "description": "Anthropic CLI (claude command)",
+        "has_auto_setup": True,
+    },
+    "claude-desktop": {
+        "name": "Claude Desktop",
+        "description": "Anthropic Claude Desktop app",
         "has_auto_setup": True,
     },
     "gemini": {
@@ -258,6 +275,35 @@ def _setup_claude_code() -> bool:
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
         console.print(f"[yellow]Warning:[/yellow] Could not run claude command: {e}")
         return False
+
+
+def _setup_claude_desktop() -> bool:
+    """Add MCP to Claude Desktop config.
+
+    Claude Desktop launches servers without inheriting the user's shell
+    PATH, so the bare command name often fails to resolve. We write the
+    full resolved path to the notebooklm-mcp binary instead.
+    """
+    config_path = _claude_desktop_config_path()
+    config = _read_json_config(config_path)
+
+    if _is_configured(config):
+        console.print("[green]✓[/green] Already configured in Claude Desktop")
+        return True
+
+    binary_path = _find_mcp_server_path()
+    if not binary_path:
+        console.print(
+            "[yellow]Warning:[/yellow] notebooklm-mcp not found in PATH, "
+            "using command name instead (may not resolve in Claude Desktop)"
+        )
+        binary_path = MCP_SERVER_CMD
+
+    _add_mcp_server(config, extra={"command": binary_path})
+    _write_json_config(config_path, config)
+    console.print("[green]✓[/green] Added to Claude Desktop")
+    console.print(f"  [dim]{config_path}[/dim]")
+    return True
 
 
 def _setup_gemini() -> bool:
@@ -479,6 +525,7 @@ def _detect_tool(client_id: str) -> bool:
     _home = Path.home()
     detection: dict[str, tuple[str | None, list[Path]]] = {
         "claude-code": ("claude", [_home / ".claude"]),
+        "claude-desktop": (None, [_claude_desktop_config_path().parent]),
         "gemini": ("gemini", [_gemini_config_path().parent]),
         "cursor": ("cursor", [_home / ".cursor"]),
         "github-copilot": ("code", [_github_copilot_config_path().parent]),
@@ -512,6 +559,9 @@ def _is_already_configured(client_id: str) -> bool:
                 return "notebooklm" in result.stdout.lower()
             return False
 
+        elif client_id == "claude-desktop":
+            config = _read_json_config(_claude_desktop_config_path())
+            return _is_configured(config)
         elif client_id == "gemini":
             config = _read_json_config(_gemini_config_path())
             return _is_configured(config, "notebooklm")
@@ -649,6 +699,7 @@ def _setup_all() -> None:
     console.print()
     setup_fns = {
         "claude-code": _setup_claude_code,
+        "claude-desktop": _setup_claude_desktop,
         "gemini": _setup_gemini,
         "cursor": _setup_cursor,
         "windsurf": _setup_windsurf,
@@ -787,6 +838,7 @@ def setup_add(
 
     Examples:
         nlm setup add claude-code
+        nlm setup add claude-desktop
         nlm setup add gemini
         nlm setup add github-copilot
         nlm setup add cursor
@@ -825,6 +877,7 @@ def setup_add(
 
     setup_fn = {
         "claude-code": _setup_claude_code,
+        "claude-desktop": _setup_claude_desktop,
         "gemini": _setup_gemini,
         "github-copilot": _setup_github_copilot,
         "cursor": _setup_cursor,
@@ -977,6 +1030,7 @@ def _remove_single(client: str) -> bool:
 
     # JSON config-based clients
     config_paths = {
+        "claude-desktop": _claude_desktop_config_path(),
         "gemini": _gemini_config_path(),
         "cursor": _cursor_config_path(),
         "windsurf": _windsurf_config_path(),
@@ -1093,6 +1147,13 @@ def setup_list() -> None:
                 config_path = "claude mcp list"
             else:
                 config_path = "not installed"
+
+        elif client_id == "claude-desktop":
+            path = _claude_desktop_config_path()
+            config = _read_json_config(path)
+            if _is_configured(config):
+                status = "[green]✓[/green]"
+            config_path = str(path).replace(str(Path.home()), "~")
 
         elif client_id == "gemini":
             path = _gemini_config_path()

--- a/tests/cli/test_setup_claude_desktop.py
+++ b/tests/cli/test_setup_claude_desktop.py
@@ -1,0 +1,245 @@
+"""Tests for Claude Desktop support in ``nlm setup add/remove/list``."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from notebooklm_tools.cli.commands.setup import (
+    CLIENT_REGISTRY,
+    MCP_SERVER_CMD,
+    _claude_desktop_config_path,
+    _detect_tool,
+    _is_already_configured,
+    _remove_single,
+    _setup_claude_desktop,
+)
+
+
+class TestClaudeDesktopRegistry:
+    """Verify Claude Desktop is properly registered in CLIENT_REGISTRY."""
+
+    def test_claude_desktop_in_registry(self):
+        assert "claude-desktop" in CLIENT_REGISTRY
+
+    def test_claude_desktop_has_auto_setup(self):
+        assert CLIENT_REGISTRY["claude-desktop"]["has_auto_setup"] is True
+
+    def test_claude_desktop_name(self):
+        assert CLIENT_REGISTRY["claude-desktop"]["name"] == "Claude Desktop"
+
+
+class TestClaudeDesktopConfigPath:
+    """Verify platform-specific config path resolution."""
+
+    def test_macos_path(self):
+        with patch("platform.system", return_value="Darwin"):
+            path = _claude_desktop_config_path()
+        assert path == (
+            Path.home() / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
+        )
+
+    def test_windows_path(self):
+        with (
+            patch("platform.system", return_value="Windows"),
+            patch.dict("os.environ", {"APPDATA": "C:/Users/test/AppData/Roaming"}),
+        ):
+            path = _claude_desktop_config_path()
+        assert path == Path("C:/Users/test/AppData/Roaming") / "Claude" / "claude_desktop_config.json"
+
+    def test_linux_path(self):
+        with patch("platform.system", return_value="Linux"):
+            path = _claude_desktop_config_path()
+        assert path == Path.home() / ".config" / "Claude" / "claude_desktop_config.json"
+
+
+class TestSetupClaudeDesktop:
+    """Test ``_setup_claude_desktop()`` writes the correct config format."""
+
+    def test_creates_config_with_full_binary_path(self, tmp_path):
+        config_path = tmp_path / "claude_desktop_config.json"
+        with (
+            patch(
+                "notebooklm_tools.cli.commands.setup._claude_desktop_config_path",
+                return_value=config_path,
+            ),
+            patch(
+                "notebooklm_tools.cli.commands.setup._find_mcp_server_path",
+                return_value="/usr/local/bin/notebooklm-mcp",
+            ),
+        ):
+            result = _setup_claude_desktop()
+
+        assert result is True
+        config = json.loads(config_path.read_text())
+        assert "notebooklm-mcp" in config["mcpServers"]
+        entry = config["mcpServers"]["notebooklm-mcp"]
+        assert entry["command"] == "/usr/local/bin/notebooklm-mcp"
+        assert entry["args"] == []
+
+    def test_falls_back_to_command_name_when_not_on_path(self, tmp_path):
+        config_path = tmp_path / "claude_desktop_config.json"
+        with (
+            patch(
+                "notebooklm_tools.cli.commands.setup._claude_desktop_config_path",
+                return_value=config_path,
+            ),
+            patch(
+                "notebooklm_tools.cli.commands.setup._find_mcp_server_path",
+                return_value=None,
+            ),
+        ):
+            result = _setup_claude_desktop()
+
+        assert result is True
+        config = json.loads(config_path.read_text())
+        assert config["mcpServers"]["notebooklm-mcp"]["command"] == MCP_SERVER_CMD
+
+    def test_preserves_existing_config_keys(self, tmp_path):
+        config_path = tmp_path / "claude_desktop_config.json"
+        existing = {
+            "mcpServers": {"fetch": {"command": "uvx", "args": ["mcp-server-fetch"]}},
+            "coworkUserFilesPath": "/Users/test/Claude",
+        }
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(existing))
+
+        with (
+            patch(
+                "notebooklm_tools.cli.commands.setup._claude_desktop_config_path",
+                return_value=config_path,
+            ),
+            patch(
+                "notebooklm_tools.cli.commands.setup._find_mcp_server_path",
+                return_value="/usr/local/bin/notebooklm-mcp",
+            ),
+        ):
+            _setup_claude_desktop()
+
+        config = json.loads(config_path.read_text())
+        assert config["coworkUserFilesPath"] == existing["coworkUserFilesPath"]
+        assert "fetch" in config["mcpServers"]
+        assert "notebooklm-mcp" in config["mcpServers"]
+
+    def test_skips_if_already_configured(self, tmp_path):
+        config_path = tmp_path / "claude_desktop_config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(
+            json.dumps(
+                {"mcpServers": {"notebooklm-mcp": {"command": "/usr/local/bin/notebooklm-mcp"}}}
+            )
+        )
+
+        with patch(
+            "notebooklm_tools.cli.commands.setup._claude_desktop_config_path",
+            return_value=config_path,
+        ):
+            result = _setup_claude_desktop()
+
+        assert result is True
+
+
+class TestIsAlreadyConfigured:
+    """Test ``_is_already_configured()`` for Claude Desktop."""
+
+    def test_detects_notebooklm_key(self, tmp_path):
+        config_path = tmp_path / "claude_desktop_config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(
+            json.dumps({"mcpServers": {"notebooklm": {"command": MCP_SERVER_CMD}}})
+        )
+        with patch(
+            "notebooklm_tools.cli.commands.setup._claude_desktop_config_path",
+            return_value=config_path,
+        ):
+            assert _is_already_configured("claude-desktop") is True
+
+    def test_returns_false_when_not_configured(self, tmp_path):
+        config_path = tmp_path / "claude_desktop_config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps({"mcpServers": {}}))
+        with patch(
+            "notebooklm_tools.cli.commands.setup._claude_desktop_config_path",
+            return_value=config_path,
+        ):
+            assert _is_already_configured("claude-desktop") is False
+
+    def test_returns_false_when_no_config_file(self, tmp_path):
+        config_path = tmp_path / "claude_desktop_config.json"
+        with patch(
+            "notebooklm_tools.cli.commands.setup._claude_desktop_config_path",
+            return_value=config_path,
+        ):
+            assert _is_already_configured("claude-desktop") is False
+
+
+class TestDetectTool:
+    """Test ``_detect_tool()`` for Claude Desktop."""
+
+    def test_detects_via_config_directory(self, tmp_path):
+        config_path = tmp_path / "Claude" / "claude_desktop_config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        with patch(
+            "notebooklm_tools.cli.commands.setup._claude_desktop_config_path",
+            return_value=config_path,
+        ):
+            assert _detect_tool("claude-desktop") is True
+
+    def test_not_detected_when_absent(self, tmp_path):
+        config_path = tmp_path / "Claude" / "claude_desktop_config.json"
+        with patch(
+            "notebooklm_tools.cli.commands.setup._claude_desktop_config_path",
+            return_value=config_path,
+        ):
+            assert _detect_tool("claude-desktop") is False
+
+
+class TestRemoveClaudeDesktop:
+    """Test ``_remove_single()`` for Claude Desktop."""
+
+    def test_removes_notebooklm_entry(self, tmp_path):
+        config_path = tmp_path / "claude_desktop_config.json"
+        config = {
+            "coworkUserFilesPath": "/Users/test/Claude",
+            "mcpServers": {
+                "notebooklm-mcp": {"command": "/usr/local/bin/notebooklm-mcp", "args": []},
+                "fetch": {"command": "uvx", "args": ["mcp-server-fetch"]},
+            },
+        }
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config))
+
+        with patch(
+            "notebooklm_tools.cli.commands.setup._claude_desktop_config_path",
+            return_value=config_path,
+        ):
+            result = _remove_single("claude-desktop")
+
+        assert result is True
+        updated = json.loads(config_path.read_text())
+        assert "notebooklm-mcp" not in updated["mcpServers"]
+        assert "fetch" in updated["mcpServers"]
+        assert updated["coworkUserFilesPath"] == config["coworkUserFilesPath"]
+
+    def test_returns_false_when_not_configured(self, tmp_path):
+        config_path = tmp_path / "claude_desktop_config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps({"mcpServers": {}}))
+
+        with patch(
+            "notebooklm_tools.cli.commands.setup._claude_desktop_config_path",
+            return_value=config_path,
+        ):
+            result = _remove_single("claude-desktop")
+
+        assert result is False
+
+    def test_returns_false_when_no_config_file(self, tmp_path):
+        config_path = tmp_path / "claude_desktop_config.json"
+
+        with patch(
+            "notebooklm_tools.cli.commands.setup._claude_desktop_config_path",
+            return_value=config_path,
+        ):
+            result = _remove_single("claude-desktop")
+
+        assert result is False


### PR DESCRIPTION
## Summary

The README documents `nlm setup add claude-desktop` and lists Claude Desktop's config path, but the CLI's `CLIENT_REGISTRY` never actually defined a `claude-desktop` client:

```
$ nlm setup add claude-desktop
Error: Unknown client 'claude-desktop'
Available clients: claude-code, gemini, cursor, github-copilot, windsurf, cline, antigravity, codex, opencode, json, all
```

It was also silently absent from `nlm setup list` and the `nlm doctor` client check.

- Adds a `claude-desktop` client to `CLIENT_REGISTRY` with a platform-aware config path resolver (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS, `%APPDATA%/Claude/claude_desktop_config.json` on Windows, `~/.config/Claude/claude_desktop_config.json` elsewhere)
- `_setup_claude_desktop()` writes the **full resolved path** to the `notebooklm-mcp` binary rather than the bare command name, since Claude Desktop doesn't inherit the shell `PATH` (same caveat already called out in the README's manual setup section)
- Wires it into detection (`_detect_tool`), `_is_already_configured`, `setup add`/`setup remove`/`setup list`, `setup add all`, `nlm doctor`, and the `--ai` docs
- Checked `nlm skill install` — no change needed there, since its `claude-code` entry already covers "Claude Code CLI and Desktop" via the shared `~/.claude/` directory

## Test plan

- [x] `uv run pytest -q -m "not e2e"` — 1264 passed, 38 skipped (no regressions)
- [x] Added `tests/cli/test_setup_claude_desktop.py` covering registry, config path (macOS/Windows/Linux), setup (fresh/full-path-fallback/preserve-existing/idempotent), detection, `_is_already_configured`, and removal
- [x] `uv run ruff check` — clean
- [x] `uv run mypy` — confirmed the pre-existing 17 errors in `setup.py` are unchanged by this diff (same count/lines on `main`)
- [x] Manually verified `nlm setup list` now shows "Claude Desktop" as a row