### PR TITLE
feat(mcp): report conservative runtime capabilities

### DIFF
--- a/src/notebooklm_tools/mcp/tools/server.py
+++ b/src/notebooklm_tools/mcp/tools/server.py
@@ -62,9 +62,56 @@ def _check_auth_status() -> str:
         return "error"
 
 
+def _runtime_capabilities(
+    registered_tools: set[str] | None = None,
+    disabled_tools: set[str] | None = None,
+) -> dict[str, Any]:
+    """Describe built-in MCP capability visibility without probing provider features.
+
+    This is intentionally a runtime/tool-surface report. It does not infer
+    account entitlements, quota, secure-computer access, or undocumented
+    provider capabilities from plan labels.
+    """
+    from notebooklm_tools.mcp import tool_groups
+    from notebooklm_tools.mcp.tools._utils import _tool_registry
+
+    registered = (
+        {name for name, _ in _tool_registry} if registered_tools is None else set(registered_tools)
+    )
+    disabled = tool_groups._resolve_disabled() if disabled_tools is None else set(disabled_tools)
+    visible = registered - disabled
+
+    groups: dict[str, dict[str, Any]] = {}
+    grouped_tools: set[str] = set()
+    for group_name, configured_tools in sorted(tool_groups.TOOL_GROUPS.items()):
+        grouped_tools |= configured_tools
+        visible_tools = configured_tools & visible
+        hidden_tools = configured_tools & registered & disabled
+        missing_tools = configured_tools - registered
+        available = bool(configured_tools) and configured_tools <= visible
+        groups[group_name] = {
+            "available": available,
+            "partially_available": bool(visible_tools) and not available,
+            "visible_tools": sorted(visible_tools),
+            "hidden_tools": sorted(hidden_tools),
+            "missing_tools": sorted(missing_tools),
+        }
+
+    return {
+        "schema_version": 1,
+        "scope": "built_in_mcp_runtime",
+        "source": "registered_tool_visibility",
+        "registered_tool_count": len(registered),
+        "visible_tool_count": len(visible),
+        "hidden_tool_count": len(registered - visible),
+        "groups": groups,
+        "ungrouped_tools": sorted(registered - grouped_tools),
+    }
+
+
 @logged_tool()
 def server_info() -> dict[str, Any]:
-    """Get server version, check for updates, and report auth status.
+    """Get version, auth status, and conservative MCP capability visibility.
 
     AI assistants: If update_available is True, inform the user that a new
     version is available and suggest updating with the provided command.
@@ -97,6 +144,8 @@ def server_info() -> dict[str, Any]:
         - update_available: True if a newer version is available
         - auth_status: configured | stale | unverified | not_configured | error
         - update_command: Command to run to update
