### PR TITLE
fix(chat): expose structured provider query errors

### DIFF
--- a/src/notebooklm_tools/mcp/tools/_utils.py
+++ b/src/notebooklm_tools/mcp/tools/_utils.py
@@ -12,6 +12,7 @@ from typing import Any, ParamSpec, TypeAlias, TypeVar, cast
 from notebooklm_tools.core.client import NotebookLMClient
 from notebooklm_tools.core.utils import extract_cookies_from_chrome_export
 from notebooklm_tools.services.auth import load_cached_tokens
+from notebooklm_tools.services.errors import ServiceError
 
 # MCP request/response logger
 mcp_logger = logging.getLogger("notebooklm_tools.mcp")
@@ -45,6 +46,15 @@ def error_result(
     if hint:
         result["hint"] = hint
     result.update(extra)
+    return result
+
+
+def service_error_result(error: ServiceError, *, status: str = "error") -> ResultDict:
+    """Serialize a ServiceError without breaking the existing MCP error shape."""
+    result = error_result(error.user_message, hint=error.hint, status=status)
+    details = error.details()
+    if details:
+        result["error_details"] = details
     return result
 
 

--- a/src/notebooklm_tools/mcp/tools/chat.py
+++ b/src/notebooklm_tools/mcp/tools/chat.py
@@ -13,6 +13,7 @@ from ._utils import (
     get_client,
     get_query_timeout,
     logged_tool,
+    service_error_result,
 )
 
 
@@ -54,7 +55,7 @@ async def notebook_query(
         )
         return {"status": "success", **result}
     except ServiceError as e:
-        return error_result(e.user_message, hint=e.hint)
+        return service_error_result(e)
     except Exception as e:
         return error_result(str(e))
 
@@ -85,7 +86,7 @@ def chat_configure(
         )
         return {"status": "success", **result}
     except ServiceError as e:
-        return error_result(e.user_message, hint=e.hint)
+        return service_error_result(e)
     except Exception as e:
         return error_result(str(e))
 
@@ -127,7 +128,7 @@ def notebook_query_start(
         )
         return {"status": "success", **result}
     except ServiceError as e:
-        return error_result(e.user_message, hint=e.hint)
+        return service_error_result(e)
     except Exception as e:
         return error_result(str(e))
 
@@ -148,6 +149,6 @@ def notebook_query_status(
         result = chat_service.query_status(query_id)
         return {"status": "success", **result}
     except ServiceError as e:
-        return error_result(e.user_message, hint=e.hint)
+        return service_error_result(e)
     except Exception as e:
         return error_result(str(e))

--- a/src/notebooklm_tools/services/chat.py
+++ b/src/notebooklm_tools/services/chat.py
@@ -19,6 +19,76 @@ VALID_RESPONSE_LENGTHS = ("default", "longer", "shorter")
 MAX_PROMPT_LENGTH = 10_000
 
 
+_QUERY_REJECTION_METADATA: dict[int, dict[str, str | bool]] = {
+    1: {"category": "cancelled", "retryable": False, "suggested_action": "submit_again_if_needed"},
+    3: {
+        "category": "invalid_argument",
+        "retryable": False,
+        "suggested_action": "check_query_arguments",
+    },
+    4: {
+        "category": "deadline_exceeded",
+        "retryable": True,
+        "suggested_action": "retry_with_longer_timeout",
+    },
+    5: {
+        "category": "not_found",
+        "retryable": False,
+        "suggested_action": "check_notebook_and_source_ids",
+    },
+    7: {
+        "category": "permission_denied",
+        "retryable": False,
+        "suggested_action": "check_access_permissions",
+    },
+    8: {
+        "category": "resource_exhausted",
+        "retryable": True,
+        "suggested_action": "retry_after_delay",
+    },
+    13: {"category": "internal", "retryable": True, "suggested_action": "retry_after_delay"},
+    14: {"category": "unavailable", "retryable": True, "suggested_action": "retry_after_delay"},
+    16: {"category": "unauthenticated", "retryable": False, "suggested_action": "run_nlm_login"},
+}
+
+
+def _query_rejected_service_error(error: QueryRejectedError) -> ServiceError:
+    """Map a provider query rejection to actionable, structured metadata."""
+    metadata = _QUERY_REJECTION_METADATA.get(
+        error.error_code,
+        {
+            "category": "provider_error",
+            "retryable": False,
+            "suggested_action": "inspect_provider_error",
+        },
+    )
+    category = str(metadata["category"])
+    messages = {
+        3: "The query request is invalid. Check the notebook ID, source IDs, and query arguments.",
+        5: "The requested notebook or source was not found. Check the supplied IDs.",
+        7: "Access to the requested notebook or source was denied.",
+        8: "NotebookLM temporarily rejected the query because a usage limit was reached.",
+        16: "NotebookLM authentication is no longer valid. Run 'nlm login' and retry.",
+    }
+    hints = {
+        3: "Correct the invalid notebook ID, source ID, or query argument before retrying.",
+        5: "Verify that the notebook and selected sources still exist and belong to this account.",
+        7: "Confirm that the active account has access to the notebook and selected sources.",
+        8: "Wait before retrying the query.",
+        16: "Run 'nlm login' for the active profile.",
+    }
+    return ServiceError(
+        f"Query failed: {error}",
+        user_message=messages.get(error.error_code, str(error)),
+        hint=hints.get(error.error_code),
+        debug_code=f"query_{category}",
+        category=category,
+        provider_code=error.error_code,
+        retryable=bool(metadata["retryable"]),
+        suggested_action=str(metadata["suggested_action"]),
+    )
+
+
 class QueryResult(TypedDict):
     """Result of a notebook query."""
 
@@ -36,6 +106,7 @@ class PendingQueryState(TypedDict):
     status: str
     result: QueryResult | None
     error: str | None
+    error_details: dict[str, str | int | bool] | None
     created_at: float
 
 
@@ -109,14 +180,7 @@ def query(
             **({"timeout": cast(float, timeout)} if timeout is not None else {}),
         )
     except QueryRejectedError as e:
-        raise ServiceError(
-            f"Query failed: {e}",
-            user_message=(
-                f"{e}. This may indicate account-level restrictions on "
-                "programmatic access. Try re-authenticating with 'nlm login' "
-                "or using a different account."
-            ),
-        ) from e
+        raise _query_rejected_service_error(e) from e
     except Exception as e:
         raise ServiceError(f"Query failed: {e}") from e
 
@@ -267,6 +331,7 @@ class QueryStatusResult(TypedDict):
     status: str
     result: QueryResult | None
     error: str | None
+    error_details: dict[str, str | int | bool] | None
 
 
 def _cleanup_expired_queries() -> None:
@@ -309,7 +374,11 @@ def _run_query_in_background(
         with _pending_lock:
             if query_id in _pending_queries:
                 _pending_queries[query_id]["status"] = "error"
-                _pending_queries[query_id]["error"] = str(e)
+                if isinstance(e, ServiceError):
+                    _pending_queries[query_id]["error"] = e.user_message
+                    _pending_queries[query_id]["error_details"] = e.details() or None
+                else:
+                    _pending_queries[query_id]["error"] = str(e)
 
 
 def query_start(
@@ -368,6 +437,7 @@ def query_start(
             "status": "in_progress",
             "result": None,
             "error": None,
+            "error_details": None,
             "created_at": time.monotonic(),
         }
 
@@ -414,6 +484,7 @@ def query_status(query_id: str) -> QueryStatusResult:
             "status": entry["status"],
             "result": entry["result"],
             "error": entry["error"],
+            "error_details": entry["error_details"],
         }
 
         # Clean up completed/errored entries after reading

--- a/src/notebooklm_tools/services/errors.py
+++ b/src/notebooklm_tools/services/errors.py
@@ -2,7 +2,7 @@
 
 
 class ServiceError(Exception):
-    """Base class for all service layer errors."""
+    """Base class for service errors with optional structured metadata."""
 
     def __init__(
         self,
@@ -10,11 +10,31 @@ class ServiceError(Exception):
         user_message: str | None = None,
         hint: str | None = None,
         debug_code: str | None = None,
+        *,
+        category: str | None = None,
+        provider_code: int | str | None = None,
+        retryable: bool | None = None,
+        suggested_action: str | None = None,
     ):
         super().__init__(message)
         self.user_message = user_message or message
         self.hint = hint
         self.debug_code = debug_code
+        self.category = category
+        self.provider_code = provider_code
+        self.retryable = retryable
+        self.suggested_action = suggested_action
+
+    def details(self) -> dict[str, str | int | bool]:
+        """Return non-empty machine-readable metadata for API and MCP clients."""
+        values: dict[str, str | int | bool | None] = {
+            "category": self.category,
+            "provider_code": self.provider_code,
+            "retryable": self.retryable,
+            "suggested_action": self.suggested_action,
+            "debug_code": self.debug_code,
+        }
+        return {key: value for key, value in values.items() if value is not None}
 
 
 class ValidationError(ServiceError):

--- a/tests/services/test_chat.py
+++ b/tests/services/test_chat.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from notebooklm_tools.core.conversation import QueryRejectedError
 from notebooklm_tools.services.chat import (
     configure_chat,
     delete_chat_history,
@@ -62,6 +63,46 @@ class TestQuery:
         mock_client.query.side_effect = RuntimeError("timeout")
         with pytest.raises(ServiceError, match="Query failed"):
             query(mock_client, "nb-123", "question")
+
+    @pytest.mark.parametrize(
+        ("provider_code", "category", "retryable", "suggested_action"),
+        [
+            (3, "invalid_argument", False, "check_query_arguments"),
+            (5, "not_found", False, "check_notebook_and_source_ids"),
+            (8, "resource_exhausted", True, "retry_after_delay"),
+            (16, "unauthenticated", False, "run_nlm_login"),
+        ],
+    )
+    def test_query_rejection_has_structured_metadata(
+        self,
+        mock_client,
+        provider_code,
+        category,
+        retryable,
+        suggested_action,
+    ):
+        mock_client.query.side_effect = QueryRejectedError(provider_code)
+
+        with pytest.raises(ServiceError) as exc_info:
+            query(mock_client, "nb-123", "question", source_ids=["src-1"])
+
+        error = exc_info.value
+        assert error.provider_code == provider_code
+        assert error.category == category
+        assert error.retryable is retryable
+        assert error.suggested_action == suggested_action
+        assert error.debug_code == f"query_{category}"
+
+    def test_invalid_argument_does_not_recommend_reauthentication(self, mock_client):
+        mock_client.query.side_effect = QueryRejectedError(3)
+
+        with pytest.raises(ServiceError) as exc_info:
+            query(mock_client, "nb-123", "question", source_ids=["missing-source"])
+
+        error = exc_info.value
+        assert "invalid" in error.user_message.lower()
+        assert "login" not in error.user_message.lower()
+        assert "login" not in (error.hint or "").lower()
 
     def test_source_ids_passed_through(self, mock_client):
         mock_client.query.return_value = {"answer": "ok"}
@@ -330,3 +371,31 @@ class TestQueryStatus:
         # Second read should fail because the entry was cleaned up
         with pytest.raises(ValidationError, match="not found"):
             query_status(query_id)
+
+    def test_error_query_preserves_structured_error_details(self, mock_client):
+        import time as _time
+
+        mock_client.query.side_effect = QueryRejectedError(3)
+        result = query_start(
+            mock_client,
+            "nb-123",
+            "question",
+            source_ids=["missing-source"],
+        )
+
+        for _ in range(100):
+            status = query_status(result["query_id"])
+            if status["status"] == "error":
+                break
+            _time.sleep(0.01)
+        else:
+            raise AssertionError("Background query did not reach an error state")
+
+        assert status["status"] == "error"
+        assert status["error_details"] == {
+            "category": "invalid_argument",
+            "provider_code": 3,
+            "retryable": False,
+            "suggested_action": "check_query_arguments",
+            "debug_code": "query_invalid_argument",
+        }

--- a/tests/test_mcp_chat.py
+++ b/tests/test_mcp_chat.py
@@ -8,6 +8,7 @@ import time
 import pytest
 
 from notebooklm_tools.mcp.tools import chat as chat_tools
+from notebooklm_tools.services.errors import ServiceError
 
 
 def test_notebook_query_is_async_for_cancellable_dispatch():
@@ -49,3 +50,35 @@ async def test_notebook_query_cancellation_does_not_wait_for_worker(monkeypatch)
         release.set()
 
     assert await asyncio.to_thread(finished.wait, 1.0)
+
+
+@pytest.mark.asyncio
+async def test_notebook_query_returns_structured_service_error(monkeypatch):
+    monkeypatch.setattr(chat_tools, "get_client", lambda: object())
+
+    def rejected_query(*args, **kwargs):
+        raise ServiceError(
+            "provider rejected query",
+            user_message="The query request is invalid.",
+            hint="Check the source IDs.",
+            debug_code="query_invalid_argument",
+            category="invalid_argument",
+            provider_code=3,
+            retryable=False,
+            suggested_action="check_query_arguments",
+        )
+
+    monkeypatch.setattr(chat_tools.chat_service, "query", rejected_query)
+
+    result = await chat_tools.notebook_query("nb-123", "question")
+
+    assert result["status"] == "error"
+    assert result["error"] == "The query request is invalid."
+    assert result["hint"] == "Check the source IDs."
+    assert result["error_details"] == {
+        "category": "invalid_argument",
+        "provider_code": 3,
+        "retryable": False,
+        "suggested_action": "check_query_arguments",
+        "debug_code": "query_invalid_argument",
+    }


### PR DESCRIPTION
﻿## Summary

- map provider query rejection codes to stable categories and retry guidance
- preserve provider code, retryability, suggested action, and a debug code in `ServiceError`
- expose metadata through an additive MCP `error_details` object
- retain the existing `{status, error, hint}` error contract

## Motivation

Provider failures such as `INVALID_ARGUMENT`, `NOT_FOUND`, `RESOURCE_EXHAUSTED`, and `UNAUTHENTICATED` currently collapse into similar text responses. Agents cannot reliably decide whether to correct input, retry later, check access, or refresh authentication.

This change prevents invalid arguments from being presented as authentication failures and makes retry decisions machine-readable.

## Compatibility

- existing error fields and text remain present
- `error_details` is added only when structured metadata exists
- `retryable=False` is preserved rather than dropped as a falsey value
- async query status retains the same structured failure metadata
- no new dependencies

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- focused chat service and MCP suites — 41 passed
- full upstream-first integration stack on Windows — 1,318 passed, 39 skipped

Provider-code transitions were validated through deterministic `QueryRejectedError` service and MCP-wrapper cases; no live query mutation was required.
