### PR TITLE
feat(auth): add profile-owned external CDP cleanup

### DIFF
--- a/src/notebooklm_tools/utils/cdp.py
+++ b/src/notebooklm_tools/utils/cdp.py
@@ -1022,7 +1022,22 @@ def close_profile_owned_cdp_browser(cdp_url: str, profile_name: str) -> bool:
                 time.sleep(0.1)
 
         if _pid_is_alive(pid):
+            # Browser.close may fail or race with browser shutdown. Re-prove
+            # listener/profile ownership immediately before any forceful kill
+            # so a recycled PID or foreign replacement can never be targeted.
+            current_pid = _listener_pid(port)
+            if current_pid != pid or not _mapped_chrome_owns_profile(
+                current_pid, profile_name, port
+            ):
+                return False
+
             _kill_process(pid)
+            for _ in range(20):
+                if not _pid_is_alive(pid):
+                    break
+                time.sleep(0.1)
+            if _pid_is_alive(pid):
+                return False
 
         _clear_port_map(port)
         return True

--- a/src/notebooklm_tools/utils/cdp.py
+++ b/src/notebooklm_tools/utils/cdp.py
@@ -83,6 +83,7 @@ __all__ = [
     "get_supported_browsers",
     "extract_cookies_via_cdp",
     "extract_cookies_via_existing_cdp",
+    "close_profile_owned_cdp_browser",
     "run_headless_auth",
     "has_chrome_profile",
     "terminate_chrome",
@@ -975,6 +976,60 @@ def terminate_chrome(process: subprocess.Popen | None = None, port: int | None =
         _chrome_process = None
         _chrome_port = None
     return True
+
+
+def close_profile_owned_cdp_browser(cdp_url: str, profile_name: str) -> bool:
+    """Close an external-CDP browser only when it owns ``profile_name``.
+
+    External CDP is normally caller-owned and should be left running. Recovery
+    integrations may instead launch the CLI's dedicated per-profile browser and
+    then attach through external CDP. This helper lets those integrations
+    release the managed profile lock without broad browser termination.
+
+    Ownership is proved fail-closed from a loopback listener PID, exact CDP
+    port, and exact ``--user-data-dir`` for the requested NotebookLM profile.
+    Foreign browsers, remote CDP endpoints, and unverifiable processes are
+    never closed.
+    """
+    try:
+        http_url = normalize_cdp_http_url(cdp_url)
+        parsed = urlparse(http_url)
+        if parsed.scheme != "http" or parsed.hostname not in {"127.0.0.1", "localhost", "::1"}:
+            return False
+        if parsed.port is None:
+            return False
+
+        port = parsed.port
+        pid = _listener_pid(port)
+        if pid is None or not _mapped_chrome_owns_profile(pid, profile_name, port):
+            return False
+
+        version_info = _fetch_cdp_version(port, timeout=1)
+        debugger_url = (
+            _normalize_ws_url(version_info.get("webSocketDebuggerUrl")) if version_info else None
+        )
+
+        if debugger_url:
+            # Browser.close commonly tears down the transport before the
+            # response is observed. Verify exit below before a forceful
+            # fallback.
+            with contextlib.suppress(Exception):
+                execute_cdp_command(debugger_url, "Browser.close")
+
+            for _ in range(20):
+                if not _pid_is_alive(pid):
+                    break
+                time.sleep(0.1)
+
+        if _pid_is_alive(pid):
+            _kill_process(pid)
+
+        _clear_port_map(port)
+        return True
+    except Exception:
+        # Failure to prove ownership must never widen into a generic browser
+        # kill.
+        return False
 
 
 def _fetch_cdp_version(port: int, *, timeout: int = 5) -> dict | None:

--- a/tests/test_cdp_profile_owned_close.py
+++ b/tests/test_cdp_profile_owned_close.py
@@ -1,0 +1,47 @@
+from notebooklm_tools.utils import cdp
+
+
+def test_close_profile_owned_cdp_browser_closes_exact_managed_profile(monkeypatch):
+    closed: list[tuple[str, str]] = []
+    cleared: list[int] = []
+    alive = iter([True, False, False])
+
+    monkeypatch.setattr(cdp, "_listener_pid", lambda _port: 4242)
+    monkeypatch.setattr(cdp, "_mapped_chrome_owns_profile", lambda _pid, _profile, _port: True)
+    monkeypatch.setattr(
+        cdp,
+        "_fetch_cdp_version",
+        lambda _port, timeout=1: {
+            "webSocketDebuggerUrl": "ws://127.0.0.1:9227/devtools/browser/managed"
+        },
+    )
+    monkeypatch.setattr(cdp, "execute_cdp_command", lambda url, command: closed.append((url, command)))
+    monkeypatch.setattr(cdp, "_pid_is_alive", lambda _pid: next(alive))
+    monkeypatch.setattr(cdp, "_clear_port_map", cleared.append)
+    monkeypatch.setattr(cdp.time, "sleep", lambda _seconds: None)
+
+    assert cdp.close_profile_owned_cdp_browser("http://127.0.0.1:9227", "harmonywave13") is True
+    assert closed == [("ws://127.0.0.1:9227/devtools/browser/managed", "Browser.close")]
+    assert cleared == [9227]
+
+
+def test_close_profile_owned_cdp_browser_leaves_foreign_browser_running(monkeypatch):
+    monkeypatch.setattr(cdp, "_listener_pid", lambda _port: 4242)
+    monkeypatch.setattr(cdp, "_mapped_chrome_owns_profile", lambda _pid, _profile, _port: False)
+    monkeypatch.setattr(
+        cdp,
+        "execute_cdp_command",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("foreign browser must not close")),
+    )
+
+    assert cdp.close_profile_owned_cdp_browser("http://127.0.0.1:9227", "harmonywave13") is False
+
+
+def test_close_profile_owned_cdp_browser_rejects_remote_endpoint(monkeypatch):
+    monkeypatch.setattr(
+        cdp,
+        "_listener_pid",
+        lambda _port: (_ for _ in ()).throw(AssertionError("remote endpoint must not be inspected")),
+    )
+
+    assert cdp.close_profile_owned_cdp_browser("http://192.0.2.10:9227", "harmonywave13") is False

--- a/tests/test_cdp_profile_owned_close.py
+++ b/tests/test_cdp_profile_owned_close.py
@@ -15,7 +15,9 @@ def test_close_profile_owned_cdp_browser_closes_exact_managed_profile(monkeypatc
             "webSocketDebuggerUrl": "ws://127.0.0.1:9227/devtools/browser/managed"
         },
     )
