### PR TITLE
release: v0.9.9 maintenance release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.9] - 2026-08-11
+
+### Fixed
+- **Windows CDP handoff safety (#289)** — Late CDP listeners are accepted only after their process is verified to own the requested profile, with a bounded grace period for legitimate browser handoff. Thanks to **@insane66613** for the PR.
+- **Home resolution in constrained environments (#288)** — Browser discovery, Snap profile routing, and migration paths now share resilient fallbacks when `Path.home()` is unavailable, honoring the explicit storage location first. Thanks to **@insane66613** for the PR.
+- **WSL non-ASCII Windows paths (#287)** — PowerShell and `wslpath` output now use explicit UTF-8 handling so Windows user/profile paths are preserved across the WSL boundary. Reported by **@etadward**.
+- **Async query result retention (#286)** — Completed and failed query results remain readable until their normal TTL instead of disappearing after the first status request. Reported by **@Joystick01**.
+- **Profile-owned CDP cleanup (#290)** — Externally managed local browsers are closed only after ownership checks, and replacement listeners never have their port mappings cleared. Thanks to **@insane66613** for the PR.
+
 ## [0.9.8] - 2026-08-08
 
 ### Fixed

--- a/desktop-extension/manifest.json
+++ b/desktop-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "gemini-notebook-mcp",
   "display_name": "Gemini Notebook MCP Server",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "Connect Claude to Gemini Notebook. Create podcasts, research topics, generate quizzes, flashcards, mind maps, and more from your notebooks.",
   "long_description": "This extension connects Claude Desktop to Gemini Notebook via the Model Context Protocol. It provides 43 tools for managing notebooks, sources, labels, chat sessions, research, sharing, and generated content.\n\n**Prerequisites:**\n1. Install the package: `pip install notebooklm-mcp-cli` or `uv tool install notebooklm-mcp-cli`\n2. Authenticate: Run `nlm login` to set up your Google account\n\n**Features:**\n- Create and manage notebooks\n- Add sources (URLs, YouTube, Google Drive, text, files)\n- Generate podcasts (Audio Overview)\n- Create quizzes, flashcards, mind maps, reports\n- Research topics with web or Drive search",
   "author": {

--- a/docs/releases/v0.9.9.md
+++ b/docs/releases/v0.9.9.md
@@ -1,0 +1,21 @@
+# v0.9.9 Maintenance Release
+
+This maintenance release hardens cross-platform browser lifecycle handling and asynchronous query polling.
+
+## Fixed
+
+- Windows CDP handoff now validates that a late listener belongs to the requested profile before accepting it.
+- Home-directory resolution now survives constrained environments and honors the configured storage path for browser and Snap discovery.
+- WSL browser startup preserves non-ASCII Windows temporary-profile paths through explicit UTF-8 subprocess handling.
+- Completed and failed asynchronous query results remain available until their configured TTL.
+- Externally managed local CDP browsers are closed only when profile ownership is verified, with replacement listeners protected from accidental cleanup.
+
+## Thanks
+
+- Thanks to **@insane66613** for PRs #288, #289, and #290.
+- Thanks to **@etadward** and **@Joystick01** for the detailed issue reports behind the WSL and async-query fixes.
+
+## Verification
+
+- Focused regression tests pass for CDP ownership, home resolution, WSL encoding, Snap routing, and query retention.
+- Full non-live suite passes: 1,402 passed, 38 skipped, and 1 live upload test deselected. Ruff lint, formatting, and package build pass.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "notebooklm-mcp-cli"
-version = "0.9.8"
+version = "0.9.9"
 description = "Unified CLI and MCP server for Google NotebookLM"
 readme = "README.md"
 license = "MIT"

--- a/src/notebooklm_tools/__init__.py
+++ b/src/notebooklm_tools/__init__.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import notebooklm_tools.utils.env_sanitize as _env_sanitize  # noqa: F401
 
-__version__ = "0.9.8"
+__version__ = "0.9.9"
 
 __all__ = ["NotebookLMClient", "__version__"]
 

--- a/src/notebooklm_tools/data/AGENTS_SECTION.md
+++ b/src/notebooklm_tools/data/AGENTS_SECTION.md
@@ -1,5 +1,5 @@
 <!-- nlm-skill-start -->
-<!-- nlm-version: 0.9.8 -->
+<!-- nlm-version: 0.9.9 -->
 ## NLM - Gemini Notebook (formerly Google NotebookLM) CLI Expert
 
 **Triggers:** "nlm", "notebooklm", "Gemini Notebook", "podcast", "audio overview", "research"

--- a/src/notebooklm_tools/data/SKILL.md
+++ b/src/notebooklm_tools/data/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nlm-skill
-version: "0.9.8"
+version: "0.9.9"
 description: "Expert guide for the Gemini Notebook (formerly Google NotebookLM) CLI (`nlm`) and MCP server - interfaces for Gemini Notebook. Use this skill when users want to interact with Gemini Notebook programmatically, including: creating/managing notebooks, adding sources (URLs, YouTube, text, Google Drive), generating content (podcasts, reports, quizzes, flashcards, mind maps, slides, infographics, videos, data tables), conducting research, chatting with sources, or automating Gemini Notebook workflows. Triggers on mentions of \"nlm\", \"notebooklm\", \"Gemini Notebook\", \"podcast generation\", \"audio overview\", \"refactor document\", \"critique draft\", or any Gemini Notebook-related automation task."
 ---
 

--- a/src/notebooklm_tools/services/chat.py
+++ b/src/notebooklm_tools/services/chat.py
@@ -468,6 +468,7 @@ def query_status(query_id: str) -> QueryStatusResult:
         ValidationError: If query_id is not found
     """
     with _pending_lock:
+        _cleanup_expired_queries()
         entry = _pending_queries.get(query_id)
         if entry is None:
             raise ValidationError(
@@ -486,9 +487,5 @@ def query_status(query_id: str) -> QueryStatusResult:
             "error": entry["error"],
             "error_details": entry["error_details"],
         }
-
-        # Clean up completed/errored entries after reading
-        if entry["status"] in ("completed", "error"):
-            del _pending_queries[query_id]
 
         return result

--- a/src/notebooklm_tools/utils/cdp.py
+++ b/src/notebooklm_tools/utils/cdp.py
@@ -75,7 +75,7 @@ def _normalize_ws_url(url: str | None) -> str | None:
 
 
 from notebooklm_tools.core.exceptions import AuthenticationError  # noqa: E402
-from notebooklm_tools.utils.config import get_base_url  # noqa: E402
+from notebooklm_tools.utils.config import get_base_url, get_home_dir  # noqa: E402
 
 __all__ = [
     "get_chrome_path",
@@ -311,7 +311,7 @@ def find_available_port(starting_from: int = 9222, max_attempts: int = 10) -> in
 
 # macOS: absolute .app bundle paths, /Applications first then ~/Applications
 def _macos_browser_candidates() -> list[tuple[str, str]]:
-    home_apps = Path.home() / "Applications"
+    home_apps = get_home_dir() / "Applications"
     entries: list[tuple[str, str]] = [
         ("Google Chrome", "Google Chrome.app/Contents/MacOS/Google Chrome"),
         ("Arc", "Arc.app/Contents/MacOS/Arc"),
@@ -346,8 +346,9 @@ _LINUX_BROWSER_CANDIDATES: list[tuple[str, str]] = [
 
 # Windows: absolute paths.  User-local installs live under %LOCALAPPDATA%.
 def _windows_browser_candidates() -> list[tuple[str, str]]:
-    local = Path.home() / "AppData" / "Local"
-    roaming = Path.home() / "AppData" / "Roaming"
+    home_dir = get_home_dir()
+    local = home_dir / "AppData" / "Local"
+    roaming = home_dir / "AppData" / "Roaming"
     pf = Path(r"C:\Program Files")
     pf86 = Path(r"C:\Program Files (x86)")
     return [
@@ -528,16 +529,16 @@ def get_snap_common_dir(browser_path: str) -> Path | None:
             if part == "snap" and index + 1 < len(parts):
                 snap_name = parts[index + 1]
                 if snap_name in ("chromium", "google-chrome", "firefox"):
-                    return Path.home() / "snap" / snap_name / "common"
+                    return get_home_dir() / "snap" / snap_name / "common"
         for part in parts:
             if part in ("chromium", "google-chrome", "firefox"):
-                return Path.home() / "snap" / part / "common"
+                return get_home_dir() / "snap" / part / "common"
     except (OSError, RuntimeError):
         pass
 
     # Fallback: try common snap names
     for snap_name in ("chromium", "google-chrome"):
-        snap_common = Path.home() / "snap" / snap_name / "common"
+        snap_common = get_home_dir() / "snap" / snap_name / "common"
         if snap_common.exists():
             return snap_common
 
@@ -710,6 +711,12 @@ def _listener_pid(port: int) -> int | None:
     except Exception:
         return None
     return None
+
+
+def _profile_owned_cdp_listener(port: int, profile_name: str) -> bool:
+    """Return whether the local CDP listener belongs to the requested profile."""
+    pid = _listener_pid(port)
+    return pid is not None and _mapped_chrome_owns_profile(pid, profile_name, port)
 
 
 def find_existing_nlm_chrome(
@@ -978,23 +985,22 @@ def terminate_chrome(process: subprocess.Popen | None = None, port: int | None =
     return True
 
 
-def close_profile_owned_cdp_browser(cdp_url: str, profile_name: str) -> bool:
-    """Close an external-CDP browser only when it owns ``profile_name``.
+def close_profile_owned_cdp_browser(cdp_url: str, profile_name: str = "default") -> bool:
+    """Close a local CDP browser only after proving profile ownership.
 
-    External CDP is normally caller-owned and should be left running. Recovery
-    integrations may instead launch the CLI's dedicated per-profile browser and
-    then attach through external CDP. This helper lets those integrations
-    release the managed profile lock without broad browser termination.
-
-    Ownership is proved fail-closed from a loopback listener PID, exact CDP
-    port, and exact ``--user-data-dir`` for the requested NotebookLM profile.
-    Foreign browsers, remote CDP endpoints, and unverifiable processes are
-    never closed.
+    This is intended for externally managed browsers. It never touches a
+    remote endpoint, and it refuses to clear the port mapping if a different
+    process replaces the managed listener while shutdown is in progress.
     """
     try:
-        http_url = normalize_cdp_http_url(cdp_url)
-        parsed = urlparse(http_url)
-        if parsed.scheme != "http" or parsed.hostname not in {"127.0.0.1", "localhost", "::1"}:
+        cdp_http_url = normalize_cdp_http_url(cdp_url)
+        parsed = urlparse(cdp_http_url)
+        host = (parsed.hostname or "").casefold().rstrip(".")
+        if parsed.scheme not in {"http", "https"} or host not in {
+            "127.0.0.1",
+            "localhost",
+            "::1",
+        }:
             return False
         if parsed.port is None:
             return False
@@ -1004,46 +1010,41 @@ def close_profile_owned_cdp_browser(cdp_url: str, profile_name: str) -> bool:
         if pid is None or not _mapped_chrome_owns_profile(pid, profile_name, port):
             return False
 
-        version_info = _fetch_cdp_version(port, timeout=1)
-        debugger_url = (
-            _normalize_ws_url(version_info.get("webSocketDebuggerUrl")) if version_info else None
-        )
-
+        version = _fetch_cdp_version(port, timeout=1)
+        debugger_url = _normalize_ws_url((version or {}).get("webSocketDebuggerUrl"))
         if debugger_url:
-            # Browser.close commonly tears down the transport before the
-            # response is observed. Verify exit below before a forceful
-            # fallback.
             with contextlib.suppress(Exception):
                 execute_cdp_command(debugger_url, "Browser.close")
-
             for _ in range(20):
-                if not _pid_is_alive(pid):
-                    break
                 time.sleep(0.1)
-
-        if _pid_is_alive(pid):
-            # Browser.close may fail or race with browser shutdown. Re-prove
-            # listener/profile ownership immediately before any forceful kill
-            # so a recycled PID or foreign replacement can never be targeted.
-            current_pid = _listener_pid(port)
-            if current_pid != pid or not _mapped_chrome_owns_profile(
-                current_pid, profile_name, port
-            ):
-                return False
-
-            _kill_process(pid)
-            for _ in range(20):
                 if not _pid_is_alive(pid):
-                    break
-                time.sleep(0.1)
-            if _pid_is_alive(pid):
-                return False
+                    replacement_pid = _listener_pid(port)
+                    if replacement_pid not in (None, pid):
+                        return False
+                    _clear_port_map(port)
+                    return True
 
-        _clear_port_map(port)
-        return True
+        if not _pid_is_alive(pid):
+            replacement_pid = _listener_pid(port)
+            if replacement_pid not in (None, pid):
+                return False
+            _clear_port_map(port)
+            return True
+
+        current_pid = _listener_pid(port)
+        if current_pid != pid or not _mapped_chrome_owns_profile(pid, profile_name, port):
+            return False
+
+        _kill_process(pid)
+        for _ in range(20):
+            time.sleep(0.1)
+            if not _pid_is_alive(pid):
+                if _listener_pid(port) is not None:
+                    return False
+                _clear_port_map(port)
+                return True
+        return False
     except Exception:
-        # Failure to prove ownership must never widen into a generic browser
-        # kill.
         return False
 
 
@@ -1495,25 +1496,36 @@ def extract_cookies_via_cdp(
 
         # Snap Chromium and some Chromium forks can take noticeably longer
         # to expose CDP than the browser window itself takes to appear.
-        # On Windows, the launcher process can also exit after re-parenting to
-        # the real browser process before the DevTools listener is ready. Give
-        # an exited launcher a short bounded grace period before classifying it
-        # as the profile-lock handoff described in #277. CDP readiness remains
-        # authoritative when it appears during that grace window.
+        # If the child already exited (Chrome handoff to an existing profile
+        # lock), stop polling the unbound port immediately (#277).
         debugger_url = None
-        launcher_exit_poll: int | None = None
-        launcher_exit_grace_polls = 5
+        launcher_exit_attempt: int | None = None
         for attempt in range(30):
+            launcher_exited = _chrome_process is not None and _chrome_process.poll() is not None
+            if launcher_exited and launcher_exit_attempt is None:
+                launcher_exit_attempt = attempt
+
             debugger_url = get_debugger_url(port, tries=1, timeout=1)
             if debugger_url:
+                launcher_exited = _chrome_process is not None and _chrome_process.poll() is not None
+                if launcher_exited and launcher_exit_attempt is None:
+                    launcher_exit_attempt = attempt
+                # On Windows, the launcher can exit after handing off to an
+                # existing Chrome process. Do not accept a late listener
+                # until its PID is proven to own this profile.
+                if (
+                    platform.system() != "Windows"
+                    or not launcher_exited
+                    or _profile_owned_cdp_listener(port, profile_name)
+                ):
+                    break
+                debugger_url = None
+
+            if launcher_exited and (
+                platform.system() != "Windows"
+                or (launcher_exit_attempt is not None and attempt - launcher_exit_attempt >= 5)
+            ):
                 break
-            if _chrome_process is not None and _chrome_process.poll() is not None:
-                if platform.system() != "Windows":
-                    break
-                if launcher_exit_poll is None:
-                    launcher_exit_poll = attempt
-                elif attempt - launcher_exit_poll >= launcher_exit_grace_polls:
-                    break
             if attempt < 29:
                 time.sleep(1)
 

--- a/src/notebooklm_tools/utils/config.py
+++ b/src/notebooklm_tools/utils/config.py
@@ -31,12 +31,12 @@ def get_home_dir() -> Path:
     try:
         return Path.home()
     except RuntimeError:
+        if configured := str(os.environ.get("NOTEBOOKLM_MCP_CLI_PATH") or "").strip():
+            return Path(configured).parent
         for name in ("USERPROFILE", "HOME"):
             value = str(os.environ.get(name) or "").strip()
             if value:
                 return Path(value)
-        if configured := str(os.environ.get("NOTEBOOKLM_MCP_CLI_PATH") or "").strip():
-            return Path(configured).parent
         return Path.cwd() / ".notebooklm-home"
 
 

--- a/src/notebooklm_tools/utils/wsl.py
+++ b/src/notebooklm_tools/utils/wsl.py
@@ -70,6 +70,7 @@ def _is_mirrored_networking() -> bool:
             ["wslinfo", "--networking-mode"],
             capture_output=True,
             text=True,
+            errors="replace",
             check=True,
             timeout=5,
         )
@@ -100,6 +101,7 @@ def get_windows_host_ip() -> str | None:
             ["ip", "route"],
             capture_output=True,
             text=True,
+            errors="replace",
             check=True,
         )
         for line in result.stdout.splitlines():
@@ -117,6 +119,7 @@ def get_windows_host_ip() -> str | None:
             ["grep", "nameserver", "/etc/resolv.conf"],
             capture_output=True,
             text=True,
+            errors="replace",
             check=True,
         )
         # Format: "nameserver 10.255.255.254"
@@ -152,6 +155,7 @@ def find_windows_chrome() -> str | None:
             ["which", "chrome.exe"],
             capture_output=True,
             text=True,
+            errors="replace",
         )
         if result.returncode == 0:
             windows_path = result.stdout.strip().replace("/mnt/c/", "C:\\").replace("/", "\\")
@@ -188,6 +192,7 @@ def launch_windows_chrome(
             ["pgrep", "-f", "chrome.exe"],
             capture_output=True,
             text=True,
+            errors="replace",
         )
         if result.returncode == 0 and result.stdout.strip():
             # Try taskkill to close Chrome
@@ -196,6 +201,7 @@ def launch_windows_chrome(
                     ["taskkill", "/f", "/im", "chrome.exe"],
                     capture_output=True,
                     text=True,
+                    errors="replace",
                     timeout=10,
                 )
                 time.sleep(2)  # Wait for Chrome to close
@@ -204,6 +210,7 @@ def launch_windows_chrome(
                     ["pgrep", "-f", "chrome.exe"],
                     capture_output=True,
                     text=True,
+                    errors="replace",
                 )
                 if result2.returncode == 0 and result2.stdout.strip():
                     raise RuntimeError(
@@ -240,9 +247,21 @@ def launch_windows_chrome(
 
     try:
         win_temp_base = subprocess.run(
-            ["powershell.exe", "-Command", "echo $env:TEMP"],
+            [
+                "powershell.exe",
+                "-NoProfile",
+                "-Command",
+                (
+                    "$utf8 = New-Object System.Text.UTF8Encoding($false); "
+                    "[Console]::OutputEncoding = $utf8; "
+                    "$OutputEncoding = $utf8; "
+                    "$env:TEMP"
+                ),
+            ],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="strict",
             check=True,
         ).stdout.strip()
         # Create a unique subdir name
@@ -254,6 +273,8 @@ def launch_windows_chrome(
             ["wslpath", "-u", windows_temp],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="strict",
             check=True,
         ).stdout.strip()
     except Exception:
@@ -263,6 +284,8 @@ def launch_windows_chrome(
             ["wslpath", "-w", temp_dir],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="strict",
             check=True,
         ).stdout.strip()
 
@@ -492,6 +515,7 @@ def create_firewall_rule(port: int = DEFAULT_WSL_CDP_PORT) -> tuple[bool, str]:
             [str(ps_path), "-Command", ps_cmd],
             capture_output=True,
             text=True,
+            errors="replace",
             timeout=10,
         )
 
@@ -546,6 +570,7 @@ def remove_firewall_rule(port: int = DEFAULT_WSL_CDP_PORT) -> bool:
             [str(ps_path), "-Command", ps_cmd],
             capture_output=True,
             text=True,
+            errors="replace",
             timeout=10,
         )
         return result.returncode == 0
@@ -603,6 +628,7 @@ def diagnose_wsl_connectivity(host_ip: str, port: int = DEFAULT_WSL_CDP_PORT) ->
                 [str(ps_path), "-Command", ps_cmd],
                 capture_output=True,
                 text=True,
+                errors="replace",
                 timeout=10,
             )
             results["tests"]["chrome_running"] = (
@@ -622,6 +648,7 @@ def diagnose_wsl_connectivity(host_ip: str, port: int = DEFAULT_WSL_CDP_PORT) ->
                 [str(ps_path), "-Command", ps_cmd],
                 capture_output=True,
                 text=True,
+                errors="replace",
                 timeout=10,
             )
             results["tests"]["port_binding"] = (

--- a/tests/services/test_chat.py
+++ b/tests/services/test_chat.py
@@ -6,6 +6,9 @@ import pytest
 
 from notebooklm_tools.core.conversation import QueryRejectedError
 from notebooklm_tools.services.chat import (
+    _QUERY_TTL_SECONDS,
+    _pending_lock,
+    _pending_queries,
     configure_chat,
     delete_chat_history,
     query,
@@ -354,7 +357,7 @@ class TestQueryStatus:
         with pytest.raises(ValidationError, match="not found"):
             query_status("nonexistent-id")
 
-    def test_completed_entry_cleaned_after_read(self, mock_client):
+    def test_completed_query_can_be_read_multiple_times_until_ttl(self, mock_client):
         import time as _time
 
         mock_client.query.return_value = {"answer": "ok"}
@@ -364,13 +367,26 @@ class TestQueryStatus:
 
         _time.sleep(1)
 
-        # First read should return the result
-        status = query_status(query_id)
-        assert status["status"] == "completed"
+        first_status = query_status(query_id)
+        second_status = query_status(query_id)
 
-        # Second read should fail because the entry was cleaned up
+        assert first_status["status"] == "completed"
+        assert second_status == first_status
+
+    def test_status_evicts_expired_query_before_reading(self, mock_client):
+        import time as _time
+
+        with _pending_lock:
+            _pending_queries["expired-status-id"] = {
+                "status": "completed",
+                "result": {"answer": "expired"},
+                "error": None,
+                "error_details": None,
+                "created_at": _time.monotonic() - _QUERY_TTL_SECONDS - 1,
+            }
+
         with pytest.raises(ValidationError, match="not found"):
-            query_status(query_id)
+            query_status("expired-status-id")
 
     def test_error_query_preserves_structured_error_details(self, mock_client):
         import time as _time

--- a/tests/test_cdp_profile_owned_close.py
+++ b/tests/test_cdp_profile_owned_close.py
@@ -74,6 +74,25 @@ def test_close_profile_owned_cdp_browser_rechecks_ownership_before_force_kill(mo
     assert cleared == []
 
 
+def test_close_profile_owned_cdp_browser_preserves_replacement_mapping(monkeypatch):
+    listener_pids = iter([4242, 4242, 9999])
+    alive = iter([True, True, False, False])
+    killed: list[int] = []
+    cleared: list[int] = []
+
+    monkeypatch.setattr(cdp, "_listener_pid", lambda _port: next(listener_pids))
+    monkeypatch.setattr(cdp, "_mapped_chrome_owns_profile", lambda *_args: True)
+    monkeypatch.setattr(cdp, "_fetch_cdp_version", lambda _port, timeout=1: None)
+    monkeypatch.setattr(cdp, "_pid_is_alive", lambda _pid: next(alive))
+    monkeypatch.setattr(cdp, "_kill_process", killed.append)
+    monkeypatch.setattr(cdp, "_clear_port_map", cleared.append)
+    monkeypatch.setattr(cdp.time, "sleep", lambda _seconds: None)
+
+    assert cdp.close_profile_owned_cdp_browser("http://127.0.0.1:9227", "harmonywave13") is False
+    assert killed == [4242]
+    assert cleared == []
+
+
 def test_close_profile_owned_cdp_browser_reports_failed_force_kill(monkeypatch):
     killed: list[int] = []
     cleared: list[int] = []

--- a/tests/test_cdp_url_check.py
+++ b/tests/test_cdp_url_check.py
@@ -181,6 +181,8 @@ def test_extract_cookies_via_cdp_accepts_debugger_after_launcher_reparents(monke
     monkeypatch.setattr(cdp, "find_available_port", lambda: 9223)
     monkeypatch.setattr(cdp, "launch_chrome", fake_launch_chrome)
     monkeypatch.setattr(cdp, "get_debugger_url", lambda *_a, **_k: next(debugger_results))
+    monkeypatch.setattr(cdp, "_listener_pid", lambda _port: 4242)
+    monkeypatch.setattr(cdp, "_mapped_chrome_owns_profile", lambda *_args: True)
     monkeypatch.setattr(cdp.time, "sleep", lambda *_: None)
     monkeypatch.setattr(
         cdp,
@@ -192,6 +194,53 @@ def test_extract_cookies_via_cdp_accepts_debugger_after_launcher_reparents(monke
         result = cdp.extract_cookies_via_cdp(profile_name="default")
         assert result["cookies"] == {"SID": "x"}
         assert result["reused_existing"] is False
+    finally:
+        cdp._chrome_process = None
+        cdp._chrome_port = None
+
+
+def test_extract_cookies_via_cdp_rejects_foreign_cdp_during_windows_grace(monkeypatch):
+    """A late listener from another profile must not be accepted after handoff."""
+
+    class FakeExitedProcess:
+        stderr = None
+
+        def poll(self) -> int:
+            return 0
+
+    def fake_launch_chrome(port, profile_name="default") -> bool:
+        cdp._chrome_process = FakeExitedProcess()
+        cdp._chrome_port = port
+        return True
+
+    debugger_results = iter(
+        ["ws://127.0.0.1:9223/devtools/browser/foreign", None, None, None, None, None]
+    )
+    monkeypatch.setattr(cdp.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(cdp, "_kill_stale_nlm_browsers", lambda: None)
+    monkeypatch.setattr(cdp, "find_existing_nlm_chrome", lambda **_: (None, None))
+    monkeypatch.setattr(cdp, "get_chrome_path", lambda: "/fake/chrome")
+    monkeypatch.setattr(cdp, "is_profile_locked", lambda *_a, **_k: False)
+    monkeypatch.setattr(cdp, "_get_profile_dir_for_launch", lambda *_a, **_k: "/fake/profile")
+    monkeypatch.setattr(cdp, "find_available_port", lambda: 9223)
+    monkeypatch.setattr(cdp, "launch_chrome", fake_launch_chrome)
+    monkeypatch.setattr(cdp, "get_debugger_url", lambda *_a, **_k: next(debugger_results))
+    monkeypatch.setattr(cdp, "_listener_pid", lambda _port: 4242)
+    monkeypatch.setattr(cdp, "_mapped_chrome_owns_profile", lambda *_args: False)
+    monkeypatch.setattr(cdp.time, "sleep", lambda *_: None)
+    monkeypatch.setattr(
+        cdp,
+        "extract_cookies_from_page",
+        lambda *_a, **_k: (_ for _ in ()).throw(
+            AssertionError("foreign CDP listener must not be used")
+        ),
+    )
+
+    try:
+        from notebooklm_tools.core.exceptions import AuthenticationError
+
+        with pytest.raises(AuthenticationError):
+            cdp.extract_cookies_via_cdp(profile_name="default")
     finally:
         cdp._chrome_process = None
         cdp._chrome_port = None

--- a/tests/test_config_home_dir.py
+++ b/tests/test_config_home_dir.py
@@ -14,16 +14,15 @@ def test_get_home_dir_falls_back_to_userprofile(monkeypatch, tmp_path: Path) -> 
     monkeypatch.setattr(Path, "home", _raise_missing_home)
     monkeypatch.setenv("USERPROFILE", str(tmp_path))
     monkeypatch.delenv("HOME", raising=False)
+    monkeypatch.delenv("NOTEBOOKLM_MCP_CLI_PATH", raising=False)
 
     assert config.get_home_dir() == tmp_path
 
 
-def test_get_home_dir_uses_explicit_storage_parent_without_os_home(
-    monkeypatch, tmp_path: Path
-) -> None:
+def test_get_home_dir_prefers_explicit_storage_parent(monkeypatch, tmp_path: Path) -> None:
     storage = tmp_path / "state" / ".notebooklm-mcp-cli"
     monkeypatch.setattr(Path, "home", _raise_missing_home)
-    monkeypatch.delenv("USERPROFILE", raising=False)
+    monkeypatch.setenv("USERPROFILE", str(tmp_path / "stale-home"))
     monkeypatch.delenv("HOME", raising=False)
     monkeypatch.setenv("NOTEBOOKLM_MCP_CLI_PATH", str(storage))
 
@@ -52,5 +51,18 @@ def test_config_module_reload_survives_missing_os_home(monkeypatch, tmp_path: Pa
         assert reloaded.OLD_CHROME_PROFILES[0].is_relative_to(tmp_path)
         assert reloaded.OLD_AUTH_LOCATIONS[0].is_relative_to(tmp_path)
 
-    # Restore module-level migration constants for later tests in this process.
     importlib.reload(config)
+
+
+def test_windows_browser_discovery_survives_missing_os_home(monkeypatch, tmp_path: Path) -> None:
+    from notebooklm_tools.utils import cdp
+
+    storage = tmp_path / "state" / ".notebooklm-mcp-cli"
+    monkeypatch.setattr(Path, "home", _raise_missing_home)
+    monkeypatch.delenv("USERPROFILE", raising=False)
+    monkeypatch.delenv("HOME", raising=False)
+    monkeypatch.setenv("NOTEBOOKLM_MCP_CLI_PATH", str(storage))
+
+    candidates = cdp._windows_browser_candidates()
+
+    assert any(str(storage.parent / "AppData" / "Local") in path for _, path in candidates)

--- a/tests/test_wsl.py
+++ b/tests/test_wsl.py
@@ -20,6 +20,7 @@ def test_get_windows_host_ip_uses_loopback_in_mirrored_mode(monkeypatch):
         ["wslinfo", "--networking-mode"],
         capture_output=True,
         text=True,
+        errors="replace",
         check=True,
         timeout=5,
     )
@@ -41,10 +42,17 @@ def test_get_windows_host_ip_uses_gateway_in_nat_mode(monkeypatch):
             ["wslinfo", "--networking-mode"],
             capture_output=True,
             text=True,
+            errors="replace",
             check=True,
             timeout=5,
         ),
-        call(["ip", "route"], capture_output=True, text=True, check=True),
+        call(
+            ["ip", "route"],
+            capture_output=True,
+            text=True,
+            errors="replace",
+            check=True,
+        ),
     ]
 
 
@@ -59,3 +67,48 @@ def test_get_windows_host_ip_uses_gateway_when_wslinfo_is_unavailable(monkeypatc
     monkeypatch.setattr(wsl.subprocess, "run", run)
 
     assert wsl.get_windows_host_ip() == "172.20.112.1"
+
+
+def test_launch_windows_chrome_preserves_non_ascii_windows_temp_path(monkeypatch):
+    monkeypatch.setattr(wsl, "is_wsl", lambda: True)
+    monkeypatch.setattr(
+        wsl,
+        "find_windows_chrome",
+        lambda: r"C:\Program Files\Google\Chrome\Application\chrome.exe",
+    )
+
+    calls = []
+    powershell_call = None
+
+    def run(args, **kwargs):
+        nonlocal powershell_call
+        calls.append((args, kwargs))
+        if args[0] == "powershell.exe":
+            powershell_call = (args, kwargs)
+            return _result(args, "C:\\Users\\王小明\\AppData\\Local\\Temp\\")
+        if args[0] == "wslpath" and args[1] == "-u":
+            return _result(args, "/tmp/nlm-chrome")
+        return _result(args, "")
+
+    class FakeProcess:
+        pid = 4242
+
+    popen_args = []
+    monkeypatch.setattr(wsl.subprocess, "run", run)
+    monkeypatch.setattr(
+        wsl.subprocess, "Popen", lambda args, **_: popen_args.append(args) or FakeProcess()
+    )
+
+    process = wsl.launch_windows_chrome()
+
+    assert process.pid == 4242
+    assert powershell_call is not None
+    powershell_args, powershell_kwargs = powershell_call
+    assert powershell_kwargs["encoding"] == "utf-8"
+    assert powershell_kwargs["errors"] == "strict"
+    assert "OutputEncoding" in powershell_args[-1]
+    assert any(
+        arg.startswith("--user-data-dir=C:\\Users\\王小明\\AppData\\Local\\Temp")
+        and "nlm-chrome-" in arg
+        for arg in popen_args[0]
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -762,7 +762,7 @@ wheels = [
 
 [[package]]
 name = "notebooklm-mcp-cli"
-version = "0.9.8"
+version = "0.9.9"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

- Prepare the v0.9.9 maintenance release.
- Retain contributor PRs #288, #289, and #290 as normal merge commits on main.
- Fix issues #286 and #287 with query-result retention and WSL non-ASCII path handling.
- Add profile-safe Windows CDP handoff and cleanup hardening.
- Credit contributors and issue reporters in the changelog and release notes.

## Verification

- Full non-live suite: 1,402 passed, 38 skipped, 1 live upload test deselected.
- Ruff lint and format checks pass.
- `uv build` produces the 0.9.9 sdist and wheel.
- Windows focused suite and package validation already passed on Jabella@192.168.68.11.