### PR TITLE
fix: classify RPC authentication failures as expired in check_auth

### DIFF
--- a/src/notebooklm_tools/core/auth.py
+++ b/src/notebooklm_tools/core/auth.py
@@ -850,6 +850,7 @@ def check_auth(
     # before declaring the profile expired.
     try:
         from notebooklm_tools.core.client import NotebookLMClient
+        from notebooklm_tools.core.errors import ClientAuthenticationError
         from notebooklm_tools.core.exceptions import AuthenticationError
 
         client = NotebookLMClient(
@@ -867,7 +868,7 @@ def check_auth(
             refreshed_bl = client._bl
         finally:
             client.close()
-    except AuthenticationError:
+    except (AuthenticationError, ClientAuthenticationError):
         return AuthCheckResult(
             valid=False,
             reason="expired",

--- a/tests/core/test_auth_check.py
+++ b/tests/core/test_auth_check.py
@@ -123,6 +123,36 @@ class TestCheckAuthAPI:
             assert result.reason == "expired"
             assert result.live is True
 
+    def test_check_auth_classifies_client_rpc_auth_error_as_expired(
+        self, tmp_path, monkeypatch
+    ):
+        """The low-level RPC client raises its own authentication class.
+
+        It is not an NLMError and must not be mislabeled as a network outage.
+        """
+        from notebooklm_tools.core.errors import ClientAuthenticationError
+
+        monkeypatch.setattr("notebooklm_tools.utils.config.get_storage_dir", lambda: tmp_path)
+        AuthManager("default").save_profile(
+            cookies={"SID": "dead", "HSID": "dead", "SSID": "dead", "APISID": "dead", "SAPISID": "dead"},
+            csrf_token="stale123",
+            session_id="sess123",
+        )
+        with (
+            patch("httpx.Client") as MockClient,
+            patch(
+                "notebooklm_tools.core.client.NotebookLMClient.list_notebooks",
+                side_effect=ClientAuthenticationError("RPC code 16"),
+            ),
+        ):
+            client = MockClient.return_value.__enter__.return_value
+            req = httpx.Request("GET", "https://accounts.google.com/ServiceLogin")
+            client.get.return_value = httpx.Response(200, request=req, text="login")
+            result = check_auth(live=True)
+
+        assert result.valid is False
+        assert result.reason == "expired"
+
     def test_check_auth_live_true_redirect_but_rpc_alive_is_valid(self, tmp_path, monkeypatch):
         """Homepage redirects can be false negatives; a live RPC wins."""
         monkeypatch.setattr("notebooklm_tools.utils.config.get_storage_dir", lambda: tmp_path)


### PR DESCRIPTION
## Problem

#301 introduced `ClientAuthenticationError` to distinguish an unreachable backend from expired authentication, but `check_auth`'s live probe still only catches the older `AuthenticationError`. When the probe's RPC call fails with an authentication error (e.g. RPC code 16), it falls through to the generic handler and the profile is reported as `network_error: ClientAuthenticationError` instead of `expired` — so users with expired cookies are told there is a network problem rather than being prompted to re-authenticate.

## Fix

Widen the except clause in `check_auth` so `ClientAuthenticationError` maps to the same `expired` result as `AuthenticationError`.

## Testing

- New regression test: `tests/core/test_auth_check.py::TestCheckAuthAPI::test_check_auth_classifies_client_rpc_auth_error_as_expired` — fails on `main` (`f26bf51`) with `network_error: ClientAuthenticationError`, passes with this change (`expired`).
- Full suite on this branch: 1434 passed, 38 skipped.