### PR TITLE
fix(auth): allow CDP grace after Windows launcher exit

### DIFF
--- a/src/notebooklm_tools/utils/cdp.py
+++ b/src/notebooklm_tools/utils/cdp.py
@@ -1438,6 +1438,8 @@ def extract_cookies_via_cdp(
             if debugger_url:
                 break
             if _chrome_process is not None and _chrome_process.poll() is not None:
+                if platform.system() != "Windows":
+                    break
                 if launcher_exit_poll is None:
                     launcher_exit_poll = attempt
                 elif attempt - launcher_exit_poll >= launcher_exit_grace_polls:

--- a/src/notebooklm_tools/utils/cdp.py
+++ b/src/notebooklm_tools/utils/cdp.py
@@ -1425,15 +1425,23 @@ def extract_cookies_via_cdp(
 
         # Snap Chromium and some Chromium forks can take noticeably longer
         # to expose CDP than the browser window itself takes to appear.
-        # If the child already exited (Chrome handoff to an existing profile
-        # lock), stop polling the unbound port immediately (#277).
+        # On Windows, the launcher process can also exit after re-parenting to
+        # the real browser process before the DevTools listener is ready. Give
+        # an exited launcher a short bounded grace period before classifying it
+        # as the profile-lock handoff described in #277. CDP readiness remains
+        # authoritative when it appears during that grace window.
         debugger_url = None
+        launcher_exit_poll: int | None = None
+        launcher_exit_grace_polls = 5
         for attempt in range(30):
             debugger_url = get_debugger_url(port, tries=1, timeout=1)
             if debugger_url:
                 break
             if _chrome_process is not None and _chrome_process.poll() is not None:
-                break
+                if launcher_exit_poll is None:
+                    launcher_exit_poll = attempt
+                elif attempt - launcher_exit_poll >= launcher_exit_grace_polls:
+                    break
             if attempt < 29:
                 time.sleep(1)
 

--- a/tests/test_cdp_url_check.py
+++ b/tests/test_cdp_url_check.py
@@ -172,6 +172,7 @@ def test_extract_cookies_via_cdp_accepts_debugger_after_launcher_reparents(monke
         return True
 
     debugger_results = iter([None, None, "ws://127.0.0.1:9223/devtools/browser/test"])
+    monkeypatch.setattr(cdp.platform, "system", lambda: "Windows")
     monkeypatch.setattr(cdp, "_kill_stale_nlm_browsers", lambda: None)
     monkeypatch.setattr(cdp, "find_existing_nlm_chrome", lambda **_: (None, None))
     monkeypatch.setattr(cdp, "get_chrome_path", lambda: "/fake/chrome")
@@ -191,6 +192,49 @@ def test_extract_cookies_via_cdp_accepts_debugger_after_launcher_reparents(monke
         result = cdp.extract_cookies_via_cdp(profile_name="default")
         assert result["cookies"] == {"SID": "x"}
         assert result["reused_existing"] is False
+    finally:
+        cdp._chrome_process = None
+        cdp._chrome_port = None
+
+
+def test_extract_cookies_via_cdp_keeps_immediate_launcher_exit_failure_off_windows(
+    monkeypatch,
+) -> None:
+    """The Windows re-parent grace must not weaken #277 behavior on other platforms."""
+
+    class FakeExitedProcess:
+        stderr = None
+
+        def poll(self) -> int:
+            return 0
+
+    calls = 0
+
+    def fake_launch_chrome(port, profile_name="default") -> bool:
+        cdp._chrome_process = FakeExitedProcess()
+        cdp._chrome_port = port
+        return True
+
+    def fake_get_debugger_url(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        return None
+
+    monkeypatch.setattr(cdp.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(cdp, "_kill_stale_nlm_browsers", lambda: None)
+    monkeypatch.setattr(cdp, "find_existing_nlm_chrome", lambda **_: (None, None))
+    monkeypatch.setattr(cdp, "get_chrome_path", lambda: "/fake/chrome")
+    monkeypatch.setattr(cdp, "is_profile_locked", lambda *_a, **_k: False)
+    monkeypatch.setattr(cdp, "_get_profile_dir_for_launch", lambda *_a, **_k: "/fake/profile")
+    monkeypatch.setattr(cdp, "find_available_port", lambda: 9223)
+    monkeypatch.setattr(cdp, "launch_chrome", fake_launch_chrome)
+    monkeypatch.setattr(cdp, "get_debugger_url", fake_get_debugger_url)
+    monkeypatch.setattr(cdp.time, "sleep", lambda *_: None)
+
+    try:
+        with pytest.raises(cdp.AuthenticationError):
+            cdp.extract_cookies_via_cdp(profile_name="default")
+        assert calls == 1
     finally:
         cdp._chrome_process = None
         cdp._chrome_port = None

--- a/tests/test_cdp_url_check.py
+++ b/tests/test_cdp_url_check.py
@@ -143,6 +143,7 @@ def test_extract_cookies_via_cdp_reports_chrome_handoff(monkeypatch) -> None:
     monkeypatch.setattr(cdp, "find_available_port", lambda: 9222)
     monkeypatch.setattr(cdp, "launch_chrome", fake_launch_chrome)
     monkeypatch.setattr(cdp, "get_debugger_url", lambda *_a, **_k: None)
+    monkeypatch.setattr(cdp.time, "sleep", lambda *_: None)
 
     try:
         with pytest.raises(AuthenticationError) as exc_info:
@@ -151,6 +152,45 @@ def test_extract_cookies_via_cdp_reports_chrome_handoff(monkeypatch) -> None:
         error = exc_info.value
         assert "already running" in str(error.message).lower()
         assert "quit chrome" in str(error.hint).lower()
+    finally:
+        cdp._chrome_process = None
+        cdp._chrome_port = None
+
+
+def test_extract_cookies_via_cdp_accepts_debugger_after_launcher_reparents(monkeypatch) -> None:
+    """An exited Windows launcher is not a failure if its CDP port binds shortly after."""
+
+    class FakeExitedProcess:
+        stderr = None
+
+        def poll(self) -> int:
+            return 0
+
+    def fake_launch_chrome(port, profile_name="default") -> bool:
+        cdp._chrome_process = FakeExitedProcess()
+        cdp._chrome_port = port
+        return True
+
+    debugger_results = iter([None, None, "ws://127.0.0.1:9223/devtools/browser/test"])
+    monkeypatch.setattr(cdp, "_kill_stale_nlm_browsers", lambda: None)
+    monkeypatch.setattr(cdp, "find_existing_nlm_chrome", lambda **_: (None, None))
+    monkeypatch.setattr(cdp, "get_chrome_path", lambda: "/fake/chrome")
+    monkeypatch.setattr(cdp, "is_profile_locked", lambda *_a, **_k: False)
+    monkeypatch.setattr(cdp, "_get_profile_dir_for_launch", lambda *_a, **_k: "/fake/profile")
+    monkeypatch.setattr(cdp, "find_available_port", lambda: 9223)
+    monkeypatch.setattr(cdp, "launch_chrome", fake_launch_chrome)
+    monkeypatch.setattr(cdp, "get_debugger_url", lambda *_a, **_k: next(debugger_results))
+    monkeypatch.setattr(cdp.time, "sleep", lambda *_: None)
+    monkeypatch.setattr(
+        cdp,
+        "extract_cookies_from_page",
+        lambda *_a, **_k: {"cookies": {"SID": "x"}, "csrf_token": "token"},
+    )
+
+    try:
+        result = cdp.extract_cookies_via_cdp(profile_name="default")
+        assert result["cookies"] == {"SID": "x"}
+        assert result["reused_existing"] is False
     finally:
         cdp._chrome_process = None
         cdp._chrome_port = None


### PR DESCRIPTION
## Summary

Refine the Windows Chrome handoff handling added for #277 so an exited launcher process is not treated as authoritative proof that CDP startup failed on Windows.

## Problem

On Windows, `chrome.exe` can exit after re-parenting startup to the actual browser process *before* the requested DevTools listener binds. Upstream v0.9.8 currently stops polling immediately when the launcher child exits. That correctly detects the #277 profile-lock handoff case, but it can also reject a valid Windows startup that exposes CDP a moment later.

## Change

On Windows only, when the launcher exits, keep polling the requested CDP port for a short bounded grace window (5 polls / ~5 seconds). If CDP becomes reachable during that window, CDP readiness wins and login proceeds. If it never binds, the existing #277 `Chrome is already running` diagnostic still fires.

On non-Windows platforms, launcher exit retains the existing immediate failure behavior from #277.

## Validation

```text
27 passed
```

Regression coverage includes:

- Windows exited launcher + no CDP -> existing actionable handoff error;
- Windows exited launcher + delayed CDP -> authentication proceeds;
- non-Windows exited launcher -> immediate #277 failure behavior remains unchanged.

This branch intentionally does not include the separate home-directory fallback PR so the fixes remain independently reviewable.
