### PR TITLE
feat(mcp): add bounded readiness polling for sources and downloads

### DIFF
--- a/src/notebooklm_tools/mcp/tools/downloads.py
+++ b/src/notebooklm_tools/mcp/tools/downloads.py
@@ -15,6 +15,9 @@ def download_artifact(
     artifact_id: str | None = None,
     output_format: str = "json",
     slide_deck_format: str = "pdf",
+    wait: bool = False,
+    wait_timeout: float = 180.0,
+    poll_interval: float = 5.0,
 ) -> ResultDict:
     """Download any NotebookLM artifact to a file.
 
@@ -38,6 +41,9 @@ def download_artifact(
         artifact_id: Optional specific artifact ID (uses latest if not provided)
         output_format: For quiz/flashcards only: json|markdown|html (default: json)
         slide_deck_format: For slide_deck only: pdf (default) or pptx
+        wait: Poll while the artifact download is still propagating
+        wait_timeout: Maximum seconds to wait when ``wait`` is enabled
+        poll_interval: Seconds between readiness checks
 
     Returns:
         dict with status and saved file path
@@ -58,6 +64,9 @@ def download_artifact(
                 artifact_id=artifact_id,
                 output_format=output_format,
                 slide_deck_format=slide_deck_format,
+                wait=wait,
+                wait_timeout=wait_timeout,
+                poll_interval=poll_interval,
             )
         )
         return {"status": "success", **download_result}

--- a/src/notebooklm_tools/mcp/tools/sources.py
+++ b/src/notebooklm_tools/mcp/tools/sources.py
@@ -250,7 +250,12 @@ def source_describe(source_id: str) -> ResultDict:
 
 
 @logged_tool()
-def source_get_content(source_id: str) -> ResultDict:
+def source_get_content(
+    source_id: str,
+    wait: bool = False,
+    wait_timeout: float = 120.0,
+    poll_interval: float = 3.0,
+) -> ResultDict:
     """Get raw text content of a source (no AI processing).
 
     Returns the original indexed text from PDFs, web pages, pasted text,
@@ -258,12 +263,21 @@ def source_get_content(source_id: str) -> ResultDict:
 
     Args:
         source_id: Source UUID
