### PR TITLE
fix(windows): resolve Claude config without environment home

### DIFF
--- a/src/notebooklm_tools/cli/commands/setup.py
+++ b/src/notebooklm_tools/cli/commands/setup.py
@@ -283,6 +283,32 @@ def _claude_desktop_msix_config_path() -> Path | None:
     return package_dir / "LocalCache" / "Roaming" / "Claude" / "claude_desktop_config.json"
 
 
+def _windows_profile_dir_from_shell() -> Path | None:
+    """Resolve the current Windows profile directory through the shell API."""
+    try:
+        import ctypes
+
+        profile = ctypes.create_unicode_buffer(260)
+        # CSIDL_PROFILE (40) resolves the current user's profile directory.
+        result = ctypes.windll.shell32.SHGetFolderPathW(None, 40, None, 0, profile)
+    except (AttributeError, OSError):
+        return None
+    if result == 0 and profile.value:
+        return Path(profile.value)
+    return None
+
+
+def _windows_home_dir() -> Path:
+    """Resolve the Windows home directory even when environment variables are absent."""
+    try:
+        return Path.home()
+    except RuntimeError as exc:
+        profile_dir = _windows_profile_dir_from_shell()
+        if profile_dir is not None:
+            return profile_dir
+        raise RuntimeError("Could not determine Windows home directory.") from exc
+
+
 def _claude_desktop_candidate_paths() -> dict[str, Path]:
     """Return regular and Relay AI/3P Claude Desktop config candidates."""
     system = platform.system()
@@ -294,16 +320,24 @@ def _claude_desktop_candidate_paths() -> dict[str, Path]:
         }
 
     if system == "Windows":
+        appdata = os.environ.get("APPDATA")
+        local_app_data = os.environ.get("LOCALAPPDATA")
+        home_dir = _windows_home_dir() if not appdata or not local_app_data else None
+
         regular_path = _claude_desktop_msix_config_path()
         if regular_path is None:
-            appdata = os.environ.get("APPDATA")
-            appdata_path = Path(appdata) if appdata else Path.home() / "AppData" / "Roaming"
+            if appdata:
+                appdata_path = Path(appdata)
+            else:
+                assert home_dir is not None
+                appdata_path = home_dir / "AppData" / "Roaming"
             regular_path = appdata_path / "Claude" / "claude_desktop_config.json"
 
-        local_app_data = os.environ.get("LOCALAPPDATA")
-        local_app_data_path = (
-            Path(local_app_data) if local_app_data else Path.home() / "AppData" / "Local"
-        )
+        if local_app_data:
+            local_app_data_path = Path(local_app_data)
+        else:
+            assert home_dir is not None
+            local_app_data_path = home_dir / "AppData" / "Local"
         return {
             CLAUDE_DESKTOP_PROFILE_REGULAR: regular_path,
             CLAUDE_DESKTOP_PROFILE_3P: local_app_data_path

--- a/tests/cli/test_setup_claude_desktop.py
+++ b/tests/cli/test_setup_claude_desktop.py
@@ -70,6 +70,20 @@ class TestClaudeDesktopConfigPath:
             path = _claude_desktop_config_path()
         assert path == Path.home() / "AppData" / "Roaming" / "Claude" / "claude_desktop_config.json"
 
+    def test_windows_path_uses_shell_profile_when_path_home_is_unavailable(self, tmp_path):
+        with (
+            patch("platform.system", return_value="Windows"),
+            patch.dict(os.environ, {}, clear=True),
+            patch("pathlib.Path.home", side_effect=RuntimeError("home unavailable")),
+            patch(
+                "notebooklm_tools.cli.commands.setup._windows_profile_dir_from_shell",
+                return_value=tmp_path,
+            ),
+        ):
+            path = _claude_desktop_config_path()
+
+        assert path == tmp_path / "AppData" / "Roaming" / "Claude" / "claude_desktop_config.json"
+
     def test_windows_path_uses_existing_msix_config(self, tmp_path):
         local_app_data = tmp_path / "LocalAppData"
         msix_config = (


### PR DESCRIPTION
﻿## Summary

- add a Windows profile-directory fallback for environments where `Path.home()` cannot resolve
- use the Windows shell profile path before constructing `AppData\Roaming` and `AppData\Local` fallbacks
- preserve the existing environment-variable and `Path.home()` behavior when those sources are available

## Problem

`_claude_desktop_candidate_paths()` currently calls `Path.home()` after `APPDATA` / `LOCALAPPDATA` are absent. On Windows, clearing the environment can make `Path.home()` raise `RuntimeError: Could not determine home directory`, including in the existing `test_windows_path_falls_back_when_appdata_is_missing` case.

## Implementation

The fallback order is:

1. `Path.home()`
2. `SHGetFolderPathW(CSIDL_PROFILE)`
3. `SYSTEMDRIVE\Users\<os.getlogin()>`

The helper raises the original `Path.home()` error when no reliable Windows profile path can be resolved.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest tests/cli/test_setup_claude_desktop.py -q` — 39 passed
- full upstream-first integration stack on Windows — 1,318 passed, 39 skipped

Manual Windows reproduction: with home-related environment variables cleared, Claude Desktop config-path resolution returns a profile-based path instead of raising from `Path.home()`.

No new dependencies.
