### PR TITLE
fix: record rebranded session host on manual cookie import (issue #292)

### DIFF
--- a/src/notebooklm_tools/core/auth.py
+++ b/src/notebooklm_tools/core/auth.py
@@ -609,7 +609,61 @@ class AuthManager:
                 hint="Make sure the file contains cookies from a NotebookLM session.",
             )
 
-        return self.save_profile(cookies)
+        # Detect the host this session actually lands on. Google rolls the
+        # "Gemini Notebook" rebrand out per-account, redirecting signed-in
+        # accounts from notebooklm.google.com to notebook.google.com (and the
+        # cloud variant). The default base URL stays notebooklm.google.com, so
+        # without recording the real host, manual-imported credentials keep
+        # hitting the old domain and get bounced to accounts.google.com even
+        # when the cookies are perfectly valid. See issue #292.
+        base_host = self._detect_session_base_host(cookies)
+
+        return self.save_profile(cookies, base_host=base_host)
+
+    @staticmethod
+    def _detect_session_base_host(
+        cookies: dict[str, str] | list[dict[str, Any]],
+    ) -> str | None:
+        """Find which Gemini Notebook host the cookies actually authenticate on.
+
+        Google rolls the "Gemini Notebook" rebrand out per-account, redirecting
+        signed-in accounts from notebooklm.google.com to notebook.google.com (and
+        the cloud variant). The default base URL stays notebooklm.google.com, so
+        without recording the real host, manual-imported credentials keep hitting
+        the old domain and get bounced to accounts.google.com even when the
+        cookies are valid (see issue #292).
+
+        A naive homepage fetch is rejected by Google's replay protection even for
+        valid cookies, so instead we try a lightweight list_notebooks() call
+        against each rebrand candidate and return the first host that succeeds.
+        """
+        from notebooklm_tools.utils.config import _ALLOWED_BASE_HOSTS
+
+        # Always include the default host first; only probe alternatives when we
+        # know they exist. Keep the order deterministic and cheap.
+        candidates = ["notebooklm.google.com"]
+        for h in sorted(_ALLOWED_BASE_HOSTS):
+            if h != "notebooklm.google.com" and h not in candidates:
+                candidates.append(h)
+
+        flat = _flatten_cookie_input(cookies)
+        for host in candidates:
+            try:
+                from notebooklm_tools.core.client import NotebookLMClient
+
+                with NotebookLMClient(
+                    cookies=flat,
+                    base_host=host,
+                    profile_name=None,
+                ) as client:
+                    client.list_notebooks()
+                if host != "notebooklm.google.com":
+                    logger.info(f"Detected rebranded session host: {host}")
+                    return host
+                return None
+            except Exception as e:
+                logger.debug(f"Session host probe failed for {host}: {e}")
+        return None
 
 
 def get_auth_manager(profile: str | None = None) -> AuthManager:

--- a/tests/core/test_login_with_file_base_host.py
+++ b/tests/core/test_login_with_file_base_host.py
@@ -5,9 +5,7 @@ from notebooklm_tools.core.auth import AuthManager
 
 def _write_cookies(tmp_path: Path) -> Path:
     cookie_file = tmp_path / "cookies.txt"
-    cookie_file.write_text(
-        "SID=sid; HSID=h; SSID=s; APISID=a; SAPISID=sp", encoding="utf-8"
-    )
+    cookie_file.write_text("SID=sid; HSID=h; SSID=s; APISID=a; SAPISID=sp", encoding="utf-8")
     return cookie_file
 
 
@@ -35,9 +33,7 @@ def test_login_with_file_records_rebranded_base_host(monkeypatch, tmp_path):
                 return []
             raise RuntimeError("auth rejected on legacy host")
 
-    monkeypatch.setattr(
-        "notebooklm_tools.core.client.NotebookLMClient", FakeClient
-    )
+    monkeypatch.setattr("notebooklm_tools.core.client.NotebookLMClient", FakeClient)
 
     manager = AuthManager("default")
     manager.profile_dir.mkdir(parents=True, exist_ok=True)
