### PR TITLE
feat: Add support for native NotebookLM collections

### DIFF
--- a/src/notebooklm_tools/core/client.py
+++ b/src/notebooklm_tools/core/client.py
@@ -21,6 +21,7 @@ from .download import DownloadMixin
 from .errors import (
     ClientAuthenticationError,
 )
+from .collections import CollectionsMixin
 from .exports import ExportMixin
 from .labels import LabelsMixin
 from .notebooks import NotebookMixin
@@ -51,6 +52,7 @@ class NotebookLMClient(
     NotebookMixin,
     NotesMixin,
     LabelsMixin,
+    CollectionsMixin,
 ):
     """Client for NotebookLM MCP internal API.
 

--- a/src/notebooklm_tools/core/client.py
+++ b/src/notebooklm_tools/core/client.py
@@ -12,6 +12,7 @@ from collections.abc import Callable
 from typing import Any
 
 from . import constants
+from .collections import CollectionsMixin
 from .conversation import ConversationMixin
 from .download import DownloadMixin
 
@@ -21,7 +22,6 @@ from .download import DownloadMixin
 from .errors import (
     ClientAuthenticationError,
 )
-from .collections import CollectionsMixin
 from .exports import ExportMixin
 from .labels import LabelsMixin
 from .notebooks import NotebookMixin

--- a/src/notebooklm_tools/core/collections.py
+++ b/src/notebooklm_tools/core/collections.py
@@ -1,0 +1,163 @@
+"""CollectionsMixin - Native NotebookLM collections management operations."""
+
+import logging
+import time
+from typing import Any
+from .base import BaseClient
+
+logger = logging.getLogger(__name__)
+
+class CollectionsMixin(BaseClient):
+    """Mixin for native NotebookLM collections management operations."""
+
+    def _get_collections_header(self) -> list:
+        """Returns the standard header for collections RPC operations."""
+        return [2, None, [1], [1, None, None, None, None, None, None, None, None, None, [1, 3]]]
+
+    def list_collections(self) -> list[dict]:
+        """Lists all collections by temporarily creating a hidden one and deleting it.
+        
+        Returns:
+            List of collections, where each collection is a dict with:
+                - id: str
+                - name: str
+                - notebook_ids: list[str]
+                - emoji: str
+        """
+        header = self._get_collections_header()
+        temp_name = f"_temp_list_query_{int(time.time())}"
+        
+        # 1. Create a temporary collection to force Google to return the list
+        params_create = [
+            header,
+            None, None, None, None,
+            [[temp_name], None, []],
+            3
+        ]
+        
+        result = self._call_rpc("agX4Bc", params_create)
+        
+        collections = []
+        temp_id = None
+        
+        if result and len(result) > 2 and isinstance(result[2], list):
+            for col in result[2]:
+                if not isinstance(col, list) or len(col) < 3:
+                    continue
+                
+                col_name = col[0] or ""
+                col_notebooks = col[1] or []
+                col_id = col[2] or ""
+                col_emoji = col[3] if len(col) > 3 else ""
+                
+                if col_name == temp_name:
+                    temp_id = col_id
+                    continue
+                    
+                collections.append({
+                    "id": col_id,
+                    "name": col_name,
+                    "notebook_ids": col_notebooks,
+                    "emoji": col_emoji
+                })
+        
+        # 2. Delete the temporary collection in the background
+        if temp_id:
+            try:
+                self.delete_collection(temp_id)
+            except Exception as e:
+                logger.warning(f"Failed to cleanup temporary listing collection {temp_id}: {e}")
+                
+        return collections
+
+    def create_collection(self, name: str, notebook_ids: list[str] = None) -> dict:
+        """Creates a new collection with the given name and notebooks.
+        
+        Args:
+            name: Name of the collection
+            notebook_ids: List of notebook UUIDs to include
+            
+        Returns:
+            The created collection dict.
+        """
+        header = self._get_collections_header()
+        notebooks = notebook_ids or []
+        
+        params = [
+            header,
+            None, None, None, None,
+            [[name], None, notebooks],
+            3
+        ]
+        
+        result = self._call_rpc("agX4Bc", params)
+        
+        # Find the newly created collection in the returned list
+        if result and len(result) > 2 and isinstance(result[2], list):
+            for col in result[2]:
+                if isinstance(col, list) and len(col) >= 3 and col[0] == name:
+                    return {
+                        "id": col[2],
+                        "name": col[0],
+                        "notebook_ids": col[1] or [],
+                        "emoji": col[3] if len(col) > 3 else ""
+                    }
+                    
+        raise RuntimeError("Failed to confirm collection creation on Google backend")
+
+    def edit_collection(self, collection_id: str, name: str = None, notebook_ids: list[str] = None) -> bool:
+        """Edits an existing collection's name and/or notebooks.
+        
+        Args:
+            collection_id: UUID of the collection to edit
+            name: New name (optional)
+            notebook_ids: New complete list of notebook IDs (optional)
+        """
+        header = self._get_collections_header()
+        
+        # Format: [[None, None, None, [[notebook_ids]]], [[new_name]]]
+        notebooks_payload = None
+        if notebook_ids is not None:
+            notebooks_payload = [None, None, None, [notebook_ids]]
+            
+        name_payload = None
+        if name is not None:
+            name_payload = [[name]]
+            
+        edit_payload = [notebooks_payload, name_payload]
+        
+        params = [
+            header,
+            None,
+            collection_id,
+            edit_payload,
+            3
+        ]
+        
+        result = self._call_rpc("le8sX", params)
+        return result == [] or result is not None
+
+    def set_collection_emoji(self, collection_id: str, emoji: str) -> bool:
+        """Sets or clears the emoji marker on a collection (pass "" to clear)."""
+        header = self._get_collections_header()
+        params = [
+            header,
+            None,
+            collection_id,
+            [[[None, emoji]]],
+            3
+        ]
+        result = self._call_rpc("le8sX", params)
+        return result == [] or result is not None
+
+    def delete_collection(self, collection_id: str) -> bool:
+        """Permanently deletes a collection. Notebooks are not deleted."""
+        header = self._get_collections_header()
+        params = [
+            header,
+            None,
+            [collection_id],
+            3
+        ]
+        result = self._call_rpc("GyzE7e", params)
+        return result == [] or result is not None

--- a/src/notebooklm_tools/core/collections.py
+++ b/src/notebooklm_tools/core/collections.py
@@ -2,10 +2,11 @@
 
 import logging
 import time
-from typing import Any
+
 from .base import BaseClient
 
 logger = logging.getLogger(__name__)
+
 
 class CollectionsMixin(BaseClient):
     """Mixin for native NotebookLM collections management operations."""
@@ -16,7 +17,7 @@ class CollectionsMixin(BaseClient):
 
     def list_collections(self) -> list[dict]:
         """Lists all collections by temporarily creating a hidden one and deleting it.
