### PR TITLE
feat(auth): add Firefox profile fallback

### DIFF
--- a/src/notebooklm_tools/cli/main.py
+++ b/src/notebooklm_tools/cli/main.py
@@ -234,7 +234,7 @@ def login_callback(
     clear: bool = typer.Option(
         False,
         "--clear",
-        help="Delete the localized Chrome profile data before logging in, to switch Google accounts",
+        help="Delete the localized browser profile data before logging in, to switch Google accounts",
     ),
     wsl: bool = typer.Option(
         False,
@@ -245,7 +245,7 @@ def login_callback(
     """
     Authenticate with NotebookLM.
 
-    Default: Uses Chrome DevTools Protocol to extract cookies automatically.
+    Default: Uses the configured managed browser to extract cookies automatically.
     Use --manual to import cookies from a file.
     Use --check to validate existing credentials.
     Use --provider openclaw --cdp-url <url> to read auth from an existing
@@ -257,6 +257,7 @@ def login_callback(
     from notebooklm_tools.core.errors import ClientAuthenticationError
     from notebooklm_tools.core.exceptions import AccountMismatchError, NLMError
     from notebooklm_tools.services.auth import AuthManager
+    from notebooklm_tools.utils.auth_browser import extract_cookies_via_browser, select_auth_backend
     from notebooklm_tools.utils.config import get_config
 
     # If a subcommand is invoked, don't run login logic
@@ -327,11 +328,12 @@ def login_callback(
         from notebooklm_tools.utils.cdp import (
             extract_cookies_via_cdp,
             extract_cookies_via_existing_cdp,
-            get_browser_display_name,
             terminate_chrome,
         )
 
         launched_local_chrome = False
+        managed_browser_backend = ""
+        managed_browser_name = ""
 
         # Default cdp_url for the builtin provider — used to detect when the
         # user explicitly passes their own --cdp-url value.
@@ -469,55 +471,66 @@ def login_callback(
                 login_timeout=300,
             )
         else:
-            # Default: builtin CDP mode - managed Chrome profile
-            from notebooklm_tools.utils.cdp import get_browser_display_name, get_chrome_path
+            backend = select_auth_backend()
+            if backend is None:
+                extract_cookies_via_browser(profile_name=profile, clear_profile=clear)
+                raise AssertionError("Authentication backend unexpectedly returned no result")
 
-            # Detect browser early so messages show the correct name
-            get_chrome_path()
-            browser_name = get_browser_display_name()
-            console.print(f"[bold]Launching {browser_name} for authentication...[/bold]")
-            console.print("[dim]Using Chrome DevTools Protocol[/dim]\n")
+            managed_browser_backend = backend["backend"]
+            managed_browser_name = backend["browser"]
+            if managed_browser_backend == "firefox_profile":
+                console.print("[bold]Launching Firefox for authentication...[/bold]")
+                console.print("[dim]Using an isolated Firefox profile[/dim]\n")
+                result, _ = extract_cookies_via_browser(
+                    profile_name=profile,
+                    clear_profile=clear,
+                    preferred="firefox",
+                )
+            else:
+                from notebooklm_tools.utils.cdp import get_chrome_path
+                from notebooklm_tools.utils.config import (
+                    check_migration_sources,
+                    get_storage_dir,
+                    run_migration,
+                )
 
-            from notebooklm_tools.utils.config import (
-                check_migration_sources,
-                get_storage_dir,
-                run_migration,
-            )
+                get_chrome_path()
+                console.print(
+                    f"[bold]Launching {managed_browser_name} for authentication...[/bold]"
+                )
+                console.print("[dim]Using Chrome DevTools Protocol[/dim]\n")
 
-            # Check if we need to migrate from legacy packages
-            # IMPORTANT: Don't use get_chrome_profile_dir() here as it creates the directory,
-            # which would prevent migration from running
-            chrome_profile = get_storage_dir() / "chrome-profile"
-            profile_exists = chrome_profile.exists() and (
-                (chrome_profile / "Default").exists() or (chrome_profile / "Local State").exists()
-            )
+                chrome_profile = get_storage_dir() / "chrome-profile"
+                profile_exists = chrome_profile.exists() and (
+                    (chrome_profile / "Default").exists()
+                    or (chrome_profile / "Local State").exists()
+                )
+                if not profile_exists and not clear:
+                    sources = check_migration_sources()
+                    if sources["chrome_profiles"]:
+                        console.print(
+                            "[yellow]Found Chrome profile from legacy installation![/yellow]"
+                        )
+                        for src in sources["chrome_profiles"]:
+                            console.print(f"  [dim]{src}[/dim]")
+                        console.print("[dim]Migrating to new location...[/dim]")
+                        for action in run_migration(dry_run=False):
+                            console.print(f"  [green]✓[/green] {action}")
+                        console.print()
 
-            if not profile_exists and not clear:
-                sources = check_migration_sources()
-                if sources["chrome_profiles"]:
-                    console.print("[yellow]Found Chrome profile from legacy installation![/yellow]")
-                    for src in sources["chrome_profiles"]:
-                        console.print(f"  [dim]{src}[/dim]")
-                    console.print("[dim]Migrating to new location...[/dim]")
-
-                    actions = run_migration(dry_run=False)
-                    for action in actions:
-                        console.print(f"  [green]✓[/green] {action}")
-                    console.print()
-
-            console.print(f"Starting {browser_name}...")
-            result = extract_cookies_via_cdp(
-                auto_launch=True,
-                wait_for_login=True,
-                login_timeout=300,
-                profile_name=profile,
-                clear_profile=clear,
-            )
-            launched_local_chrome = True
+                console.print(f"Starting {managed_browser_name}...")
+                result = extract_cookies_via_cdp(
+                    auto_launch=True,
+                    wait_for_login=True,
+                    login_timeout=300,
+                    profile_name=profile,
+                    clear_profile=clear,
+                )
+                launched_local_chrome = True
 
         if result.get("reused_existing"):
             console.print(
-                f"[yellow]Warning:[/yellow] Connected to an already-running {get_browser_display_name()} instance. "
+                f"[yellow]Warning:[/yellow] Connected to an already-running {managed_browser_name} instance. "
                 "Profile isolation may not apply — verify the account is correct."
             )
 
@@ -537,11 +550,12 @@ def login_callback(
             force=force,
             build_label=build_label,
             base_host=base_host,
+            browser_backend=managed_browser_backend or None,
         )
 
         # Close builtin auth Chrome to release profile lock (enables headless auth later)
         if launched_local_chrome:
-            console.print(f"[dim]Closing {get_browser_display_name()}...[/dim]")
+            console.print(f"[dim]Closing {managed_browser_name}...[/dim]")
             terminate_chrome()
 
         console.print("\n[green]✓[/green] Successfully authenticated!")
@@ -564,23 +578,30 @@ def login_callback(
                 f"[bold]{e.stored_email}[/bold])."
             )
             console.print(
-                f"[dim]Clearing stale browser session and relaunching {get_browser_display_name()}...[/dim]\n"
+                f"[dim]Clearing stale browser session and relaunching {managed_browser_name}...[/dim]\n"
             )
 
-            # Close the mismatch Chrome
-            with contextlib.suppress(Exception):
-                terminate_chrome()
+            if launched_local_chrome:
+                with contextlib.suppress(Exception):
+                    terminate_chrome()
 
             # Retry with cleared Chrome profile
             try:
-                result = extract_cookies_via_cdp(
-                    auto_launch=True,
-                    wait_for_login=True,
-                    login_timeout=300,
-                    profile_name=profile,
-                    clear_profile=True,
-                )
-                launched_local_chrome = True
+                if managed_browser_backend == "firefox_profile":
+                    result, _ = extract_cookies_via_browser(
+                        profile_name=profile,
+                        clear_profile=True,
+                        preferred="firefox",
+                    )
+                else:
+                    result = extract_cookies_via_cdp(
+                        auto_launch=True,
+                        wait_for_login=True,
+                        login_timeout=300,
+                        profile_name=profile,
+                        clear_profile=True,
+                    )
+                    launched_local_chrome = True
 
                 cookies = result["cookies"]
                 csrf_token = result.get("csrf_token", "")
@@ -597,10 +618,11 @@ def login_callback(
                     force=True,  # Allow overwrite on retry
                     build_label=build_label,
                     base_host=base_host,
+                    browser_backend=managed_browser_backend or None,
                 )
 
                 if launched_local_chrome:
-                    console.print(f"[dim]Closing {get_browser_display_name()}...[/dim]")
+                    console.print(f"[dim]Closing {managed_browser_name}...[/dim]")
                     terminate_chrome()
 
                 console.print("\n[green]✓[/green] Successfully authenticated!")

--- a/src/notebooklm_tools/core/auth.py
+++ b/src/notebooklm_tools/core/auth.py
@@ -466,7 +466,7 @@ class AuthManager:
         """
         from datetime import datetime
 
-        from notebooklm_tools.core.exceptions import AccountMismatchError
+        from notebooklm_tools.core.exceptions import AccountMismatchError, AuthenticationError
 
         # Guard: check for account mismatch before overwriting
         if not force and email and self.metadata_file.exists():
@@ -481,6 +481,12 @@ class AuthManager:
                     )
             except (json.JSONDecodeError, KeyError):
                 pass  # Corrupted metadata, allow overwrite
+
+        if not force and browser_backend == "firefox_profile" and self.profile_exists():
+            raise AuthenticationError(
+                message="Firefox login cannot verify the Google account for an existing profile",
+                hint="Confirm the account, then run 'nlm login --force' to replace the saved credentials.",
+            )
 
         from notebooklm_tools.utils.config import safe_mkdir
 

--- a/src/notebooklm_tools/core/auth.py
+++ b/src/notebooklm_tools/core/auth.py
@@ -456,6 +456,7 @@ class AuthManager:
         force: bool = False,
         build_label: str | None = None,
         base_host: str | None = None,
+        browser_backend: str | None = None,
     ) -> Profile:
         """Save credentials to the current profile.
 
@@ -498,13 +499,15 @@ class AuthManager:
         with f:
             json.dump(cookies, f, indent=2, ensure_ascii=False)
 
-        # Preserve existing email if new email is None
-        if email is None and self.metadata_file.exists():
-            try:
-                existing_metadata = json.loads(self.metadata_file.read_text(encoding="utf-8"))
-                email = existing_metadata.get("email")
-            except Exception:
-                pass
+        preserved_metadata: dict[str, Any] = {}
+        if self.metadata_file.exists():
+            with contextlib.suppress(Exception):
+                preserved_metadata = json.loads(self.metadata_file.read_text(encoding="utf-8"))
+
+        if email is None:
+            email = preserved_metadata.get("email")
+        if browser_backend is None:
+            browser_backend = preserved_metadata.get("browser_backend")
 
         # Save metadata with restrictive permissions from creation
         metadata = {
@@ -513,6 +516,7 @@ class AuthManager:
             "email": email,
             "build_label": build_label,
             "base_host": base_host,
+            "browser_backend": browser_backend,
             "last_validated": datetime.now().isoformat(),
         }
         fd = os.open(str(self.metadata_file), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)

--- a/src/notebooklm_tools/utils/auth_browser.py
+++ b/src/notebooklm_tools/utils/auth_browser.py
@@ -7,6 +7,7 @@ from notebooklm_tools.core.exceptions import AuthenticationError
 from notebooklm_tools.utils.config import get_config, get_profile_dir
 
 CHROMIUM_BROWSER_KEYS = {"auto", "chrome", "arc", "brave", "edge", "chromium", "vivaldi", "opera"}
+FIREFOX_BROWSER_KEY = "firefox"
 
 
 def _normalize_browser(preferred: str | None = None) -> str:
@@ -19,18 +20,32 @@ def get_supported_auth_browsers() -> list[str]:
     """Return user-facing browser names for auth."""
     from notebooklm_tools.utils.cdp import get_supported_browsers as get_supported_chromium_browsers
 
-    return get_supported_chromium_browsers()
+    browsers = get_supported_chromium_browsers()
+    from notebooklm_tools.utils.firefox import get_firefox_path
+
+    if get_firefox_path():
+        browsers.append("Firefox")
+    return browsers
 
 
 def select_auth_backend(preferred: str | None = None) -> dict[str, str] | None:
     """Pick the best available auth backend for the configured browser."""
     from notebooklm_tools.utils.cdp import _get_chromium_path, get_browser_display_name
+    from notebooklm_tools.utils.firefox import get_firefox_path
 
     preferred = _normalize_browser(preferred)
+
+    if preferred == FIREFOX_BROWSER_KEY:
+        if get_firefox_path():
+            return {"backend": "firefox_profile", "browser": "Firefox"}
+        return None
 
     chromium_path = _get_chromium_path(preferred if preferred in CHROMIUM_BROWSER_KEYS else "auto")
     if chromium_path:
         return {"backend": "chromium_cdp", "browser": get_browser_display_name()}
+
+    if preferred == "auto" and get_firefox_path():
+        return {"backend": "firefox_profile", "browser": "Firefox"}
 
     return None
 
@@ -46,15 +61,32 @@ def extract_cookies_via_browser(
     """Extract auth cookies using the selected backend."""
     backend = select_auth_backend(preferred)
     if not backend:
+        if _normalize_browser(preferred) == FIREFOX_BROWSER_KEY:
+            from notebooklm_tools.utils.firefox import ensure_firefox_available
+
+            ensure_firefox_available()
         browsers = get_supported_auth_browsers()
         if len(browsers) > 1:
             browser_text = ", ".join(browsers[:-1]) + f", or {browsers[-1]}"
-        else:
+        elif browsers:
             browser_text = browsers[0]
+        else:
+            browser_text = "a supported browser"
         raise AuthenticationError(
             message="No supported browser found",
             hint=f"Install {browser_text}, or use 'nlm login --manual' to import cookies from a file.",
         )
+
+    if backend["backend"] == "firefox_profile":
+        from notebooklm_tools.utils.firefox import extract_cookies_via_firefox
+
+        result = extract_cookies_via_firefox(
+            wait_for_login=wait_for_login,
+            login_timeout=login_timeout,
+            profile_name=profile_name,
+            clear_profile=clear_profile,
+        )
+        return result, backend
 
     from notebooklm_tools.utils.cdp import extract_cookies_via_cdp
 
@@ -85,7 +117,7 @@ def run_headless_auth(profile_name: str = "default", timeout: int = 30) -> Any |
     preferred_backend = _get_saved_browser_backend(profile_name)
     attempts: list[str] = []
 
-    if preferred_backend == "chromium_cdp":
+    if preferred_backend in {"chromium_cdp", "firefox_profile"}:
         attempts.append(preferred_backend)
 
     selected = select_auth_backend()
@@ -103,5 +135,13 @@ def run_headless_auth(profile_name: str = "default", timeout: int = 30) -> Any |
             if tokens:
                 return tokens
             continue
+        if backend == "firefox_profile":
+            from notebooklm_tools.utils.firefox import (
+                run_headless_auth as run_headless_firefox_auth,
+            )
+
+            tokens = run_headless_firefox_auth(timeout=timeout, profile_name=profile_name)
+            if tokens:
+                return tokens
 
     return None

--- a/src/notebooklm_tools/utils/config.py
+++ b/src/notebooklm_tools/utils/config.py
@@ -212,9 +212,10 @@ def get_snap_chrome_profile_dir(
 
 
 def get_firefox_profile_dir(profile_name: str = "default") -> Path:
-    """Get Firefox profile directory kept for backwards compatibility."""
+    """Get the persistent Firefox profile directory for automated auth."""
     firefox_dir = get_storage_dir() / "firefox-profiles" / profile_name
-    safe_mkdir(firefox_dir, parents=True)
+    safe_mkdir(firefox_dir, parents=True, mode=0o700)
+    firefox_dir.chmod(0o700)
     return firefox_dir
 
 
@@ -441,7 +442,9 @@ class AuthConfig(BaseModel):
 
     browser: str = Field(
         default="auto",
-        description=("Browser for auth: auto, chrome, arc, brave, edge, chromium, vivaldi, opera"),
+        description=(
+            "Browser for auth: auto, chrome, arc, brave, edge, chromium, firefox, vivaldi, opera"
+        ),
     )
     default_profile: str = Field(default="default", description="Default profile name")
 

--- a/src/notebooklm_tools/utils/firefox.py
+++ b/src/notebooklm_tools/utils/firefox.py
@@ -1,0 +1,208 @@
+"""Firefox profile utilities for NotebookLM authentication."""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import platform
+import shutil
+import sqlite3
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+from notebooklm_tools.core.exceptions import AuthenticationError
+from notebooklm_tools.utils.config import get_base_url, get_firefox_profile_dir
+
+_logger = logging.getLogger(__name__)
+
+
+def get_firefox_path() -> str | None:
+    """Return the Firefox executable path for the current platform."""
+    system = platform.system()
+    if system == "Darwin":
+        candidates = (
+            Path("/Applications/Firefox.app/Contents/MacOS/firefox"),
+            Path.home() / "Applications/Firefox.app/Contents/MacOS/firefox",
+        )
+        for candidate in candidates:
+            if candidate.exists():
+                return str(candidate)
+        return None
+    if system == "Windows":
+        for variable in ("PROGRAMFILES", "PROGRAMFILES(X86)"):
+            base_path = os.environ.get(variable)
+            if not base_path:
+                continue
+            candidate = Path(base_path) / "Mozilla Firefox" / "firefox.exe"
+            if candidate.exists():
+                return str(candidate)
+        local_app_data_path = os.environ.get("LOCALAPPDATA")
+        if not local_app_data_path:
+            return None
+        candidate = Path(local_app_data_path) / "Mozilla Firefox" / "firefox.exe"
+        return str(candidate) if candidate.exists() else None
+    return shutil.which("firefox") or shutil.which("firefox-esr")
+
+
+def ensure_firefox_available() -> str:
+    """Return the Firefox executable or raise an actionable error."""
+    firefox = get_firefox_path()
+    if not firefox:
+        raise AuthenticationError(
+            message="Firefox is not installed",
+            hint="Install Firefox, then run 'nlm login' again.",
+        )
+    return firefox
+
+
+def _is_google_cookie_host(host: str) -> bool:
+    normalized = host.lstrip(".").lower()
+    return normalized == "google.com" or normalized.endswith(".google.com")
+
+
+def _read_google_cookies(profile_dir: Path) -> list[dict[str, Any]]:
+    """Snapshot Firefox's cookie store so it can be read while Firefox is open."""
+    cookie_db = profile_dir / "cookies.sqlite"
+    if not cookie_db.exists():
+        return []
+
+    try:
+        with (
+            sqlite3.connect(f"{cookie_db.as_uri()}?mode=ro", uri=True) as source,
+            sqlite3.connect(":memory:") as snapshot,
+        ):
+            source.backup(snapshot)
+            rows = snapshot.execute(
+                "SELECT name, value, host, path, expiry, isSecure, isHttpOnly FROM moz_cookies"
+            ).fetchall()
+    except sqlite3.Error as exc:
+        _logger.debug("Could not read Firefox cookies: %s", exc)
+        return []
+
+    return [
+        {
+            "name": name,
+            "value": value,
+            "domain": host,
+            "path": path,
+            "expires": expiry,
+            "secure": bool(is_secure),
+            "httpOnly": bool(is_http_only),
+        }
+        for name, value, host, path, expiry, is_secure, is_http_only in rows
+        if isinstance(host, str) and _is_google_cookie_host(host)
+    ]
+
+
+def _launch_firefox(firefox_path: str, profile_dir: Path) -> subprocess.Popen[bytes]:
+    try:
+        return subprocess.Popen(
+            [
+                firefox_path,
+                "-no-remote",
+                "-profile",
+                str(profile_dir),
+                f"{get_base_url()}/",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except OSError as exc:
+        raise AuthenticationError(
+            message="Failed to launch Firefox",
+            hint="Close any Firefox windows using the NLM auth profile and try again.",
+        ) from exc
+
+
+def _terminate_process(process: subprocess.Popen[bytes]) -> None:
+    with contextlib.suppress(Exception):
+        process.terminate()
+        process.wait(timeout=5)
+        return
+    with contextlib.suppress(Exception):
+        process.kill()
+
+
+def _wait_for_google_cookies(profile_dir: Path, timeout: int) -> list[dict[str, Any]]:
+    from notebooklm_tools.core.auth import validate_cookies
+
+    deadline = time.monotonic() + timeout
+    last_log_at = 0
+    while time.monotonic() < deadline:
+        cookies = _read_google_cookies(profile_dir)
+        if validate_cookies(cookies):
+            return cookies
+        elapsed = int(time.monotonic() - (deadline - timeout))
+        if elapsed - last_log_at >= 30:
+            last_log_at = elapsed
+            _logger.warning("Still waiting for Firefox sign-in... (%ds elapsed)", elapsed)
+        time.sleep(0.5)
+    raise AuthenticationError(
+        message="Login timeout",
+        hint="Please log in to Gemini Notebook in the Firefox window.",
+    )
+
+
+def has_firefox_profile(profile_name: str = "default") -> bool:
+    """Return whether the NLM Firefox profile has a cookie store."""
+    return (get_firefox_profile_dir(profile_name) / "cookies.sqlite").exists()
+
+
+def extract_cookies_via_firefox(
+    *,
+    wait_for_login: bool = True,
+    login_timeout: int = 300,
+    profile_name: str = "default",
+    clear_profile: bool = False,
+) -> dict[str, Any]:
+    """Launch normal Firefox and capture Google cookies from its isolated profile."""
+    from notebooklm_tools.core.auth import validate_cookies
+
+    firefox_path = ensure_firefox_available()
+    profile_dir = get_firefox_profile_dir(profile_name)
+    if clear_profile and profile_dir.exists():
+        shutil.rmtree(profile_dir)
+        profile_dir = get_firefox_profile_dir(profile_name)
+
+    process: subprocess.Popen[bytes] | None = None
+    try:
+        if wait_for_login:
+            process = _launch_firefox(firefox_path, profile_dir)
+            cookies = _wait_for_google_cookies(profile_dir, login_timeout)
+        else:
+            cookies = _read_google_cookies(profile_dir)
+            if not validate_cookies(cookies):
+                raise AuthenticationError(
+                    message="Firefox profile is not signed in",
+                    hint="Run 'nlm login' interactively to sign in to Gemini Notebook.",
+                )
+        return {
+            "cookies": cookies,
+            "csrf_token": "",
+            "session_id": "",
+            "email": "",
+            "build_label": "",
+            "base_host": "",
+        }
+    finally:
+        if process is not None:
+            _terminate_process(process)
+
+
+def run_headless_auth(timeout: int = 30, profile_name: str = "default") -> Any | None:
+    """Refresh cached credentials from the saved Firefox profile cookie store."""
+    del timeout
+
+    from notebooklm_tools.core.auth import AuthTokens, save_tokens_to_cache, validate_cookies
+
+    if not has_firefox_profile(profile_name):
+        return None
+    cookies = _read_google_cookies(get_firefox_profile_dir(profile_name))
+    if not validate_cookies(cookies):
+        return None
+    tokens = AuthTokens(cookies=cookies, extracted_at=time.time())
+    save_tokens_to_cache(tokens, profile_name=profile_name)
+    return tokens

--- a/tests/cli/test_login.py
+++ b/tests/cli/test_login.py
@@ -86,6 +86,7 @@ def test_login_force_bypasses_saved_profile_validation(monkeypatch, tmp_path):
             "force": True,
             "build_label": "build",
             "base_host": "",
+            "browser_backend": "chromium_cdp",
         }
     ]
     assert "Successfully authenticated!" in result.output

--- a/tests/core/test_auth_guard.py
+++ b/tests/core/test_auth_guard.py
@@ -1,6 +1,6 @@
 """Tests for account mismatch guard in profile saving."""
 
-from notebooklm_tools.core.exceptions import AccountMismatchError, NLMError
+from notebooklm_tools.core.exceptions import AccountMismatchError, AuthenticationError, NLMError
 
 
 def test_account_mismatch_error_inherits_nlm_error():
@@ -138,6 +138,23 @@ class TestSaveProfileMismatchGuard:
         # Should keep the old email when new is None
         assert profile is not None
         assert profile.email == "work@company.com"
+
+    def test_firefox_login_requires_force_for_existing_profile(self, tmp_path, monkeypatch):
+        """Firefox cannot identify the account, so it must not overwrite credentials silently."""
+        manager = self._create_existing_profile(tmp_path, "work@company.com")
+        monkeypatch.setattr(
+            "notebooklm_tools.utils.config.get_profile_dir",
+            lambda name: tmp_path / "profiles" / name,
+        )
+
+        with pytest.raises(AuthenticationError, match="cannot verify the Google account"):
+            manager.save_profile(
+                cookies=[{"name": "SID", "value": "new-sid"}],
+                email="",
+                browser_backend="firefox_profile",
+            )
+
+        assert json.loads(manager.cookies_file.read_text()) == [{"name": "SID", "value": "old-sid"}]
 
     def test_save_allows_on_fresh_profile(self, tmp_path, monkeypatch):
         """save_profile should work on a brand new profile with no existing data."""

--- a/tests/test_auth_browser.py
+++ b/tests/test_auth_browser.py
@@ -4,16 +4,16 @@ import json
 from unittest.mock import patch
 
 
-def test_select_auth_backend_ignores_firefox_preference_and_uses_chromium():
+def test_select_auth_backend_uses_firefox_when_explicitly_requested():
     from notebooklm_tools.utils.auth_browser import select_auth_backend
 
     with (
         patch("notebooklm_tools.utils.cdp._get_chromium_path", return_value="chromium"),
-        patch("notebooklm_tools.utils.cdp.get_browser_display_name", return_value="Chromium"),
+        patch("notebooklm_tools.utils.firefox.get_firefox_path", return_value="firefox"),
     ):
         backend = select_auth_backend("firefox")
 
-    assert backend == {"backend": "chromium_cdp", "browser": "Chromium"}
+    assert backend == {"backend": "firefox_profile", "browser": "Firefox"}
 
 
 def test_select_auth_backend_auto_prefers_chromium_when_available():
@@ -22,31 +22,38 @@ def test_select_auth_backend_auto_prefers_chromium_when_available():
     with (
         patch("notebooklm_tools.utils.cdp._get_chromium_path", return_value="google-chrome"),
         patch("notebooklm_tools.utils.cdp.get_browser_display_name", return_value="Google Chrome"),
+        patch("notebooklm_tools.utils.firefox.get_firefox_path", return_value="firefox"),
     ):
         backend = select_auth_backend("auto")
 
     assert backend == {"backend": "chromium_cdp", "browser": "Google Chrome"}
 
 
-def test_select_auth_backend_returns_none_when_no_chromium_browser_available():
+def test_select_auth_backend_auto_uses_firefox_when_chromium_is_unavailable():
     from notebooklm_tools.utils.auth_browser import select_auth_backend
 
-    with patch("notebooklm_tools.utils.cdp._get_chromium_path", return_value=None):
+    with (
+        patch("notebooklm_tools.utils.cdp._get_chromium_path", return_value=None),
+        patch("notebooklm_tools.utils.firefox.get_firefox_path", return_value="firefox"),
+    ):
         backend = select_auth_backend("auto")
 
-    assert backend is None
+    assert backend == {"backend": "firefox_profile", "browser": "Firefox"}
 
 
-def test_supported_auth_browsers_excludes_firefox():
+def test_supported_auth_browsers_includes_firefox_when_installed():
     from notebooklm_tools.utils.auth_browser import get_supported_auth_browsers
 
-    with patch(
-        "notebooklm_tools.utils.cdp.get_supported_browsers",
-        return_value=["Google Chrome", "Chromium"],
+    with (
+        patch(
+            "notebooklm_tools.utils.cdp.get_supported_browsers",
+            return_value=["Google Chrome", "Chromium"],
+        ),
+        patch("notebooklm_tools.utils.firefox.get_firefox_path", return_value="firefox"),
     ):
         browsers = get_supported_auth_browsers()
 
-    assert browsers == ["Google Chrome", "Chromium"]
+    assert browsers == ["Google Chrome", "Chromium", "Firefox"]
 
 
 def test_get_chromium_path_ignores_explicit_firefox_preference():


### PR DESCRIPTION
## Summary

- add an isolated Firefox profile auth backend that does not require CDP or WebDriver
- persist the selected auth backend and refresh Firefox credentials from its cookie store
- preserve Chromium/CDP as the default and add Firefox selection coverage

## Motivation

In governed environments, policies may block launching Chrome in headless or remote-debugging mode. This occurred in my environment even though normal Google sign-in worked, leaving manual cookie export as the only workaround.

## Validation

- `nlm login --profile firefox --force`: 28 cookies extracted
- `nlm login --check --profile firefox`: 20 notebooks accessible
- `uv run --dev ruff check . --output-format=github`
- `uv run --dev ruff format --check .`
- `uv run --dev --with pytest-github-actions-annotate-failures --with pytest-asyncio pytest -v --tb=short -m "not e2e"`
  - 1407 passed, 38 skipped, 1 deselected

Closes #294