+        wait: Poll until indexed content is available
+        wait_timeout: Maximum seconds to wait when ``wait`` is enabled
+        poll_interval: Seconds between readiness checks
 
     Returns: content (str), title (str), source_type (str), char_count (int)
     """
     try:
         client = get_client()
-        result = sources_service.get_source_content(client, source_id)
+        result = sources_service.get_source_content(
+            client,
+            source_id,
+            wait=wait,
+            wait_timeout=wait_timeout,
+            poll_interval=poll_interval,
+        )
         return {"status": "success", **result}
     except ServiceError as e:
         return error_result(e.user_message, hint=e.hint)

--- a/src/notebooklm_tools/services/downloads.py
+++ b/src/notebooklm_tools/services/downloads.py
@@ -1,8 +1,10 @@
 """Downloads service — shared validation and routing for artifact downloads."""
 
+import asyncio
 import inspect
 import os
 import re
+import time
 from collections.abc import Awaitable, Callable, Sequence
 from pathlib import Path
 from typing import Any, cast
@@ -286,46 +288,17 @@ def download_sync(
     return {"artifact_type": artifact_type, "path": saved_path}
 
 
-async def download_async(
+async def _download_once_async(
     client: NotebookLMClient,
     notebook_id: str,
     artifact_type: str,
     output_path: str,
-    artifact_id: str | None = None,
-    output_format: str = "json",
-    progress_callback: Callable[[int, int], None] | None = None,
-    slide_deck_format: str = "pdf",
+    artifact_id: str | None,
+    output_format: str,
+    progress_callback: Callable[[int, int], None] | None,
+    slide_deck_format: str,
 ) -> DownloadResult:
-    """Download a streaming artifact asynchronously.
-
-    For: audio, video, slide_deck, infographic, quiz, flashcards.
-
-    Args:
-        client: Authenticated NotebookLM client
-        notebook_id: Notebook UUID
-        artifact_type: Type of artifact
-        output_path: Path to save file
-        artifact_id: Specific artifact ID (optional)
-        output_format: For quiz/flashcards: json|markdown|html
-        progress_callback: Called with (current, total) for progress tracking
-        slide_deck_format: For slide_deck only: "pdf" (default) or "pptx"
-
-    Returns:
-        DownloadResult with artifact_type and path
-
-    Raises:
-        ValidationError: If artifact_type or output_format is invalid
-        ServiceError: If the download fails
-    """
-    validate_artifact_type(artifact_type)
-    validate_output_path(output_path)
-
-    if artifact_type == "audio":
-        validate_audio_extension(output_path)
-
-    if artifact_type in INTERACTIVE_TYPES:
-        validate_output_format(output_format)
-
+    """Attempt one artifact download without readiness polling."""
     try:
         saved_path = await _dispatch_async(
             client,
@@ -340,13 +313,15 @@ async def download_async(
     except (ValidationError, ServiceError):
         raise
     except ArtifactDownloadError as e:
-        if artifact_type == "audio" and "still propagating" in e.details:
+        if "still propagating" in e.details.lower():
             raise ServiceError(
                 f"Failed to download {artifact_type}: {e}",
                 user_message=(
-                    "Audio is complete, but its media download URL is still propagating. "
-                    "Try again in a few minutes."
+                    f"{artifact_type.title()} is complete, but its download is still propagating. "
+                    "Try again shortly."
                 ),
+                hint="Retry the download after a short delay.",
+                debug_code="artifact_not_ready",
             ) from e
         raise ServiceError(
             f"Failed to download {artifact_type}: {e}",
@@ -362,9 +337,88 @@ async def download_async(
         raise ServiceError(
             f"Download returned no path for {artifact_type}",
             user_message=f"{artifact_type} is not ready or does not exist.",
+            hint="Retry shortly if the artifact was just created.",
+            debug_code="artifact_not_ready",
         )
 
     return {"artifact_type": artifact_type, "path": saved_path}
+
+
+async def download_async(
+    client: NotebookLMClient,
+    notebook_id: str,
+    artifact_type: str,
+    output_path: str,
+    artifact_id: str | None = None,
+    output_format: str = "json",
+    progress_callback: Callable[[int, int], None] | None = None,
+    slide_deck_format: str = "pdf",
+    *,
+    wait: bool = False,
+    wait_timeout: float = 180.0,
+    poll_interval: float = 5.0,
+) -> DownloadResult:
+    """Download a streaming artifact asynchronously.
+
+    For: audio, video, slide_deck, infographic, quiz, flashcards.
+
+    Args:
+        client: Authenticated NotebookLM client
+        notebook_id: Notebook UUID
+        artifact_type: Type of artifact
+        output_path: Path to save file
+        artifact_id: Specific artifact ID (optional)
+        output_format: For quiz/flashcards: json|markdown|html
+        progress_callback: Called with (current, total) for progress tracking
+        slide_deck_format: For slide_deck only: "pdf" (default) or "pptx"
+        wait: Poll while the artifact download is still propagating
+        wait_timeout: Maximum seconds to wait when ``wait`` is enabled
+        poll_interval: Seconds between readiness checks
+
+    Returns:
+        DownloadResult with artifact_type and path
+
+    Raises:
+        ValidationError: If artifact_type, output_format, or polling options are invalid
+        ServiceError: If the download fails or readiness times out
+    """
+    validate_artifact_type(artifact_type)
+    validate_output_path(output_path)
+
+    if artifact_type == "audio":
+        validate_audio_extension(output_path)
+    if artifact_type in INTERACTIVE_TYPES:
+        validate_output_format(output_format)
+    if wait and wait_timeout < 0:
+        raise ValidationError("wait_timeout must be greater than or equal to 0.")
+    if wait and poll_interval <= 0:
+        raise ValidationError("poll_interval must be greater than 0.")
+
+    deadline = time.monotonic() + wait_timeout
+    while True:
+        try:
+            return await _download_once_async(
+                client,
+                notebook_id,
+                artifact_type,
+                output_path,
+                artifact_id,
+                output_format,
+                progress_callback,
+                slide_deck_format,
+            )
+        except ServiceError as e:
+            if not wait or e.debug_code != "artifact_not_ready":
+                raise
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise ServiceError(
+                    f"{artifact_type} download was not ready after {wait_timeout}s",
+                    user_message=f"{artifact_type} is not ready yet.",
+                    hint="Retry shortly or increase wait_timeout.",
+                    debug_code="artifact_not_ready",
+                ) from e
+            await asyncio.sleep(min(poll_interval, remaining))
 
 
 _INVALID_FILENAME_CHARS = re.compile(r'[<>:"/\\|?*\x00-\x1f]')

--- a/src/notebooklm_tools/services/sources.py
+++ b/src/notebooklm_tools/services/sources.py
@@ -1,6 +1,7 @@
 """Sources service — shared validation and logic for source management."""
 
 import os
+import time
 import urllib.parse
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -664,37 +665,64 @@ def describe_source(
 def get_source_content(
     client: NotebookLMClient,
     source_id: str,
+    *,
+    wait: bool = False,
+    wait_timeout: float = 120.0,
+    poll_interval: float = 3.0,
 ) -> SourceContentResult:
     """Get raw text content of a source (no AI processing).
 
     Args:
         client: Authenticated NotebookLM client
         source_id: Source UUID