-        
+
         Returns:
             List of collections, where each collection is a dict with:
                 - id: str
@@ -26,72 +27,64 @@ class CollectionsMixin(BaseClient):
         """
         header = self._get_collections_header()
         temp_name = f"_temp_list_query_{int(time.time())}"
-        
+
         # 1. Create a temporary collection to force Google to return the list
-        params_create = [
-            header,
-            None, None, None, None,
-            [[temp_name], None, []],
-            3
-        ]
-        
+        params_create = [header, None, None, None, None, [[temp_name], None, []], 3]
+
         result = self._call_rpc("agX4Bc", params_create)
-        
+
         collections = []
         temp_id = None
-        
+
         if result and len(result) > 2 and isinstance(result[2], list):
             for col in result[2]:
                 if not isinstance(col, list) or len(col) < 3:
                     continue
-                
+
                 col_name = col[0] or ""
                 col_notebooks = col[1] or []
                 col_id = col[2] or ""
                 col_emoji = col[3] if len(col) > 3 else ""
-                
+
                 if col_name == temp_name:
                     temp_id = col_id
                     continue
-                    
-                collections.append({
-                    "id": col_id,
-                    "name": col_name,
-                    "notebook_ids": col_notebooks,
-                    "emoji": col_emoji
-                })
-        
+
+                collections.append(
+                    {
+                        "id": col_id,
+                        "name": col_name,
+                        "notebook_ids": col_notebooks,
+                        "emoji": col_emoji,
+                    }
+                )
+
         # 2. Delete the temporary collection in the background
         if temp_id:
             try:
                 self.delete_collection(temp_id)
             except Exception as e:
                 logger.warning(f"Failed to cleanup temporary listing collection {temp_id}: {e}")
-                
+
         return collections
 
     def create_collection(self, name: str, notebook_ids: list[str] = None) -> dict:
         """Creates a new collection with the given name and notebooks.