-    monkeypatch.setattr(cdp, "execute_cdp_command", lambda url, command: closed.append((url, command)))
+    monkeypatch.setattr(
+        cdp, "execute_cdp_command", lambda url, command: closed.append((url, command))
+    )
     monkeypatch.setattr(cdp, "_pid_is_alive", lambda _pid: next(alive))
     monkeypatch.setattr(cdp, "_clear_port_map", cleared.append)
     monkeypatch.setattr(cdp.time, "sleep", lambda _seconds: None)
@@ -31,7 +33,9 @@ def test_close_profile_owned_cdp_browser_leaves_foreign_browser_running(monkeypa
     monkeypatch.setattr(
         cdp,
         "execute_cdp_command",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("foreign browser must not close")),
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("foreign browser must not close")
+        ),
     )
 
     assert cdp.close_profile_owned_cdp_browser("http://127.0.0.1:9227", "harmonywave13") is False
@@ -41,7 +45,9 @@ def test_close_profile_owned_cdp_browser_rejects_remote_endpoint(monkeypatch):
     monkeypatch.setattr(
         cdp,
         "_listener_pid",
-        lambda _port: (_ for _ in ()).throw(AssertionError("remote endpoint must not be inspected")),
+        lambda _port: (_ for _ in ()).throw(
+            AssertionError("remote endpoint must not be inspected")
+        ),
     )
 
     assert cdp.close_profile_owned_cdp_browser("http://192.0.2.10:9227", "harmonywave13") is False