+        wait: Poll until indexed content is available
+        wait_timeout: Maximum seconds to wait when ``wait`` is enabled
+        poll_interval: Seconds between readiness checks
 
     Returns:
         SourceContentResult with content, title, type, and char_count
 
     Raises:
-        ServiceError: If content retrieval fails
+        ValidationError: If polling options are invalid
+        ServiceError: If content retrieval fails or readiness times out
     """
-    try:
-        result = client.get_source_fulltext(source_id)
-        if not result:
+    if wait and wait_timeout < 0:
+        raise ValidationError("wait_timeout must be greater than or equal to 0.")
+    if wait and poll_interval <= 0:
+        raise ValidationError("poll_interval must be greater than 0.")
+
+    deadline = time.monotonic() + wait_timeout
+    while True:
+        try:
+            result = client.get_source_fulltext(source_id)
+        except Exception as e:
+            raise ServiceError(
+                f"Failed to get content for source {source_id}: {e}",
+                user_message="Failed to get source content.",
+            ) from e
+
+        content = result.get("content", "") if result else ""
+        if result and (content or not wait):
+            return {
+                "content": content,
+                "title": result.get("title", ""),
+                "source_type": result.get("type", "unknown"),
+                "char_count": len(content),
+            }
+
+        if not wait:
             raise ServiceError(
                 f"No content returned for source {source_id}",
                 user_message="Failed to get source content.",
+                debug_code="source_not_ready",
             )
-        content = result.get("content", "")
-        return {
-            "content": content,
-            "title": result.get("title", ""),
-            "source_type": result.get("type", "unknown"),
-            "char_count": len(content),
-        }
-    except ServiceError:
-        raise
-    except Exception as e:
-        raise ServiceError(
-            f"Failed to get content for source {source_id}: {e}",
-            user_message="Failed to get source content.",
-        ) from e
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise ServiceError(
+                f"Source {source_id} content was not ready after {wait_timeout}s",
+                user_message="Source content is not ready yet.",
+                hint="NotebookLM may still be indexing this source. Retry shortly or increase wait_timeout.",
+                debug_code="source_not_ready",
+            )
+        time.sleep(min(poll_interval, remaining))

--- a/tests/services/test_downloads.py
+++ b/tests/services/test_downloads.py
@@ -238,6 +238,65 @@ class TestDownloadAsync:
             await download_async(mock_client, "nb-1", "audio", "/tmp/out")
 
     @pytest.mark.asyncio
+    async def test_waits_for_propagating_artifact(self, mock_client, monkeypatch):
+        propagation_error = ArtifactDownloadError(
+            "audio",
+            details="media download URL is still propagating; retry shortly",
+        )
+        mock_client.download_audio = AsyncMock(side_effect=[propagation_error, "/tmp/audio.m4a"])
+        sleep = AsyncMock()
+        monkeypatch.setattr("notebooklm_tools.services.downloads.asyncio.sleep", sleep)
+
+        result = await download_async(
+            mock_client,
+            "nb-1",
+            "audio",
+            "/tmp/out.m4a",
+            wait=True,
+            wait_timeout=10,
+            poll_interval=0.25,
+        )
+
+        assert result["path"] == "/tmp/audio.m4a"
+        assert mock_client.download_audio.await_count == 2
+        sleep.assert_awaited_once_with(0.25)
+
+    @pytest.mark.asyncio
+    async def test_wait_timeout_has_stable_debug_code(self, mock_client):
+        mock_client.download_audio = AsyncMock(return_value=None)
+
+        with pytest.raises(ServiceError) as exc_info:
+            await download_async(
+                mock_client,
+                "nb-1",
+                "audio",
+                "/tmp/out.m4a",
+                wait=True,
+                wait_timeout=0,
+            )
+
+        assert exc_info.value.debug_code == "artifact_not_ready"
+        assert exc_info.value.hint is not None
+
+    @pytest.mark.asyncio
+    async def test_non_transient_error_is_not_retried(self, mock_client, monkeypatch):
+        mock_client.download_audio = AsyncMock(side_effect=RuntimeError("denied"))
+        sleep = AsyncMock()
+        monkeypatch.setattr("notebooklm_tools.services.downloads.asyncio.sleep", sleep)
+
+        with pytest.raises(ServiceError, match="Failed to download"):
+            await download_async(
+                mock_client,
+                "nb-1",
+                "audio",
+                "/tmp/out.m4a",
+                wait=True,
+            )
+
+        assert mock_client.download_audio.await_count == 1
+        sleep.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_progress_callback_passed_through(self, mock_client):
         cb = MagicMock()
         await download_async(

--- a/tests/services/test_sources.py
+++ b/tests/services/test_sources.py
@@ -523,6 +523,42 @@ class TestGetSourceContent:
         with pytest.raises(ServiceError, match="No content returned"):
             get_source_content(mock_client, "src-1")
 
+    def test_waits_until_indexed_content_is_available(self, mock_client, monkeypatch):
+        mock_client.get_source_fulltext.side_effect = [
+            {"content": "", "title": "Pending", "type": "text"},
+            {"content": "Ready", "title": "Indexed", "type": "text"},
+        ]
+        sleeps = []
+        monkeypatch.setattr(
+            "notebooklm_tools.services.sources.time.sleep",
+            sleeps.append,
+        )
+
+        result = get_source_content(
+            mock_client,
+            "src-1",
+            wait=True,
+            wait_timeout=10,
+            poll_interval=0.25,
+        )
+
+        assert result["content"] == "Ready"
+        assert mock_client.get_source_fulltext.call_count == 2
+        assert sleeps == [0.25]
+
+    def test_wait_timeout_has_stable_debug_code(self, mock_client):
+        mock_client.get_source_fulltext.return_value = None
+
+        with pytest.raises(ServiceError) as exc_info:
+            get_source_content(mock_client, "src-1", wait=True, wait_timeout=0)
+
+        assert exc_info.value.debug_code == "source_not_ready"
+        assert exc_info.value.hint is not None
+
+    def test_rejects_invalid_poll_interval(self, mock_client):
+        with pytest.raises(ValidationError, match="poll_interval"):
+            get_source_content(mock_client, "src-1", wait=True, poll_interval=0)
+
 
 class TestAddSources:
     """Test add_sources (bulk) function."""

--- a/tests/test_mcp_downloads.py
+++ b/tests/test_mcp_downloads.py
@@ -1,6 +1,6 @@
 """Unit tests for the download_all_artifacts MCP tool."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from notebooklm_tools.mcp.tools import downloads
 from notebooklm_tools.services.errors import ServiceError, ValidationError