-        
+
         Args:
             name: Name of the collection
             notebook_ids: List of notebook UUIDs to include
-            
+
         Returns:
             The created collection dict.
         """
         header = self._get_collections_header()
         notebooks = notebook_ids or []
-        
-        params = [
-            header,
-            None, None, None, None,
-            [[name], None, notebooks],
-            3
-        ]
-        
+
+        params = [header, None, None, None, None, [[name], None, notebooks], 3]
+
         result = self._call_rpc("agX4Bc", params)
-        
+
         # Find the newly created collection in the returned list
         if result and len(result) > 2 and isinstance(result[2], list):
             for col in result[2]:
@@ -100,64 +93,49 @@ class CollectionsMixin(BaseClient):
                         "id": col[2],
                         "name": col[0],
                         "notebook_ids": col[1] or [],
-                        "emoji": col[3] if len(col) > 3 else ""
+                        "emoji": col[3] if len(col) > 3 else "",
                     }
-                    
+
         raise RuntimeError("Failed to confirm collection creation on Google backend")
 
-    def edit_collection(self, collection_id: str, name: str = None, notebook_ids: list[str] = None) -> bool:
+    def edit_collection(
+        self, collection_id: str, name: str = None, notebook_ids: list[str] = None
+    ) -> bool:
         """Edits an existing collection's name and/or notebooks.
-        
+
         Args:
             collection_id: UUID of the collection to edit
             name: New name (optional)
             notebook_ids: New complete list of notebook IDs (optional)
         """
         header = self._get_collections_header()
-        
+
         # Format: [[None, None, None, [[notebook_ids]]], [[new_name]]]
         notebooks_payload = None
         if notebook_ids is not None:
             notebooks_payload = [None, None, None, [notebook_ids]]
-            
+
         name_payload = None
         if name is not None:
             name_payload = [[name]]
-            
+
         edit_payload = [notebooks_payload, name_payload]
-        
-        params = [
-            header,
-            None,
-            collection_id,
-            edit_payload,
-            3
-        ]
-        
+
+        params = [header, None, collection_id, edit_payload, 3]
+
         result = self._call_rpc("le8sX", params)
         return result == [] or result is not None
 
     def set_collection_emoji(self, collection_id: str, emoji: str) -> bool:
         """Sets or clears the emoji marker on a collection (pass "" to clear)."""
         header = self._get_collections_header()
-        params = [
-            header,
-            None,
-            collection_id,
-            [[[None, emoji]]],
-            3
-        ]
+        params = [header, None, collection_id, [[[None, emoji]]], 3]
         result = self._call_rpc("le8sX", params)
         return result == [] or result is not None
 
     def delete_collection(self, collection_id: str) -> bool:
         """Permanently deletes a collection. Notebooks are not deleted."""
         header = self._get_collections_header()
-        params = [
-            header,
-            None,
-            [collection_id],
-            3
-        ]
+        params = [header, None, [collection_id], 3]
         result = self._call_rpc("GyzE7e", params)
         return result == [] or result is not None

--- a/src/notebooklm_tools/mcp/server.py
+++ b/src/notebooklm_tools/mcp/server.py
@@ -83,6 +83,7 @@ def _register_tools() -> None:
         batch,
         chat,
         chats,
+        collections,
         cross_notebook,
         downloads,
         exports,

--- a/src/notebooklm_tools/mcp/tool_groups.py
+++ b/src/notebooklm_tools/mcp/tool_groups.py
@@ -65,6 +65,11 @@ TOOL_GROUPS: dict[str, set[str]] = {
     "organization": {
         "label",
         "tag",
+        "collection_list",
+        "collection_create",
+        "collection_edit",
+        "collection_set_emoji",
+        "collection_delete",
     },
     "automation": {
         "batch",

--- a/src/notebooklm_tools/mcp/tools/__init__.py
+++ b/src/notebooklm_tools/mcp/tools/__init__.py
@@ -10,6 +10,13 @@ from .chat import (
     notebook_query_status,
 )
 from .chats import chat_export, chat_get, chat_list
+from .collections import (
+    collection_create,
+    collection_delete,
+    collection_edit,
+    collection_list,
+    collection_set_emoji,
+)
 from .cross_notebook import cross_notebook_query
 from .downloads import download_all_artifacts, download_artifact
 from .exports import (
@@ -69,6 +76,12 @@ __all__ = [
     "notebook_create",
     "notebook_rename",
     "notebook_delete",
+    # Collections (5)
+    "collection_list",
+    "collection_create",
+    "collection_edit",
+    "collection_set_emoji",
+    "collection_delete",
     # Sources (7)
     "source_add",
     "source_list_drive",

--- a/src/notebooklm_tools/mcp/tools/collections.py
+++ b/src/notebooklm_tools/mcp/tools/collections.py
@@ -38,9 +38,7 @@ def collection_create(name: str, notebook_ids: list[str] = None) -> ResultDict:
 
 @logged_tool()
 def collection_edit(
-    collection_id: str,
-    name: str = None,
-    notebook_ids: list[str] = None
+    collection_id: str, name: str = None, notebook_ids: list[str] = None
 ) -> ResultDict:
     """Edit an existing collection's name and/or list of notebooks.
 

