### PR TITLE
fix(config): tolerate missing OS home directory

### DIFF
--- a/src/notebooklm_tools/utils/config.py
+++ b/src/notebooklm_tools/utils/config.py
@@ -20,6 +20,26 @@ from pydantic import BaseModel, Field
 STORAGE_DIR_NAME = ".notebooklm-mcp-cli"
 
 
+def get_home_dir() -> Path:
+    """Resolve a writable home anchor without failing at module import.
+
+    Service and hermetic runtimes can intentionally omit HOME/USERPROFILE. The
+    CLI still needs deterministic local state in that case, but importing the
+    package must not crash before an explicit NOTEBOOKLM_MCP_CLI_PATH override
+    can be honored.
+    """
+    try:
+        return Path.home()
+    except RuntimeError:
+        for name in ("USERPROFILE", "HOME"):
+            value = str(os.environ.get(name) or "").strip()
+            if value:
+                return Path(value)
+        if configured := str(os.environ.get("NOTEBOOKLM_MCP_CLI_PATH") or "").strip():
+            return Path(configured).parent
+        return Path.cwd() / ".notebooklm-home"
+
+
 def safe_mkdir(
     path: Path, *, parents: bool = False, exist_ok: bool = True, mode: int = 0o777
 ) -> None:
@@ -101,7 +121,7 @@ def get_storage_dir() -> Path:
     if env_path := os.environ.get("NOTEBOOKLM_MCP_CLI_PATH"):
         storage_dir = Path(env_path)
     else:
-        storage_dir = Path.home() / STORAGE_DIR_NAME
+        storage_dir = get_home_dir() / STORAGE_DIR_NAME
 
     safe_mkdir(storage_dir, mode=0o700)
     return storage_dir
@@ -176,14 +196,14 @@ def get_snap_chrome_profile_dir(
     if snap_common is None:
         # Auto-detect snap common directory
         for snap_name in ("chromium", "google-chrome"):
-            candidate = Path.home() / "snap" / snap_name / "common"
+            candidate = get_home_dir() / "snap" / snap_name / "common"
             if candidate.exists():
                 snap_common = candidate
                 break
 
     if snap_common is None:
         # Fallback: use chromium common dir (create if needed)
-        snap_common = Path.home() / "snap" / "chromium" / "common"
+        snap_common = get_home_dir() / "snap" / "chromium" / "common"
         safe_mkdir(snap_common, parents=True)
 
     chrome_dir = snap_common / "notebooklm-mcp-cli" / "chrome-profiles" / profile_name
@@ -214,13 +234,13 @@ def get_auth_cache_file() -> Path:
 
 # Old locations for Chrome profiles (checked for migration)
 OLD_CHROME_PROFILES = [
-    Path.home() / ".notebooklm-mcp" / "chrome-profile",  # Old MCP (pre-0.2.13)
-    Path.home() / ".nlm" / "chrome-profile",  # Old CLI
+    get_home_dir() / ".notebooklm-mcp" / "chrome-profile",  # Old MCP (pre-0.2.13)
+    get_home_dir() / ".nlm" / "chrome-profile",  # Old CLI
 ]
 
 # Old locations for auth.json (checked for migration)
 OLD_AUTH_LOCATIONS = [
-    Path.home() / ".notebooklm-mcp" / "auth.json",  # Old MCP (pre-0.2.13)
+    get_home_dir() / ".notebooklm-mcp" / "auth.json",  # Old MCP (pre-0.2.13)
 ]
 
 # Old locations for aliases

--- a/tests/test_config_home_dir.py
+++ b/tests/test_config_home_dir.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
 
 from notebooklm_tools.utils import config
@@ -37,3 +38,19 @@ def test_get_home_dir_has_deterministic_cwd_fallback(monkeypatch, tmp_path: Path
     monkeypatch.chdir(tmp_path)
 
     assert config.get_home_dir() == tmp_path / ".notebooklm-home"
+
+
+def test_config_module_reload_survives_missing_os_home(monkeypatch, tmp_path: Path) -> None:
+    with monkeypatch.context() as scoped:
+        scoped.setattr(Path, "home", _raise_missing_home)
+        scoped.setenv("USERPROFILE", str(tmp_path))
+        scoped.delenv("HOME", raising=False)
+        scoped.delenv("NOTEBOOKLM_MCP_CLI_PATH", raising=False)
+
+        reloaded = importlib.reload(config)
+
+        assert reloaded.OLD_CHROME_PROFILES[0].is_relative_to(tmp_path)
+        assert reloaded.OLD_AUTH_LOCATIONS[0].is_relative_to(tmp_path)
+
+    # Restore module-level migration constants for later tests in this process.
+    importlib.reload(config)

--- a/tests/test_config_home_dir.py
+++ b/tests/test_config_home_dir.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from notebooklm_tools.utils import config
+
+
+def _raise_missing_home() -> Path:
+    raise RuntimeError("Could not determine home directory.")
+
+
+def test_get_home_dir_falls_back_to_userprofile(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(Path, "home", _raise_missing_home)
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.delenv("HOME", raising=False)
+
+    assert config.get_home_dir() == tmp_path
+
+
+def test_get_home_dir_uses_explicit_storage_parent_without_os_home(
+    monkeypatch, tmp_path: Path
+) -> None:
+    storage = tmp_path / "state" / ".notebooklm-mcp-cli"
+    monkeypatch.setattr(Path, "home", _raise_missing_home)
+    monkeypatch.delenv("USERPROFILE", raising=False)
+    monkeypatch.delenv("HOME", raising=False)
+    monkeypatch.setenv("NOTEBOOKLM_MCP_CLI_PATH", str(storage))
+
+    assert config.get_home_dir() == storage.parent
+
+
+def test_get_home_dir_has_deterministic_cwd_fallback(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(Path, "home", _raise_missing_home)
+    monkeypatch.delenv("USERPROFILE", raising=False)
+    monkeypatch.delenv("HOME", raising=False)
+    monkeypatch.delenv("NOTEBOOKLM_MCP_CLI_PATH", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    assert config.get_home_dir() == tmp_path / ".notebooklm-home"


### PR DESCRIPTION
## Summary

Prevent NotebookLM CLI imports from crashing when `pathlib.Path.home()` cannot resolve an OS home directory, as can happen in stripped service, MCP, scheduled-task, and hermetic Windows runtimes.

## Reproduction

In a service-like environment with no usable HOME/USERPROFILE, importing `notebooklm_tools.utils.config` can fail at module import time from migration constants such as `OLD_CHROME_PROFILES`:

```text
RuntimeError: Could not determine home directory.
```

That happens before an explicit `NOTEBOOKLM_MCP_CLI_PATH` can be honored.

## Change

Adds a small `get_home_dir()` resolver that:

1. uses `Path.home()` when available;
2. falls back to `USERPROFILE` / `HOME`;
3. uses the parent of explicit `NOTEBOOKLM_MCP_CLI_PATH` when configured;
4. finally uses a deterministic `.notebooklm-home` directory under the current working directory.

All internal home-path construction in config/migration setup uses that resolver instead of raw import-time `Path.home()` calls.

## Validation

```text
4 passed
```

Tests cover USERPROFILE fallback, explicit storage fallback, deterministic cwd fallback, and an actual module reload with `Path.home()` forced to raise so the import-time migration constants are re-evaluated under the failing condition.

The failure was also independently reproduced while testing a separate CDP branch against upstream v0.9.8: test collection crashed in `config.py` until a normal home was injected into that process.