--- a/tests/test_cdp_profile_owned_close.py
+++ b/tests/test_cdp_profile_owned_close.py
@@ -51,3 +51,41 @@ def test_close_profile_owned_cdp_browser_rejects_remote_endpoint(monkeypatch):
     )
 
     assert cdp.close_profile_owned_cdp_browser("http://192.0.2.10:9227", "harmonywave13") is False
+
+
+def test_close_profile_owned_cdp_browser_rechecks_ownership_before_force_kill(monkeypatch):
+    ownership_checks = iter([True, False])
+    killed: list[int] = []
+    cleared: list[int] = []
+
+    monkeypatch.setattr(cdp, "_listener_pid", lambda _port: 4242)
+    monkeypatch.setattr(
+        cdp,
+        "_mapped_chrome_owns_profile",
+        lambda _pid, _profile, _port: next(ownership_checks),
+    )
+    monkeypatch.setattr(cdp, "_fetch_cdp_version", lambda _port, timeout=1: None)
+    monkeypatch.setattr(cdp, "_pid_is_alive", lambda _pid: True)
+    monkeypatch.setattr(cdp, "_kill_process", killed.append)
+    monkeypatch.setattr(cdp, "_clear_port_map", cleared.append)
+
+    assert cdp.close_profile_owned_cdp_browser("http://127.0.0.1:9227", "harmonywave13") is False
+    assert killed == []
+    assert cleared == []
+
+
+def test_close_profile_owned_cdp_browser_reports_failed_force_kill(monkeypatch):
+    killed: list[int] = []
+    cleared: list[int] = []
+
+    monkeypatch.setattr(cdp, "_listener_pid", lambda _port: 4242)
+    monkeypatch.setattr(cdp, "_mapped_chrome_owns_profile", lambda *_args: True)
+    monkeypatch.setattr(cdp, "_fetch_cdp_version", lambda _port, timeout=1: None)
+    monkeypatch.setattr(cdp, "_pid_is_alive", lambda _pid: True)
+    monkeypatch.setattr(cdp, "_kill_process", killed.append)
+    monkeypatch.setattr(cdp, "_clear_port_map", cleared.append)
+    monkeypatch.setattr(cdp.time, "sleep", lambda _seconds: None)
+
+    assert cdp.close_profile_owned_cdp_browser("http://127.0.0.1:9227", "harmonywave13") is False
+    assert killed == [4242]
+    assert cleared == []


### PR DESCRIPTION
## Summary

Add a fail-closed helper for automation that attaches to a NotebookLM-managed browser through external CDP and needs to release that exact managed profile afterward.

## Motivation

`extract_cookies_via_existing_cdp()` correctly treats browser lifecycle as caller-owned. Higher-level integrations may launch the CLI's dedicated per-profile browser themselves, attach through external CDP, and then need a safe way to close only that browser after credentials are validated.

This is a generic opt-in CDP lifecycle primitive; it contains no Session Broker policy or orchestration.

## Change

Adds `close_profile_owned_cdp_browser(cdp_url, profile_name)` to `utils.cdp` and exports it for integrations.

The helper fails closed unless ownership can be proven from:

- a loopback CDP endpoint;
- the listener PID for that exact port;
- the existing `_mapped_chrome_owns_profile()` check for the exact `--remote-debugging-port` and `--user-data-dir`.

It first attempts `Browser.close`. Before any forceful PID kill it re-reads the listener and re-proves profile/port ownership, protecting against shutdown races and PID reuse. A forced kill is then verified before the port-map entry is cleared. If ownership changes or termination cannot be confirmed, the helper returns `False` and preserves state rather than broadening cleanup.

Ordinary external-CDP login semantics are unchanged; callers must explicitly opt into this helper.

## Validation

```text
30 passed
```

Tests cover:

- exact managed-profile closure;
- refusal to close a foreign browser;
- refusal to inspect/close a remote CDP endpoint;
- ownership changing before force-kill;
- force-kill failure without falsely clearing the port map.