--- a/src/notebooklm_tools/mcp/tools/collections.py
+++ b/src/notebooklm_tools/mcp/tools/collections.py
@@ -1,0 +1,103 @@
+"""Collection tools - native NotebookLM collections management operations."""
+
+from ...services import ServiceError
+from ...services import collections as collections_service
+from ._utils import ResultDict, error_result, get_client, logged_tool
+
+
+@logged_tool()
+def collection_list() -> ResultDict:
+    """List all native collections."""
+    try:
+        client = get_client()
+        result = collections_service.list_collections(client)
+        return {"status": "success", **result}
+    except ServiceError as e:
+        return error_result(e.user_message, hint=e.hint)
+    except Exception as e:
+        return error_result(str(e))
+
+
+@logged_tool()
+def collection_create(name: str, notebook_ids: list[str] = None) -> ResultDict:
+    """Create a new collection.
+
+    Args:
+        name: Name of the collection
+        notebook_ids: List of notebook UUIDs to include in the collection (optional)
+    """
+    try:
+        client = get_client()
+        result = collections_service.create_collection(client, name, notebook_ids)
+        return {"status": "success", **result}
+    except ServiceError as e:
+        return error_result(e.user_message, hint=e.hint)
+    except Exception as e:
+        return error_result(str(e))
+
+
+@logged_tool()
+def collection_edit(
+    collection_id: str,
+    name: str = None,
+    notebook_ids: list[str] = None
+) -> ResultDict:
+    """Edit an existing collection's name and/or list of notebooks.
+
+    Args:
+        collection_id: UUID of the collection
+        name: New name for the collection (optional)
+        notebook_ids: New complete list of notebook UUIDs to include (optional)
+    """
+    try:
+        client = get_client()
+        result = collections_service.edit_collection(client, collection_id, name, notebook_ids)
+        return {"status": "success", **result}
+    except ServiceError as e:
+        return error_result(e.user_message, hint=e.hint)
+    except Exception as e:
+        return error_result(str(e))
+
+
+@logged_tool()
+def collection_set_emoji(collection_id: str, emoji: str) -> ResultDict:
+    """Set or clear the emoji marker on a collection.
+
+    Args:
+        collection_id: UUID of the collection
+        emoji: Emoji character (use empty string "" to clear)
+    """
+    try:
+        client = get_client()
+        result = collections_service.set_collection_emoji(client, collection_id, emoji)
+        return {"status": "success", **result}
+    except ServiceError as e:
+        return error_result(e.user_message, hint=e.hint)
+    except Exception as e:
+        return error_result(str(e))
+
+
+@logged_tool()
+def collection_delete(collection_id: str, confirm: bool = False) -> ResultDict:
+    """Delete a collection permanently. Notebooks inside the collection are NOT deleted.
+
+    Args:
+        collection_id: UUID of the collection
+        confirm: Must be True after user approval
+    """
+    if not confirm:
+        return {
+            "status": "error",
+            "error": "Deletion not confirmed. You must ask the user to confirm "
+            "before deleting. Set confirm=True only after user approval.",
+            "warning": "This action is IRREVERSIBLE. The collection will be permanently deleted.",
+        }
+
+    try:
+        client = get_client()
+        result = collections_service.delete_collection(client, collection_id)
+        return {"status": "success", **result}
+    except ServiceError as e:
+        return error_result(e.user_message, hint=e.hint)
+    except Exception as e:
+        return error_result(str(e))