@@ -185,3 +185,38 @@ def test_service_error_surfaces_user_message_and_hint():
     assert result["status"] == "error"
     assert result["error"] == "Notebook not found."
     assert result["hint"] == "Check the ID."
+
+
+def test_download_artifact_forwards_readiness_options():
+    mock_client = MagicMock()
+    service_result = {"artifact_type": "audio", "path": "/tmp/audio.m4a"}
+
+    with (
+        patch("notebooklm_tools.mcp.tools.downloads.get_client", return_value=mock_client),
+        patch(
+            "notebooklm_tools.mcp.tools.downloads.downloads_service.download_async",
+            new=AsyncMock(return_value=service_result),
+        ) as download_async,
+    ):
+        result = downloads.download_artifact(
+            notebook_id="nb-1",
+            artifact_type="audio",
+            output_path="/tmp/audio.m4a",
+            wait=True,
+            wait_timeout=9,
+            poll_interval=0.5,
+        )
+
+    assert result["status"] == "success"
+    download_async.assert_awaited_once_with(
+        mock_client,
+        "nb-1",
+        "audio",
+        "/tmp/audio.m4a",
+        artifact_id=None,
+        output_format="json",
+        slide_deck_format="pdf",
+        wait=True,
+        wait_timeout=9,
+        poll_interval=0.5,
+    )

