### PR TITLE
feat(core): make rate-limit retry ceiling configurable

### DIFF
--- a/src/notebooklm_tools/core/base.py
+++ b/src/notebooklm_tools/core/base.py
@@ -67,6 +67,33 @@ def _safe_int_env(name: str, default: int) -> int:
     return value
 
 
+def _rate_limit_max_retries() -> int:
+    """Return the retry ceiling for HTTP 429 and RPC RESOURCE_EXHAUSTED errors.
+
+    The default preserves the standard transport retry behavior. Setting
+    ``NOTEBOOKLM_RATE_LIMIT_MAX_RETRIES=0`` surfaces rate limits immediately,
+    which is useful when a caller or queue owns retry scheduling.
+    """
+    name = "NOTEBOOKLM_RATE_LIMIT_MAX_RETRIES"
+    raw = os.environ.get(name)
+    if raw is None or raw.strip() == "":
+        return DEFAULT_MAX_RETRIES
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid %s=%r; falling back to default %d",
+            name,
+            raw,
+            DEFAULT_MAX_RETRIES,
+        )
+        return DEFAULT_MAX_RETRIES
+    if value < 0:
+        logger.warning("%s=%d is negative; clamping to 0", name, value)
+        return 0
+    return value
+
+
 def load_rpc_overrides() -> dict[str, str]:
     """Load runtime RPC-ID overrides from NOTEBOOKLM_RPC_OVERRIDES.
 
@@ -801,7 +828,8 @@ class BaseClient:
         try:
             return self._extract_rpc_result(parsed, rpc_id)
         except ResourceExhaustedError:
-            if _server_retry < DEFAULT_MAX_RETRIES:
+            max_retries = _rate_limit_max_retries()
+            if _server_retry < max_retries:
                 import time as _time
 
                 delay = min(DEFAULT_BASE_DELAY * (2**_server_retry), DEFAULT_MAX_DELAY)
@@ -809,7 +837,7 @@ class BaseClient:
                     "RPC rate limit (RESOURCE_EXHAUSTED) on %s, attempt %d/%d, retrying in %.1fs...",
                     rpc_id,
                     _server_retry + 1,
-                    DEFAULT_MAX_RETRIES + 1,
+                    max_retries + 1,
                     delay,
                 )
                 _time.sleep(delay)
@@ -910,16 +938,19 @@ class BaseClient:
             return result
 
         except httpx.HTTPStatusError as e:
-            # Retry on transient server errors (5xx, 429) with exponential backoff
+            # Retry on transient server errors (5xx, 429) with exponential backoff.
+            # Rate limits have a separate ceiling so external schedulers can own
+            # retry policy without disabling safe connection or 5xx retries.
             if is_retryable_error(e):
                 import time as _time
 
                 status = e.response.status_code
+                max_retries = _rate_limit_max_retries() if status == 429 else DEFAULT_MAX_RETRIES
                 # Use _server_retry to track retries across recursive calls
-                if _server_retry < DEFAULT_MAX_RETRIES:
+                if _server_retry < max_retries:
                     delay = min(DEFAULT_BASE_DELAY * (2**_server_retry), DEFAULT_MAX_DELAY)
                     logger.warning(
-                        f"Server error {status} on attempt {_server_retry + 1}/{DEFAULT_MAX_RETRIES + 1}, "
+                        f"Server error {status} on attempt {_server_retry + 1}/{max_retries + 1}, "
                         f"retrying in {delay:.1f}s..."
                     )
                     _time.sleep(delay)
@@ -980,7 +1011,8 @@ class BaseClient:
 
         except ResourceExhaustedError:
             # RPC-level rate limit (HTTP 200, error code 8). Back off and retry.
-            if _server_retry < DEFAULT_MAX_RETRIES:
+            max_retries = _rate_limit_max_retries()
+            if _server_retry < max_retries:
                 import time as _time
 
                 delay = min(DEFAULT_BASE_DELAY * (2**_server_retry), DEFAULT_MAX_DELAY)
@@ -988,7 +1020,7 @@ class BaseClient:
                     "RPC rate limit (RESOURCE_EXHAUSTED) on %s, attempt %d/%d, retrying in %.1fs...",
                     rpc_id,
                     _server_retry + 1,
-                    DEFAULT_MAX_RETRIES + 1,
+                    max_retries + 1,
                     delay,
                 )
                 _time.sleep(delay)

--- a/src/notebooklm_tools/mcp/server.py
+++ b/src/notebooklm_tools/mcp/server.py
@@ -137,6 +137,7 @@ Environment Variables:
   NOTEBOOKLM_MCP_DEBUG         Debug logging (default: false)
   NOTEBOOKLM_HL                Interface language and default artifact language (default: en)
   NOTEBOOKLM_QUERY_TIMEOUT     Query timeout in seconds (default: 120.0)
+  NOTEBOOKLM_RATE_LIMIT_MAX_RETRIES Retry count for HTTP 429/RPC resource limits (default: 3; 0 disables)
 
 Examples:
   notebooklm-mcp                              # Default stdio transport

--- a/tests/core/test_rpc_errors.py
+++ b/tests/core/test_rpc_errors.py
@@ -1,11 +1,13 @@
 """Tests for RPC drift detection and RPC-level retry in BaseClient."""
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
+import httpx
 import pytest
 
-from notebooklm_tools.core.base import BaseClient
-from notebooklm_tools.core.errors import RPCDriftError
+from notebooklm_tools.core.base import BaseClient, _rate_limit_max_retries
+from notebooklm_tools.core.errors import ResourceExhaustedError, RPCDriftError
+from notebooklm_tools.core.retry import DEFAULT_MAX_RETRIES
 
 
 def _client():
@@ -65,8 +67,6 @@ def test_call_rpc_retries_on_resource_exhausted(monkeypatch):
 
 def test_call_rpc_resource_exhausted_exhausts_retries(monkeypatch):
     """After max retries, ResourceExhaustedError propagates."""
-    from notebooklm_tools.core.errors import ResourceExhaustedError
-
     client = _client()
     exhausted = [[["wrb.fr", "EXPECTED", None, None, None, [8], "generic"]]]
     fake_resp = type(
@@ -144,3 +144,150 @@ def test_call_rpc_does_not_retry_read_timeout():
             client._call_rpc("EXPECTED", [])
 
     assert mock_get_client.return_value.post.call_count == 1
+
+
+def _response_with_status(status: int) -> Mock:
+    request = httpx.Request(
+        "POST",
+        "https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute",
+    )
+    response = httpx.Response(status, request=request)
+    mocked = Mock()
+    mocked.status_code = status
+    mocked.text = ""
+    if status >= 400:
+        mocked.raise_for_status.side_effect = httpx.HTTPStatusError(
+            f"HTTP {status}",
+            request=request,
+            response=response,
+        )
+    else:
+        mocked.raise_for_status.return_value = None
+    return mocked
+
+
+def test_rate_limit_retry_limit_defaults_and_validation(monkeypatch):
+    monkeypatch.delenv("NOTEBOOKLM_RATE_LIMIT_MAX_RETRIES", raising=False)
+    assert _rate_limit_max_retries() == DEFAULT_MAX_RETRIES
+
+    monkeypatch.setenv("NOTEBOOKLM_RATE_LIMIT_MAX_RETRIES", "invalid")
+    assert _rate_limit_max_retries() == DEFAULT_MAX_RETRIES
+
+    monkeypatch.setenv("NOTEBOOKLM_RATE_LIMIT_MAX_RETRIES", "-2")
+    assert _rate_limit_max_retries() == 0
+
+
+def test_resource_exhausted_has_configurable_retry_ceiling(monkeypatch):
+    monkeypatch.setenv("NOTEBOOKLM_RATE_LIMIT_MAX_RETRIES", "1")
+    client = _client()
+    exhausted = [[["wrb.fr", "EXPECTED", None, None, None, [8], "generic"]]]
+    ok = [[["wrb.fr", "EXPECTED", "[1]", None, None, None, "generic"]]]
+    response = _response_with_status(200)
+
+    with (
+        patch.object(client, "_get_client") as mock_get_client,
+        patch.object(client, "_parse_response", side_effect=[exhausted, ok]),
+        patch("time.sleep") as sleep,
+    ):
+        mock_get_client.return_value.post.return_value = response
+        result = client._call_rpc("EXPECTED", [])
+
+    assert result == [1]
+    assert mock_get_client.return_value.post.call_count == 2
+    sleep.assert_called_once()
+
+
+def test_resource_exhausted_surfaces_immediately_when_limit_is_zero(monkeypatch):
+    monkeypatch.setenv("NOTEBOOKLM_RATE_LIMIT_MAX_RETRIES", "0")
+    client = _client()
+    exhausted = [[["wrb.fr", "EXPECTED", None, None, None, [8], "generic"]]]
+    response = _response_with_status(200)
+
+    with (
+        patch.object(client, "_get_client") as mock_get_client,
+        patch.object(client, "_parse_response", return_value=exhausted),
+        patch("time.sleep") as sleep,
+    ):
+        mock_get_client.return_value.post.return_value = response
+        with pytest.raises(ResourceExhaustedError):
+            client._call_rpc("EXPECTED", [])
+
+    assert mock_get_client.return_value.post.call_count == 1
+    sleep.assert_not_called()
+
+
+def test_http_429_surfaces_immediately_when_limit_is_zero(monkeypatch):
+    monkeypatch.setenv("NOTEBOOKLM_RATE_LIMIT_MAX_RETRIES", "0")
+    client = _client()
+
+    with (
+        patch.object(client, "_get_client") as mock_get_client,
+        patch("time.sleep") as sleep,
+    ):
+        mock_get_client.return_value.post.return_value = _response_with_status(429)
+        with pytest.raises(httpx.HTTPStatusError):
+            client._call_rpc("EXPECTED", [])
+
+    assert mock_get_client.return_value.post.call_count == 1
+    sleep.assert_not_called()
+
+
+def test_http_5xx_retries_are_not_disabled_by_rate_limit_policy(monkeypatch):
+    monkeypatch.setenv("NOTEBOOKLM_RATE_LIMIT_MAX_RETRIES", "0")
+    client = _client()
+    ok = [[["wrb.fr", "EXPECTED", "[1]", None, None, None, "generic"]]]
+
+    with (
+        patch.object(client, "_get_client") as mock_get_client,
+        patch.object(client, "_parse_response", return_value=ok),
+        patch("time.sleep") as sleep,
+    ):
+        mock_get_client.return_value.post.side_effect = [
+            _response_with_status(503),
+            _response_with_status(200),
+        ]
+        result = client._call_rpc("EXPECTED", [])
+
+    assert result == [1]
+    assert mock_get_client.return_value.post.call_count == 2
+    sleep.assert_called_once()
+
+
+def test_connect_retry_is_not_disabled_by_rate_limit_policy(monkeypatch):
+    monkeypatch.setenv("NOTEBOOKLM_RATE_LIMIT_MAX_RETRIES", "0")
+    client = _client()
+    ok = [[["wrb.fr", "EXPECTED", "[1]", None, None, None, "generic"]]]
+
+    with (
+        patch.object(client, "_get_client") as mock_get_client,
+        patch.object(client, "_parse_response", return_value=ok),
+        patch("time.sleep"),
+    ):
+        mock_get_client.return_value.post.side_effect = [
+            httpx.ConnectTimeout("connect timed out"),
+            _response_with_status(200),
+        ]
+        result = client._call_rpc("EXPECTED", [])
+
+    assert result == [1]
+    assert mock_get_client.return_value.post.call_count == 2
+
+
+def test_cdp_resource_exhausted_surfaces_immediately_when_limit_is_zero(monkeypatch):
+    monkeypatch.setenv("NOTEBOOKLM_RATE_LIMIT_MAX_RETRIES", "0")
+    client = _client()
+    exhausted = [[["wrb.fr", "EXPECTED", None, None, None, [8], "generic"]]]
+
+    with (
+        patch.object(client, "_prepare_cdp_transport"),
+        patch.object(client, "_build_request_body", return_value="body"),
+        patch.object(client, "_build_url", return_value="https://example.test/rpc"),
+        patch.object(client, "_post_form_via_cdp", return_value="raw") as post,
+        patch.object(client, "_parse_response", return_value=exhausted),
+        patch("time.sleep") as sleep,
+        pytest.raises(ResourceExhaustedError),
+    ):
+        client._call_rpc_via_cdp("EXPECTED", [])
+
+    assert post.call_count == 1
+    sleep.assert_not_called()


### PR DESCRIPTION
﻿## Summary

Add `NOTEBOOKLM_RATE_LIMIT_MAX_RETRIES` so callers that own queueing or backoff can choose how many automatic rate-limit retries the client performs.

## Behavior

- unset or empty: preserve the existing `DEFAULT_MAX_RETRIES` behavior
- `0`: surface HTTP 429 and RPC `RESOURCE_EXHAUSTED` immediately
- positive integer: retry rate limits up to that ceiling
- invalid or negative values: fall back to the existing default

The setting applies only to rate limits. HTTP 5xx recovery, connection retries, and authentication recovery retain their existing behavior. Direct HTTP and CDP transports use the same policy.

## Motivation

External orchestrators often need to own retry timing globally. Without a rate-limit-specific ceiling, the client and the outer queue can both back off, increasing latency and making scheduling nondeterministic.

## Compatibility

Default behavior is unchanged and no dependencies are added.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- focused RPC/retry suite — 16 passed
- full upstream-first integration stack on Windows — 1,318 passed, 39 skipped

Rate-limit branches were exercised with deterministic HTTP/RPC responses, including separation from 5xx and connection retry paths. A real account was not intentionally driven into a quota failure.