--- a/src/notebooklm_tools/services/collections.py
+++ b/src/notebooklm_tools/services/collections.py
@@ -3,24 +3,19 @@
 from ..core.client import NotebookLMClient
 from .errors import ServiceError, ValidationError
 
+
 def list_collections(client: NotebookLMClient) -> dict:
     """List all native collections."""
     try:
         collections = client.list_collections()
-        return {
-            "collections": collections,
-            "count": len(collections)
-        }
+        return {"collections": collections, "count": len(collections)}
     except Exception as e:
         raise ServiceError(f"Failed to list collections: {e}") from e
 
-def create_collection(
-    client: NotebookLMClient,
-    name: str,
-    notebook_ids: list[str] = None
-) -> dict:
+
+def create_collection(client: NotebookLMClient, name: str, notebook_ids: list[str] = None) -> dict:
     """Create a new collection.
-    
+
     Args:
         client: Authenticated NotebookLM client
         name: Name of the collection
@@ -31,25 +26,23 @@ def create_collection(
             "Collection name is required.",
             user_message="Collection name cannot be empty.",
         )
-    
+
     try:
         col = client.create_collection(name, notebook_ids)
         return {
             "collection_id": col["id"],
             "collection": col,
-            "message": f"Created collection: {name}"
+            "message": f"Created collection: {name}",
         }
     except Exception as e:
         raise ServiceError(f"Failed to create collection: {e}") from e
 
+
 def edit_collection(
-    client: NotebookLMClient,
-    collection_id: str,
-    name: str = None,
-    notebook_ids: list[str] = None
+    client: NotebookLMClient, collection_id: str, name: str = None, notebook_ids: list[str] = None
 ) -> dict:
     """Edit an existing collection.
-    
+
     Args:
         client: Authenticated NotebookLM client
         collection_id: UUID of the collection
@@ -61,25 +54,22 @@ def edit_collection(
             "New collection name cannot be empty.",
             user_message="Collection name cannot be empty.",
         )
-        
+
     try:
         success = client.edit_collection(collection_id, name, notebook_ids)
         if success:
             return {
                 "collection_id": collection_id,
-                "message": f"Updated collection {collection_id}"
+                "message": f"Updated collection {collection_id}",
             }
         raise ServiceError("Google backend returned falsy result for collection edit")
     except Exception as e:
         raise ServiceError(f"Failed to edit collection: {e}") from e
 
-def set_collection_emoji(
-    client: NotebookLMClient,
-    collection_id: str,
-    emoji: str
-) -> dict:
+
+def set_collection_emoji(client: NotebookLMClient, collection_id: str, emoji: str) -> dict:
     """Sets or clears the emoji marker on a collection.
-    
+
     Args:
         client: Authenticated NotebookLM client
         collection_id: UUID of the collection
@@ -91,18 +81,16 @@ def set_collection_emoji(
             return {
                 "collection_id": collection_id,
                 "emoji": emoji,
-                "message": f"Updated emoji to '{emoji}' for collection {collection_id}"
+                "message": f"Updated emoji to '{emoji}' for collection {collection_id}",
             }
         raise ServiceError("Google backend returned falsy result for collection emoji edit")
     except Exception as e:
         raise ServiceError(f"Failed to set collection emoji: {e}") from e
 
-def delete_collection(
-    client: NotebookLMClient,
-    collection_id: str
-) -> dict:
+
+def delete_collection(client: NotebookLMClient, collection_id: str) -> dict:
     """Permanently delete a collection.
-    
+
     Args:
         client: Authenticated NotebookLM client
         collection_id: UUID of the collection