@@ -66,9 +62,7 @@ def test_login_with_file_keeps_default_host_when_no_rebrand(monkeypatch, tmp_pat
                 return []
             raise RuntimeError("unexpected host probe")
 
-    monkeypatch.setattr(
-        "notebooklm_tools.core.client.NotebookLMClient", FakeClient
-    )
+    monkeypatch.setattr("notebooklm_tools.core.client.NotebookLMClient", FakeClient)
 
     manager = AuthManager("default")
     manager.profile_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/core/test_login_with_file_base_host.py
+++ b/tests/core/test_login_with_file_base_host.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+
+from notebooklm_tools.core.auth import AuthManager
+
+
+def _write_cookies(tmp_path: Path) -> Path:
+    cookie_file = tmp_path / "cookies.txt"
+    cookie_file.write_text(
+        "SID=sid; HSID=h; SSID=s; APISID=a; SAPISID=sp", encoding="utf-8"
+    )
+    return cookie_file
+
+
+def test_login_with_file_records_rebranded_base_host(monkeypatch, tmp_path):
+    """Manual cookie import must record the real session host.
+
+    Google rolls the Gemini Notebook rebrand out per-account, redirecting
+    notebooklm.google.com -> notebook.google.com. Otherwise valid cookies keep
+    bouncing off the old host. See issue #292.
+    """
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            self.base_host = kwargs.get("base_host")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def list_notebooks(self):
+            # Simulate the rebrand: only the rebranded host accepts the cookies.
+            if self.base_host == "notebook.google.com":
+                return []
+            raise RuntimeError("auth rejected on legacy host")
+
+    monkeypatch.setattr(
+        "notebooklm_tools.core.client.NotebookLMClient", FakeClient
+    )
+
+    manager = AuthManager("default")
+    manager.profile_dir.mkdir(parents=True, exist_ok=True)
+    cookie_file = _write_cookies(tmp_path)
+
+    manager.login_with_file(cookie_file)
+
+    metadata = (manager.profile_dir / "metadata.json").read_text(encoding="utf-8")
+    assert '"base_host": "notebook.google.com"' in metadata
+
+
+def test_login_with_file_keeps_default_host_when_no_rebrand(monkeypatch, tmp_path):
+    class FakeClient:
+        def __init__(self, **kwargs):
+            self.base_host = kwargs.get("base_host")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def list_notebooks(self):
+            # Default host works: no rebrand for this account.
+            if self.base_host == "notebooklm.google.com":
+                return []
+            raise RuntimeError("unexpected host probe")
+
+    monkeypatch.setattr(
+        "notebooklm_tools.core.client.NotebookLMClient", FakeClient
+    )
+
+    manager = AuthManager("default")
+    manager.profile_dir.mkdir(parents=True, exist_ok=True)
+    cookie_file = _write_cookies(tmp_path)
+
+    manager.login_with_file(cookie_file)
+
+    metadata = (manager.profile_dir / "metadata.json").read_text(encoding="utf-8")
+    assert '"base_host": null' in metadata


### PR DESCRIPTION
## Summary

Fixes #292. Manual `nlm login --manual` imported valid cookies but never recorded which host the session actually signed in on (`base_host`). The default base URL stays `notebooklm.google.com`, which Google now irreversibly 301-redirects to `notebook.google.com` for rebranded accounts. Imported cookies kept hitting the legacy host and were bounced to `accounts.google.com` even when the cookies were perfectly valid — surfacing as the misleading "Authentication expired" error.

## Root cause

- `AuthManager.login_with_file()` only ran `validate_notebooklm_cookies()` (cookie-name shape) then `save_profile(cookies)` — leaving `base_host` `null`.
- `get_base_url()` defaults to `notebooklm.google.com` unless `profile_host` (from `base_host`) or `NOTEBOOKLM_BASE_URL` is set.
- The browser/CDP login path already records `base_host` (#269), but the manual-import path bypassed it.

## Fix

`login_with_file()` now probes each rebrand candidate host (`notebook.google.com`, cloud variants) with a lightweight `list_notebooks()` call and persists the first host that succeeds as `base_host`. This mirrors the detection the browser path already does, so manual imports route to the correct host without needing `NOTEBOOKLM_BASE_URL`.

## Test plan

- Added `tests/core/test_login_with_file_base_host.py` (2 unit tests: rebrand detected + no-rebrand keeps `null`).
- Verified end-to-end on a rebranded headless account: `nlm login --manual` now writes `base_host: notebook.google.com` and `nlm list notebooks` succeeds with no env override.
- `ruff` and `mypy` clean for the added code (pre-existing generic-dict errors in the file are untouched); existing auth/login test suites pass (40 passed).

## Notes

The host probe deliberately uses `list_notebooks()` rather than a homepage fetch: Google rejects the homepage fetch via replay protection even for valid cookies, but the batchexecute `list_notebooks` call succeeds — the same behavior the auth doctor already relies on.