+        - mcp_capabilities: Built-in tool groups visible in this server process
+        - provider_capabilities: Explicitly unprobed provider/account capabilities
     """
     latest = _get_latest_pypi_version()
     update_available = False
@@ -112,4 +161,12 @@ def server_info() -> dict[str, Any]:
         "auth_status": _check_auth_status(),
         "update_command": "uv tool upgrade notebooklm-mcp-cli",
         "pip_update_command": "pip install --upgrade notebooklm-mcp-cli",
+        "mcp_capabilities": _runtime_capabilities(),
+        "provider_capabilities": {
+            "status": "not_probed",
+            "reason": (
+                "server_info reports MCP runtime visibility only; account plan labels "
+                "are not treated as provider capability evidence."
+            ),
+        },
     }

--- a/tests/test_mcp_server_capabilities.py
+++ b/tests/test_mcp_server_capabilities.py
@@ -1,0 +1,86 @@
+"""Tests for conservative server capability reporting."""
+
+from unittest.mock import patch
+
+from notebooklm_tools.mcp.tools.server import _runtime_capabilities, server_info
+
+
+def test_runtime_capabilities_report_complete_and_partial_groups():
+    registered = {
+        "notebook_list",
+        "notebook_get",
+        "notebook_describe",
+        "notebook_query",
+        "notebook_query_start",
+        "notebook_query_status",
+        "extension_tool",
+    }
+    disabled = {"notebook_get", "notebook_query_status"}
+
+    result = _runtime_capabilities(registered, disabled)
+
+    notebooks = result["groups"]["notebooks_read"]
+    assert notebooks["available"] is False
+    assert notebooks["partially_available"] is True
+    assert notebooks["visible_tools"] == ["notebook_describe", "notebook_list"]
+    assert notebooks["hidden_tools"] == ["notebook_get"]
+    assert notebooks["missing_tools"] == []
+
+    chat = result["groups"]["chat"]
+    assert chat["available"] is False
+    assert chat["partially_available"] is True
+    assert "notebook_query_status" in chat["hidden_tools"]
+
+    assert result["registered_tool_count"] == 7
+    assert result["visible_tool_count"] == 5
+    assert result["hidden_tool_count"] == 2
+    assert result["ungrouped_tools"] == ["extension_tool"]
+
+
+def test_empty_group_is_not_reported_as_available():
+    result = _runtime_capabilities({"server_info"}, set())
+
+    assert result["groups"]["server"]["available"] is True
+    assert result["groups"]["research"]["available"] is False
+    assert result["groups"]["research"]["partially_available"] is False
+    assert result["groups"]["research"]["missing_tools"] == [
+        "research_import",
+        "research_start",
+        "research_status",
+    ]
+
+
+def test_group_with_only_one_registered_tool_is_partial_not_available():
+    result = _runtime_capabilities({"notebook_list"}, set())
+
+    group = result["groups"]["notebooks_read"]
+    assert group["available"] is False
+    assert group["partially_available"] is True
+    assert group["visible_tools"] == ["notebook_list"]
+    assert group["missing_tools"] == ["notebook_describe", "notebook_get"]
+
+
+def test_server_info_marks_provider_capabilities_unprobed():
+    with (
+        patch(
+            "notebooklm_tools.mcp.tools.server._get_latest_pypi_version",
+            return_value=None,
+        ),
+        patch(
+            "notebooklm_tools.mcp.tools.server._check_auth_status",
+            return_value="configured",
+        ),
+        patch(
+            "notebooklm_tools.mcp.tools.server._runtime_capabilities",
+            return_value={"schema_version": 1, "scope": "built_in_mcp_runtime"},
+        ),
+    ):
+        result = server_info()
+
+    assert result["status"] == "success"
+    assert result["mcp_capabilities"] == {
+        "schema_version": 1,
+        "scope": "built_in_mcp_runtime",
+    }
+    assert result["provider_capabilities"]["status"] == "not_probed"
+    assert "plan labels" in result["provider_capabilities"]["reason"]


### PR DESCRIPTION
﻿## Summary

Extend `server_info` with conservative capability information derived from the built-in MCP tool registry and current visibility configuration.

The response adds:

- `mcp_capabilities`: registered and visible built-in tool counts, group availability, hidden tools, missing tools, and ungrouped tools
- `provider_capabilities`: an explicit `not_probed` result

## Motivation

MCP clients need a stable way to determine which built-in operations this process can expose, particularly when tool groups are disabled. They should not infer provider/account capabilities from subscription labels or from the existence of unrelated tools.

## Safety and compatibility

- all existing `server_info` fields are retained
- capability reporting is read-only
- group availability is true only when every configured tool in the group is registered and visible
- provider-side features, quotas, plans, and secure-computer access are explicitly not inferred
- optional external/plugin tools are not claimed as built-in capabilities
- no new dependencies

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- focused capability suite — 4 passed
- manual `server_info` smoke: 43 registered, 43 visible, no ungrouped built-ins, provider status `not_probed`
- full upstream-first integration stack on Windows — 1,318 passed, 39 skipped