@@ -110,9 +98,7 @@ def delete_collection(
     try:
         success = client.delete_collection(collection_id)
         if success:
-            return {
-                "message": f"Collection {collection_id} has been permanently deleted."
-            }
+            return {"message": f"Collection {collection_id} has been permanently deleted."}
         raise ServiceError("Google backend returned falsy result for collection deletion")
     except Exception as e:
         raise ServiceError(f"Failed to delete collection: {e}") from e

--- a/src/notebooklm_tools/services/collections.py
+++ b/src/notebooklm_tools/services/collections.py
@@ -1,0 +1,118 @@
+"""Collections service — shared business logic for native collections CRUD and metadata operations."""
+
+from ..core.client import NotebookLMClient
+from .errors import ServiceError, ValidationError
+
+def list_collections(client: NotebookLMClient) -> dict:
+    """List all native collections."""
+    try:
+        collections = client.list_collections()
+        return {
+            "collections": collections,
+            "count": len(collections)
+        }
+    except Exception as e:
+        raise ServiceError(f"Failed to list collections: {e}") from e
+
+def create_collection(
+    client: NotebookLMClient,
+    name: str,
+    notebook_ids: list[str] = None
+) -> dict:
+    """Create a new collection.
+    
+    Args:
+        client: Authenticated NotebookLM client
+        name: Name of the collection
+        notebook_ids: Optional list of notebook UUIDs to include
+    """
+    if not name or not name.strip():
+        raise ValidationError(
+            "Collection name is required.",
+            user_message="Collection name cannot be empty.",
+        )
+    
+    try:
+        col = client.create_collection(name, notebook_ids)
+        return {
+            "collection_id": col["id"],
+            "collection": col,
+            "message": f"Created collection: {name}"
+        }
+    except Exception as e:
+        raise ServiceError(f"Failed to create collection: {e}") from e
+
+def edit_collection(
+    client: NotebookLMClient,
+    collection_id: str,
+    name: str = None,
+    notebook_ids: list[str] = None
+) -> dict:
+    """Edit an existing collection.
+    
+    Args:
+        client: Authenticated NotebookLM client
+        collection_id: UUID of the collection
+        name: New name (optional)
+        notebook_ids: New complete list of notebook IDs (optional)
+    """
+    if name is not None and not name.strip():
+        raise ValidationError(
+            "New collection name cannot be empty.",
+            user_message="Collection name cannot be empty.",
+        )
+        
+    try:
+        success = client.edit_collection(collection_id, name, notebook_ids)
+        if success:
+            return {
+                "collection_id": collection_id,
+                "message": f"Updated collection {collection_id}"
+            }
+        raise ServiceError("Google backend returned falsy result for collection edit")
+    except Exception as e:
+        raise ServiceError(f"Failed to edit collection: {e}") from e
+
+def set_collection_emoji(
+    client: NotebookLMClient,
+    collection_id: str,
+    emoji: str
+) -> dict:
+    """Sets or clears the emoji marker on a collection.
+    
+    Args:
+        client: Authenticated NotebookLM client
+        collection_id: UUID of the collection
+        emoji: Emoji character (use "" to clear)
+    """
+    try:
+        success = client.set_collection_emoji(collection_id, emoji)
+        if success:
+            return {
+                "collection_id": collection_id,
+                "emoji": emoji,
+                "message": f"Updated emoji to '{emoji}' for collection {collection_id}"
+            }
+        raise ServiceError("Google backend returned falsy result for collection emoji edit")
+    except Exception as e:
+        raise ServiceError(f"Failed to set collection emoji: {e}") from e
+
+def delete_collection(
+    client: NotebookLMClient,
+    collection_id: str
+) -> dict:
+    """Permanently delete a collection.
+    
+    Args:
+        client: Authenticated NotebookLM client
+        collection_id: UUID of the collection
+    """
+    try:
+        success = client.delete_collection(collection_id)
+        if success:
+            return {
+                "message": f"Collection {collection_id} has been permanently deleted."
+            }
+        raise ServiceError("Google backend returned falsy result for collection deletion")
+    except Exception as e:
+        raise ServiceError(f"Failed to delete collection: {e}") from e


### PR DESCRIPTION
This Pull Request introduces full programmatic support for native NotebookLM (Gemini Notebook) collections. 

### What was accomplished
* Reverse-engineered internal Google Labs RPCs for collection management:
  * **List**: \gX4Bc\ using a lightweight query technique (creating a short-lived temporary collection and extracting the full list, avoiding \INVALID_ARGUMENT\ errors).
  * **Create**: \gX4Bc\ with the root-level collection header layout.
  * **Edit/Rename**: \le8sX\ with double-nested list parameters.
  * **Emoji**: \le8sX\ with triple-nested list parameters to set/clear collection emojis.
  * **Delete**: \GyzE7e\ with root-level array format.
* Added \CollectionsMixin\ in \
otebooklm_tools.core\.
* Registered service layer functions in \
otebooklm_tools.services.collections\.
* Exposed FastMCP server tools in \
otebooklm_tools.mcp.tools\:
  * \collection_list\
  * \collection_create\
  * \collection_edit\
  * \collection_set_emoji\
  * \collection_delete\

This makes native collections management fully accessible to LLM agents and the CLI interface.