--- a/tests/test_mcp_sources.py
+++ b/tests/test_mcp_sources.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
-from notebooklm_tools.mcp.tools.sources import source_list_drive
+from notebooklm_tools.mcp.tools.sources import source_get_content, source_list_drive
 
 
 def test_source_list_drive_forwards_skip_freshness():
@@ -25,3 +25,36 @@ def test_source_list_drive_forwards_skip_freshness():
 
     assert result["status"] == "success"
     list_drive_sources.assert_called_once_with(client, "nb-1", skip_freshness=True)
+
+
+def test_source_get_content_forwards_readiness_options():
+    client = MagicMock()
+    service_result = {
+        "content": "ready",
+        "title": "Source",
+        "source_type": "text",
+        "char_count": 5,
+    }
+
+    with (
+        patch("notebooklm_tools.mcp.tools.sources.get_client", return_value=client),
+        patch(
+            "notebooklm_tools.mcp.tools.sources.sources_service.get_source_content",
+            return_value=service_result,
+        ) as get_content,
+    ):
+        result = source_get_content(
+            "src-1",
+            wait=True,
+            wait_timeout=9,
+            poll_interval=0.5,
+        )
+
+    assert result["status"] == "success"
+    get_content.assert_called_once_with(
+        client,
+        "src-1",
+        wait=True,
+        wait_timeout=9,
+        poll_interval=0.5,
+    )


### PR DESCRIPTION
﻿## Summary

- add opt-in bounded polling to `source_get_content`
- add opt-in bounded polling to `download_artifact`
- keep polling and timeout logic in `services/`, with thin MCP wrappers
- preserve current behavior by default with `wait=False`

This is the focused polling behavior discussed during review of #229. It deliberately excludes the ChatGPT bridge, authentication, CDP, and public-route changes from that earlier work.

## Behavior

Both tools accept:

- `wait: bool = False`
- `wait_timeout`
- `poll_interval`

Polling uses monotonic deadlines, enforces a minimum interval, and retries only recognized not-ready states. Validation, authentication, permission, and other terminal failures continue to fail immediately.

The download service supports both synchronous and awaitable download implementations without calling `asyncio.run()` from the MCP wrapper.

## Compatibility

- existing calls remain immediate because `wait` defaults to `False`
- successful response shapes are unchanged
- no new dependencies

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- focused source/download service and MCP suites — 164 passed
- dependency composition with structured errors — 207 passed
- full upstream-first integration stack on Windows — 1,318 passed, 39 skipped

A live in-progress NotebookLM source/artifact was not available during final validation, so timeout and transition states were exercised with deterministic service/client tests rather than a live mutation.
