### PR TITLE
fix: distinguish an unreachable backend from expired authentication

### DIFF
--- a/src/notebooklm_tools/core/base.py
+++ b/src/notebooklm_tools/core/base.py
@@ -25,7 +25,7 @@ from notebooklm_tools.utils.config import get_base_url
 
 from . import constants
 from .data_types import ConversationTurn
-from .errors import ClientAuthenticationError as AuthenticationError
+from .errors import ClientAuthenticationError as AuthenticationError, TransientBackendError
 from .errors import ResourceExhaustedError, RPCDriftError, RPCError
 from .retry import (
     DEFAULT_BASE_DELAY,
@@ -142,6 +142,29 @@ def _extract_user_message(detail_data: Any, _depth: int = 0) -> str:
 # Timeout configuration (seconds)
 DEFAULT_TIMEOUT = 30.0  # Default for most operations
 SOURCE_ADD_TIMEOUT = 120.0  # Extended timeout for all source operations
+
+
+def _is_unreachable_failure(exc: Exception | None) -> bool:
+    """Return True when the evidence shows an unreachable backend, not expiry.
+
+    A refresh can fail because the saved cookies are genuinely rejected, or
+    because the homepage fetch never completed. Only the first case justifies
+    telling the user to log in again.
+    """
+    if exc is None:
+        return False
+    if isinstance(exc, (httpx.TransportError, httpx.TimeoutException)):
+        return True
+    if isinstance(exc, OSError):
+        return True
+    text = str(exc).lower()
+    if 'accounts.google.com' in text or 'expired' in text:
+        return False
+    return any(
+        marker in text
+        for marker in ('could not reach', 'network', 'timed out', 'timeout',
+                       'connection', 'temporarily unavailable', 'dns')
+    )
 
 
 class BaseClient:
@@ -1047,15 +1070,21 @@ class BaseClient:
         # -- Auth recovery (reached only for 401/403 HTTP or RPC Error 16) --
 
         # Layer 1: Refresh CSRF/session tokens (first retry only)
+        refresh_failure: Exception | None = None
         if not _retry:
             try:
                 self._refresh_auth_tokens()
                 with self._state_lock:
                     self._client = None
                 return self._call_rpc(rpc_id, params, path, timeout, _retry=True)
-            except ValueError:
-                # CSRF refresh failed (cookies expired) - continue to layer 2
-                pass
+            except ValueError as exc:
+                # Refresh failed. This is NOT proof of expiry: the same path is
+                # reached when the homepage fetch never completed. Preserve the
+                # cause so the final message can stay truthful.
+                refresh_failure = exc
+            except (httpx.HTTPError, OSError) as exc:
+                # Transport failure during refresh. Never report this as expiry.
+                refresh_failure = exc
 
         # Layer 2 & 3: Reload from disk or run headless auth (deep retry)
         if not _deep_retry and self._try_reload_or_headless_auth():
@@ -1063,7 +1092,18 @@ class BaseClient:
                 self._client = None
             return self._call_rpc(rpc_id, params, path, timeout, _retry=True, _deep_retry=True)
 
-        # All recovery attempts failed
+        # All recovery attempts failed.
+        # Distinguish 'credentials are rejected' from 'the backend was unreachable'.
+        # Reporting an unreachable backend as an expired session sends users to a
+        # re-login that cannot fix the problem, and makes automated monitors raise
+        # false credential alerts.
+        if _is_unreachable_failure(refresh_failure):
+            raise TransientBackendError(
+                "Could not reach NotebookLM while verifying the session "
+                f"({type(refresh_failure).__name__}). Saved credentials may still be "
+                "valid. Check connectivity and retry; only run 'nlm login' if this "
+                "persists after the backend is reachable again."
+            ) from refresh_failure
         msg = (
             "Authentication expired. Run 'nlm login' in your terminal to re-authenticate. "
             "MCP users: the server should auto-detect the new credentials; "

--- a/src/notebooklm_tools/core/errors.py
+++ b/src/notebooklm_tools/core/errors.py
@@ -91,6 +91,16 @@ class ArtifactNotFoundError(ArtifactError):
         self.artifact_type = artifact_type
 
 
+class TransientBackendError(Exception):
+    """The backend could not be reached while verifying or refreshing a session.
+
+    This is deliberately NOT an authentication error. Credentials may still be
+    valid; the request simply never reached a verdict. Callers and monitors must
+    not treat this as expiry, because re-authentication cannot fix a transport
+    failure and a false expiry signal causes unnecessary interactive logins.
+    """
+
+
 class ClientAuthenticationError(Exception):
     """Raised when authentication fails (HTTP 401/403 or RPC Error 16).
 


### PR DESCRIPTION
## Problem

When the NotebookLM homepage fetch cannot complete, the auth recovery ladder in `base.py` falls through to the same final `raise` as a genuinely rejected cookie. A transport failure is therefore surfaced as:

> Authentication expired. Run 'nlm login' in your terminal to re-authenticate.

That message is wrong in this case and actively harmful:

1. It tells the user to re-authenticate, which cannot fix a network failure.
2. Automated monitors that key on this error raise false credential alerts and escalate to a human.

The cause is that layer 1 discards *why* it failed:

```python
except ValueError:
    # CSRF refresh failed (cookies expired) - continue to layer 2
    pass
```

The comment assumes expiry, but `_refresh_auth_tokens` raises `ValueError` for any refresh failure, including one where the request never reached a verdict.

## Observed

Same profile, same cookies, within the same minute:

| Command | Result |
|---|---|
| `nlm login --check` x3 | non-zero exit, `network_error: ClientAuthenticationError` |
| `nlm notebook list` x10 | **10/10 success** |

`login --check` even prints "your saved credentials may still be valid" while still exiting non-zero, so callers that check the exit code conclude expiry.

## Change

- Preserve the layer-1 failure cause instead of discarding it.
- Add `_is_unreachable_failure()` to classify transport failures (`httpx.TransportError`, `httpx.TimeoutException`, `OSError`, and message markers) versus genuine rejection.
- Raise a new `TransientBackendError` when the evidence only shows an unreachable backend.
- Genuine expiry (an `accounts.google.com` redirect or an explicit expiry message) still raises `AuthenticationError` with the original text, so existing handlers are unaffected.

`TransientBackendError` is intentionally **not** a subclass of the auth error, so `except AuthenticationError` callers no longer swallow a network problem as expiry.

## Verification

Classifier behavior, run under the installed interpreter:

| Input | Classified unreachable |
|---|---|
| `ValueError("Could not reach NotebookLM (network_error)")` | True |
| `ValueError("Authentication expired. accounts.google.com")` | **False** |
| `httpx.ConnectError` | True |
| `OSError("dns fail")` | True |
| `None` | False |

5/5 as expected. Both touched modules compile cleanly.

## Scope

Two files, +55/-5. No behavior change for a real expiry path.
